### PR TITLE
feat(chat): warn + block codec commands that would disconnect the sender

### DIFF
--- a/src/client/java/dev/ethan/waypointer/WaypointerClient.java
+++ b/src/client/java/dev/ethan/waypointer/WaypointerClient.java
@@ -3,6 +3,7 @@ package dev.ethan.waypointer;
 import dev.ethan.waypointer.chat.ChatCoordDetector;
 import dev.ethan.waypointer.chat.ChatImportCache;
 import dev.ethan.waypointer.chat.ChatImportDetector;
+import dev.ethan.waypointer.chat.ClientCodecSendGuard;
 import dev.ethan.waypointer.commands.WaypointerCommands;
 import dev.ethan.waypointer.config.Storage;
 import dev.ethan.waypointer.config.WaypointerConfig;
@@ -58,6 +59,10 @@ public final class WaypointerClient implements ClientModInitializer {
         new WaypointerKeybinds(WaypointerClient::openGui, manager, config).install();
         new ChatCoordDetector(config).install();
         new ChatImportDetector(config, chatImportCache).install();
+        // Installed unconditionally: this is a safety net, not a feature. A
+        // codec-bearing command that would disconnect the user is always a
+        // bug regardless of config, so there's no toggle to disable it.
+        ClientCodecSendGuard.install();
 
         ClientLifecycleEvents.CLIENT_STOPPING.register(client -> {
             // Flush any debounced writes before the JVM tears down -- the

--- a/src/client/java/dev/ethan/waypointer/chat/ClientCodecSendGuard.java
+++ b/src/client/java/dev/ethan/waypointer/chat/ClientCodecSendGuard.java
@@ -42,18 +42,21 @@ public final class ClientCodecSendGuard {
 
     /**
      * Build the cancel-notification chat line. Kept separate from the hook
-     * body so the formatting choices (colors, verb echo, byte math phrasing)
-     * can be tuned without touching the registration path.
+     * body so the wording can be tuned without touching the registration
+     * path.
+     *
+     * The copy is intentionally plain-language: no "bytes", no "cap", no
+     * "packet". Most players don't care (and shouldn't have to) about the
+     * underlying reason; they just need to know the send was stopped, why
+     * it mattered, and what to do next.
      */
     private static Component buildWarning(CodecSendGuard.Decision d) {
         MutableComponent prefix = Component.literal("[Waypointer] ").withStyle(ChatFormatting.AQUA);
         MutableComponent body = Component.literal(
-                "Blocked your /" + d.commandLeader() + " -- it would have disconnected you. "
-                + "The command was " + d.wireBytes() + " B (cap is "
-                + CodecSendGuard.COMMAND_WIRE_LIMIT_BYTES + " B, over by "
-                + d.overByBytes() + " B). "
-                + "Shrink the codec by stripping toggles in the export screen, "
-                + "or share via a channel other than a chat command."
+                "Stopped your /" + d.commandLeader() + " -- it was too long to send and would have "
+                + "kicked you from the server. "
+                + "Try sharing fewer waypoints, or open the export screen and turn off extras "
+                + "(names, colors, etc.) to make it shorter."
         ).withStyle(ChatFormatting.RED);
         return prefix.append(body);
     }

--- a/src/client/java/dev/ethan/waypointer/chat/ClientCodecSendGuard.java
+++ b/src/client/java/dev/ethan/waypointer/chat/ClientCodecSendGuard.java
@@ -49,14 +49,20 @@ public final class ClientCodecSendGuard {
      * "packet". Most players don't care (and shouldn't have to) about the
      * underlying reason; they just need to know the send was stopped, why
      * it mattered, and what to do next.
+     *
+     * Crucially, regular chat ({@code /ac}-free, no command verb) has a
+     * more forgiving server-side limit than commands do, so a route that's
+     * too long for {@code /pc} or {@code /msg} can often still be pasted
+     * straight into chat. We surface that as the primary suggestion so
+     * users don't conclude "the codec is broken" and give up.
      */
     private static Component buildWarning(CodecSendGuard.Decision d) {
         MutableComponent prefix = Component.literal("[Waypointer] ").withStyle(ChatFormatting.AQUA);
         MutableComponent body = Component.literal(
-                "Stopped your /" + d.commandLeader() + " -- it was too long to send and would have "
-                + "kicked you from the server. "
-                + "Try sharing fewer waypoints, or open the export screen and turn off extras "
-                + "(names, colors, etc.) to make it shorter."
+                "Stopped your /" + d.commandLeader() + " -- it was too long for a command and would "
+                + "have kicked you from the server. "
+                + "You can still paste it straight into chat, or open the export screen and turn off "
+                + "extras (names, colors, etc.) to shrink it first."
         ).withStyle(ChatFormatting.RED);
         return prefix.append(body);
     }

--- a/src/client/java/dev/ethan/waypointer/chat/ClientCodecSendGuard.java
+++ b/src/client/java/dev/ethan/waypointer/chat/ClientCodecSendGuard.java
@@ -1,0 +1,60 @@
+package dev.ethan.waypointer.chat;
+
+import net.fabricmc.fabric.api.client.message.v1.ClientSendMessageEvents;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+
+/**
+ * Client-side wiring for {@link CodecSendGuard}.
+ *
+ * Registers a Fabric allow-command hook that runs {@link CodecSendGuard#inspect}
+ * on every outbound command and, when the decision is {@code block}, cancels
+ * the send and prints an inline chat message explaining what happened. The
+ * explanation matters: Watchdog disconnects are silent from the user's POV,
+ * so without a visible reason the user would see the guard as "chat randomly
+ * ate my command" and lose trust in the mod.
+ *
+ * This installer exists as a thin adapter so {@link CodecSendGuard} can stay
+ * in the main source set (and thus in unit tests) without growing Minecraft
+ * imports.
+ */
+public final class ClientCodecSendGuard {
+
+    private ClientCodecSendGuard() {}
+
+    public static void install() {
+        ClientSendMessageEvents.ALLOW_COMMAND.register(ClientCodecSendGuard::onAllowCommand);
+    }
+
+    private static boolean onAllowCommand(String command) {
+        CodecSendGuard.Decision d = CodecSendGuard.inspect(command);
+        if (!d.shouldBlock()) return true;
+
+        LocalPlayer player = Minecraft.getInstance().player;
+        if (player != null) {
+            player.displayClientMessage(buildWarning(d), false);
+        }
+        return false;
+    }
+
+    /**
+     * Build the cancel-notification chat line. Kept separate from the hook
+     * body so the formatting choices (colors, verb echo, byte math phrasing)
+     * can be tuned without touching the registration path.
+     */
+    private static Component buildWarning(CodecSendGuard.Decision d) {
+        MutableComponent prefix = Component.literal("[Waypointer] ").withStyle(ChatFormatting.AQUA);
+        MutableComponent body = Component.literal(
+                "Blocked your /" + d.commandLeader() + " -- it would have disconnected you. "
+                + "The command was " + d.wireBytes() + " B (cap is "
+                + CodecSendGuard.COMMAND_WIRE_LIMIT_BYTES + " B, over by "
+                + d.overByBytes() + " B). "
+                + "Shrink the codec by stripping toggles in the export screen, "
+                + "or share via a channel other than a chat command."
+        ).withStyle(ChatFormatting.RED);
+        return prefix.append(body);
+    }
+}

--- a/src/client/java/dev/ethan/waypointer/render/TracerRenderer.java
+++ b/src/client/java/dev/ethan/waypointer/render/TracerRenderer.java
@@ -92,6 +92,9 @@ public final class TracerRenderer {
         int overrideColor = config.tracerColor();
 
         for (WaypointGroup g : groups) {
+            if (config.hideTracerOnStaticRoutes() && g.loadMode() == WaypointGroup.LoadMode.STATIC) {
+                continue;
+            }
             Waypoint target = g.current();
             if (target == null) continue;
             int color = matchWaypoint ? target.color() : overrideColor;

--- a/src/client/java/dev/ethan/waypointer/render/WaypointRenderer.java
+++ b/src/client/java/dev/ethan/waypointer/render/WaypointRenderer.java
@@ -48,10 +48,7 @@ import org.joml.Vector3fc;
  *
  * <p>Load-mode aware: {@code STATIC} groups render every waypoint, {@code SEQUENCE}
  * groups render only the prev/current/next triple (delegated to
- * {@link WaypointGroup#forEachVisibleIndex}). The
- * {@link WaypointerConfig#windowedRendering() windowedRendering} flag forces
- * every group onto the prev/current/next window to cut label clutter on
- * dense static routes without changing their navigation behavior.
+ * {@link WaypointGroup#forEachVisibleIndex}).
  */
 public final class WaypointRenderer implements HudElement {
 
@@ -188,7 +185,6 @@ public final class WaypointRenderer implements HudElement {
         int currentIdx = g.currentIndex();
         boolean showCompleted = config.showCompleted();
         float beaconOpacity = (float) config.beaconOpacity();
-        boolean windowed = config.windowedRendering();
 
         g.forEachVisibleIndex(i -> {
             Waypoint w = g.get(i);
@@ -204,7 +200,7 @@ public final class WaypointRenderer implements HudElement {
             if (lines != null) {
                 RenderHelpers.emitLineBox(lines, ps, x, y, z, x + 1f, y + 1f, z + 1f, w.color(), alpha);
             }
-        }, windowed);
+        });
     }
 
     // ---- HUD path: 2D labels projected from world anchors --------------------------------
@@ -236,7 +232,6 @@ public final class WaypointRenderer implements HudElement {
                                  WaypointGroup group) {
         int currentIdx = group.currentIndex();
         boolean showCompleted = config.showCompleted();
-        boolean windowed = config.windowedRendering();
 
         group.forEachVisibleIndex(i -> {
             Waypoint w = group.get(i);
@@ -267,7 +262,7 @@ public final class WaypointRenderer implements HudElement {
             drawCenteredLabel(g, font, name, sx, sy, NAME_ARGB);
             drawCenteredLabel(g, font, distanceString(distance),
                     sx, sy + font.lineHeight + DISTANCE_ROW_GAP, DISTANCE_ARGB);
-        }, windowed);
+        });
     }
 
     /**

--- a/src/client/java/dev/ethan/waypointer/screen/ConfigScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/ConfigScreen.java
@@ -90,11 +90,6 @@ public final class ConfigScreen extends Screen {
                 "Draws a dark rectangle behind floating waypoint names for readability.\n"
               + "Turn off for a lighter HUD when labels stack in busy areas.");
         y += rowH;
-        addBoolRow(col1, y, "Only render nearby waypoints (prev/current/next)",
-                config.windowedRendering(), config::setWindowedRendering,
-                "Renders only the previous, current, and next waypoint for every group,\n"
-              + "including STATIC routes. Cuts clutter on dense shared routes.");
-        y += rowH;
         addBoxStyleRow(col1, y, colW);
 
         // --- Column 2: Behavior ------------------------------------------------------------

--- a/src/client/java/dev/ethan/waypointer/screen/ConfigScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/ConfigScreen.java
@@ -5,6 +5,7 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.Checkbox;
 import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 
@@ -44,76 +45,120 @@ public final class ConfigScreen extends Screen {
         int colW = (width - PAD_OUTER * 2 - colGap) / 2;
         int col2 = col1 + colW + colGap;
 
-        // Section headers sit above each column and answer "what am I looking at".
-        // Without them the inputs feel like a wall.
         int headerY = top;
         int rowsY = top + 16;
 
         // --- Column 1: Rendering -----------------------------------------------------------
         int y = rowsY;
         addNumberRow(col1, y, colW, "Default reach radius (blocks)",
-                config.defaultReachRadius(), config::setDefaultReachRadius);
+                config.defaultReachRadius(), config::setDefaultReachRadius,
+                "How close you must stand (in blocks) to mark the current waypoint reached,\n"
+              + "when a waypoint does not set its own radius. Group default radius can\n"
+              + "override this in the group editor.");
         y += rowH;
         addNumberRow(col1, y, colW, "Tracer opacity (0-1)",
-                config.tracerOpacity(), config::setTracerOpacity);
+                config.tracerOpacity(), config::setTracerOpacity,
+                "Opacity of the line drawn from the crosshair to the active waypoint.\n"
+              + "0 is fully transparent, 1 is solid.");
         y += rowH;
         addNumberRow(col1, y, colW, "Beacon opacity (0-1)",
-                config.beaconOpacity(), config::setBeaconOpacity);
+                config.beaconOpacity(), config::setBeaconOpacity,
+                "Opacity of each waypoint's world-space box / beacon. 0 hides the volume,\n"
+              + "1 is the strongest fill; labels can still show separately.");
         y += rowH;
         addNumberRow(col1, y, colW, "Tracer color (hex RRGGBB)",
-                config.tracerColor(), v -> config.setTracerColor((int) v), true);
+                config.tracerColor(), v -> config.setTracerColor((int) v), true,
+                "Fixed tracer color as hex RRGGBB (e.g. 4FE05A). Only used when\n"
+              + "\"Tracer inherits waypoint color\" is off.");
         y += rowH;
         addBoolRow(col1, y, "Tracer inherits waypoint color",
-                config.matchTracerToWaypointColor(), config::setMatchTracerToWaypointColor);
+                config.matchTracerToWaypointColor(), config::setMatchTracerToWaypointColor,
+                "When on, the tracer uses each waypoint's rendered color (gradient routes\n"
+              + "shift hue as you progress). When off, every tracer uses the hex color above.");
         y += rowH;
-        addBoolRow(col1, y, "Show label backdrop", config.showLabelBackdrop(), config::setShowLabelBackdrop);
+        addBoolRow(col1, y, "Show tracers", config.showTracer(), config::setShowTracer,
+                "Master switch for crosshair tracers. When off, no tracer lines are drawn\n"
+              + "for any group (other waypoint rendering is unchanged).");
+        y += rowH;
+        addBoolRow(col1, y, "Hide tracer on static routes",
+                config.hideTracerOnStaticRoutes(), config::setHideTracerOnStaticRoutes,
+                "When on (default), groups in STATIC load mode skip the tracer: every\n"
+              + "waypoint is already visible, so the line is often clutter. SEQUENCE\n"
+              + "routes still get a tracer to the current target.");
+        y += rowH;
+        addBoolRow(col1, y, "Show label backdrop", config.showLabelBackdrop(), config::setShowLabelBackdrop,
+                "Draws a dark rectangle behind floating waypoint names for readability.\n"
+              + "Turn off for a lighter HUD when labels stack in busy areas.");
         y += rowH;
         addBoolRow(col1, y, "Only render nearby waypoints (prev/current/next)",
-                config.windowedRendering(), config::setWindowedRendering);
+                config.windowedRendering(), config::setWindowedRendering,
+                "Renders only the previous, current, and next waypoint for every group,\n"
+              + "including STATIC routes. Cuts clutter on dense shared routes.");
         y += rowH;
         addBoxStyleRow(col1, y, colW);
 
         // --- Column 2: Behavior ------------------------------------------------------------
         int y2 = rowsY;
-        addBoolRow(col2, y2, "Show waypoint names", config.showWaypointNames(), config::setShowWaypointNames);
+        addBoolRow(col2, y2, "Show waypoint names", config.showWaypointNames(), config::setShowWaypointNames,
+                "Floating name labels at each rendered waypoint. Off keeps beacons without text.");
         y2 += rowH;
-        addBoolRow(col2, y2, "Show completed waypoints", config.showCompleted(), config::setShowCompleted);
+        addBoolRow(col2, y2, "Show completed waypoints", config.showCompleted(), config::setShowCompleted,
+                "When on, waypoints you have already reached still draw (usually faded).\n"
+              + "When off, completed stops disappear from the world HUD.");
         y2 += rowH;
-        addBoolRow(col2, y2, "Draw tracers", config.showTracer(), config::setShowTracer);
-        y2 += rowH;
-        addBoolRow(col2, y2, "Chat coord detection", config.chatCoordDetection(), config::setChatCoordDetection);
+        addBoolRow(col2, y2, "Chat coord detection", config.chatCoordDetection(), config::setChatCoordDetection,
+                "Scans incoming chat for coordinates and can offer quick-add flows for\n"
+              + "temporary or permanent waypoints (no effect when chat has no coords).");
         y2 += rowH;
         addBoolRow(col2, y2, "Chat codec detection (imports)",
-                config.chatCodecDetection(), config::setChatCodecDetection);
+                config.chatCodecDetection(), config::setChatCodecDetection,
+                "Detects Waypointer share codes pasted in chat so you can import routes\n"
+              + "without opening the main menu.");
         y2 += rowH;
         addBoolRow(col2, y2, "Include names in default export",
-                config.exportIncludeNames(), config::setExportIncludeNames);
+                config.exportIncludeNames(), config::setExportIncludeNames,
+                "When exporting, include waypoint names in the payload. Makes shared codes\n"
+              + "longer but preserves labels for the recipient.");
         y2 += rowH;
         addBoolRow(col2, y2, "Enable waypoint skip-ahead mechanic",
-                config.skipAheadMechanicEnabled(), config::setSkipAheadMechanicEnabled);
+                config.skipAheadMechanicEnabled(), config::setSkipAheadMechanicEnabled,
+                "Allows proximity to advance to a later waypoint on the route when you walk\n"
+              + "into its radius, skipping intermediates. Off forces strict one-by-one order\n"
+              + "for every group (per-group toggles still apply when this is on).");
         y2 += rowH;
         addBoolRow(col2, y2, "Disable skip-ahead on new waypoints",
-                config.disableGroupSkipAheadOnWaypointAdd(), config::setDisableGroupSkipAheadOnWaypointAdd);
+                config.disableGroupSkipAheadOnWaypointAdd(), config::setDisableGroupSkipAheadOnWaypointAdd,
+                "When you add a waypoint to a group, that group's skip-ahead turns off so you\n"
+              + "are not instantly advanced past the new point. Re-enable in the group editor.");
         y2 += rowH;
         addBoolRow(col2, y2, "Reset progress when joining a world",
-                config.resetProgressOnWorldJoin(), config::setResetProgressOnWorldJoin);
+                config.resetProgressOnWorldJoin(), config::setResetProgressOnWorldJoin,
+                "On world load or multiplayer join, every group's \"current\" waypoint resets\n"
+              + "to the start. Off keeps saved progress across reconnects.");
         y2 += rowH;
         addBoolRow(col2, y2, "Restart route after last waypoint",
-                config.restartRouteWhenComplete(), config::setRestartRouteWhenComplete);
+                config.restartRouteWhenComplete(), config::setRestartRouteWhenComplete,
+                "After you complete the final waypoint, progress wraps to the first point\n"
+              + "so loop and farm routes do not sit in a \"finished\" state.");
         y2 += rowH;
         addBoolRow(col2, y2, "Always use scoreboard for zone detection",
-                config.preferScoreboardFallback(), config::setPreferScoreboardFallback);
+                config.preferScoreboardFallback(), config::setPreferScoreboardFallback,
+                "Prefer Hypixel-style scoreboard hints when resolving the current zone ID,\n"
+              + "even when other signals exist. Use if tab/location detection misbehaves.");
         y2 += rowH;
         addBoolRow(col2, y2, "Check for updates on startup",
-                config.checkForUpdates(), config::setCheckForUpdates);
+                config.checkForUpdates(), config::setCheckForUpdates,
+                "On client start, checks GitHub once for a newer Waypointer release.\n"
+              + "Off avoids any update HTTP request.");
 
-        // Footer
         int footerY = height - FOOTER_H;
         List<GuiTokens.ButtonSpec> empty = new ArrayList<>();
-        GuiTokens.ButtonSpec done = new GuiTokens.ButtonSpec("Done", this::onClose);
+        GuiTokens.ButtonSpec done = new GuiTokens.ButtonSpec("Done", -1, this::onClose,
+                Tooltip.create(Component.literal(
+                        "Return to the previous screen.\n"
+                      + "Every change on this page is saved as you type or click.")));
         GuiTokens.layoutFooter(width, footerY, empty, done, this::addRenderableWidget, font);
 
-        // Stash header positions so render() can draw the section labels.
         this.renderingHeaderX = col1;
         this.behaviorHeaderX = col2;
         this.sectionHeaderY = headerY;
@@ -125,8 +170,9 @@ public final class ConfigScreen extends Screen {
 
     private interface DoubleSetter { void accept(double value); }
 
-    private void addNumberRow(int x, int y, int colW, String label, double initial, DoubleSetter setter) {
-        addNumberRow(x, y, colW, label, initial, setter, false);
+    private void addNumberRow(int x, int y, int colW, String label, double initial, DoubleSetter setter,
+                              String tooltip) {
+        addNumberRow(x, y, colW, label, initial, setter, false, tooltip);
     }
 
     /**
@@ -134,8 +180,8 @@ public final class ConfigScreen extends Screen {
      * through user-friendly {@code RRGGBB} strings without us needing to expose a real
      * color picker.
      */
-    private void addNumberRow(int x, int y, int colW, String label, double initial, DoubleSetter setter, boolean hex) {
-        // Label takes most of the row; edit box is a fixed width on the right.
+    private void addNumberRow(int x, int y, int colW, String label, double initial, DoubleSetter setter,
+                              boolean hex, String tooltip) {
         int boxW = 80;
         int labelW = colW - boxW - GAP;
         addRenderableOnly(new LabelWidget(x, y + 6, label, labelW));
@@ -148,19 +194,12 @@ public final class ConfigScreen extends Screen {
                 double parsed = hex ? Integer.parseInt(v.trim(), 16) : Double.parseDouble(v.trim());
                 setter.accept(parsed);
             } catch (NumberFormatException ignored) {
-                // Swallowed; invalid input just doesn't propagate. Box keeps the text so
-                // the user can correct a typo without losing their edit.
             }
         });
+        box.setTooltip(Tooltip.create(Component.literal(tooltip)));
         addRenderableWidget(box);
     }
 
-    /**
-     * Cycling button for the three-way BoxStyle enum. Chose a cycling button over
-     * three radios because the modes form a natural progression (outline → fill →
-     * both) and a single clickable label is less visual noise than a cluster of
-     * toggles.
-     */
     private void addBoxStyleRow(int x, int y, int colW) {
         int labelW = colW - 140 - GAP;
         addRenderableOnly(new LabelWidget(x, y + 6, "Box style", labelW));
@@ -169,7 +208,13 @@ public final class ConfigScreen extends Screen {
             WaypointerConfig.BoxStyle next = values[(config.boxStyle().ordinal() + 1) % values.length];
             config.setBoxStyle(next);
             b.setMessage(Component.literal(boxStyleLabel(next)));
-        }).bounds(x + labelW + GAP, y, 140, BTN_H).build();
+        }).bounds(x + labelW + GAP, y, 140, BTN_H)
+                .tooltip(Tooltip.create(Component.literal(
+                        "How each waypoint is drawn in the world:\n"
+                      + "Outlined — edge lines only.\n"
+                      + "Filled — translucent faces (easier to see at distance).\n"
+                      + "Filled + Outline — both for maximum contrast.")))
+                .build();
         addRenderableWidget(btn);
     }
 
@@ -181,21 +226,19 @@ public final class ConfigScreen extends Screen {
         };
     }
 
-    private void addBoolRow(int x, int y, String label, boolean initial, java.util.function.Consumer<Boolean> setter) {
+    private void addBoolRow(int x, int y, String label, boolean initial,
+                            java.util.function.Consumer<Boolean> setter, String tooltip) {
         Checkbox cb = Checkbox.builder(Component.literal(label), font)
                 .pos(x, y)
                 .selected(initial)
                 .onValueChange((b, v) -> setter.accept(v))
                 .build();
+        cb.setTooltip(Tooltip.create(Component.literal(tooltip)));
         addRenderableWidget(cb);
     }
 
     @Override
     public void render(GuiGraphics g, int mouseX, int mouseY, float partial) {
-        // Solid dark backdrop so labels and checkboxes aren't competing with the world
-        // behind the menu. The other Waypointer screens paint SURFACE panels under their
-        // content; this one used to render naked over vanilla's gradient which made every
-        // label read as low-contrast foreground text on a bright sky.
         g.fill(0, 0, width, height, SURFACE);
 
         super.render(g, mouseX, mouseY, partial);
@@ -218,8 +261,6 @@ public final class ConfigScreen extends Screen {
             implements net.minecraft.client.gui.components.Renderable {
         @Override
         public void render(GuiGraphics g, int mouseX, int mouseY, float partial) {
-            // Minecraft's font doesn't truncate automatically; we could implement ellipsis
-            // but every current label fits, so drawing as-is is fine.
             g.drawString(net.minecraft.client.Minecraft.getInstance().font, text, x, y, TEXT, false);
         }
     }

--- a/src/client/java/dev/ethan/waypointer/screen/ExportScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/ExportScreen.java
@@ -58,6 +58,28 @@ public final class ExportScreen extends Screen {
     /** Minecraft chat input cap. Exports longer than this can't be pasted directly. */
     private static final int CHAT_INPUT_LIMIT = 256;
 
+    /**
+     * UTF-8 byte ceiling a server enforces on serverbound command packets.
+     *
+     * Chat INPUT is measured in characters (256 chars fit in the textbox), but
+     * the wire packet is measured in bytes, and Hypixel's Watchdog closes the
+     * socket the instant a {@code ServerboundChatCommandPacket} serialises past
+     * this cap. CJK glyphs are 3 UTF-8 bytes each so a visibly-short codec can
+     * silently punch over the ceiling and disconnect the sender.
+     */
+    private static final int COMMAND_WIRE_LIMIT_BYTES = 256;
+
+    /**
+     * UTF-8 bytes occupied by the command name + separator when the codec is
+     * pasted after a typical short chat command like {@code /pc }. The leading
+     * {@code /} is stripped by the client before the packet is sent, so only
+     * {@code "pc "} (3 bytes) actually travels on the wire. This is the
+     * reference prefix used to decide whether the export can be shared inline
+     * via a chat command -- longer prefixes (e.g. {@code /msg <name> }) will
+     * fit fewer codec bytes; we surface the shortest-realistic case here.
+     */
+    private static final int REFERENCE_COMMAND_PREFIX_BYTES = "pc ".length();
+
     /** How long to show the "Copied!" state on the copy button before reverting. */
     private static final long COPIED_FEEDBACK_MS = 1500;
 
@@ -307,33 +329,60 @@ public final class ExportScreen extends Screen {
         int y = togglesBottom + GAP_SECTION;
 
         drawSizeSummary(g, PAD_OUTER, y);
-        y += LINE_H + GAP_SECTION;
+        // Size summary spans two lines (chat-char fit + command-wire-byte
+        // fit). Keep the section gap tight so the preview still has room
+        // to show multiple wrap lines at small window sizes.
+        y += LINE_H * 2 + GAP_SECTION;
 
         g.drawString(font, "Encoded preview (this is what gets copied)", PAD_OUTER, y, TEXT_DIM, false);
         y += LINE_H;
         drawPreview(g, PAD_OUTER, y, width - PAD_OUTER, height - FOOTER_H - GAP);
     }
 
+    /**
+     * Render the two-line fit summary: chars-in-chat-textbox on the first line,
+     * wire-bytes-in-a-command on the second.
+     *
+     * Both checks matter and they fail independently. The chat textbox rejects
+     * at 256 characters regardless of byte count, so a purely-ASCII export can
+     * squeak through the textbox but still never be relevant; meanwhile the
+     * server's command packet cap is 256 BYTES, which with 3-byte CJK glyphs
+     * trips long before the chat-char cap does. Surfacing only the char cap
+     * (as this screen previously did) meant routes that looked "safe to share"
+     * disconnected the sender the moment they typed {@code /pc <codec>}.
+     */
     private void drawSizeSummary(GuiGraphics g, int x, int y) {
         int chars = encoded.length();
-        int fitColor = chars <= CHAT_INPUT_LIMIT ? 0xFF88DD88 : 0xFFDD7070;
-        String fit = chars <= CHAT_INPUT_LIMIT
-                ? "fits in one chat message"
-                : "exceeds " + CHAT_INPUT_LIMIT + "-char chat cap";
-        String main = chars + " chars (" + fit + ")";
-        g.drawString(font, main, x, y, fitColor, false);
+        int wireBytes = encoded.getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
+        int commandBytes = REFERENCE_COMMAND_PREFIX_BYTES + wireBytes;
 
-        // Show the raw label byte length next to the size so the user can see
-        // how their label is contributing. Sanitize once for display so the
-        // preview matches what actually ships.
+        boolean chatOk = chars <= CHAT_INPUT_LIMIT;
+        boolean commandOk = commandBytes <= COMMAND_WIRE_LIMIT_BYTES;
+
+        int chatColor = chatOk ? 0xFF88DD88 : 0xFFDD7070;
+        String chatFit = chatOk ? "fits in a chat message" : "exceeds " + CHAT_INPUT_LIMIT + "-char chat input cap";
+        String chatLine = chars + " chars (" + chatFit + ")";
+        g.drawString(font, chatLine, x, y, chatColor, false);
+
         String sanitized = WaypointCodec.Options.sanitizeLabel(currentLabel);
         if (!sanitized.isEmpty()) {
             int gap = font.width("  ");
             int labelBytes = sanitized.getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
             g.drawString(font,
                     "label: " + labelBytes + "B sanitized",
-                    x + font.width(main) + gap, y, 0xFF88AACC, false);
+                    x + font.width(chatLine) + gap, y, 0xFF88AACC, false);
         }
+
+        // Second line: wire-byte budget for sharing via a command. The user
+        // thinks in "can I paste this into /pc?" terms; we answer that
+        // directly instead of making them translate a character count into
+        // UTF-8 bytes in their head.
+        int cmdColor = commandOk ? 0xFF88DD88 : 0xFFDD7070;
+        String cmdFit = commandOk
+                ? "fits after /pc (" + commandBytes + "/" + COMMAND_WIRE_LIMIT_BYTES + " B on the wire)"
+                : "too long to share via /pc -- would disconnect you ("
+                        + commandBytes + "/" + COMMAND_WIRE_LIMIT_BYTES + " B)";
+        g.drawString(font, wireBytes + " B  " + cmdFit, x, y + LINE_H, cmdColor, false);
     }
 
     private void drawPreview(GuiGraphics g, int x1, int y1, int x2, int y2) {

--- a/src/client/java/dev/ethan/waypointer/screen/ExportScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/ExportScreen.java
@@ -343,15 +343,20 @@ public final class ExportScreen extends Screen {
      * Render the two-line fit summary.
      *
      * Line 1 answers "can I paste this into chat?" (character count vs. the
-     * chat textbox cap). Line 2 answers "can I send this in /pc?" (UTF-8
-     * byte count vs. the command-packet ceiling, which is what Hypixel
-     * Watchdog closes the connection on).
+     * chat textbox cap). Line 2 answers "can I send this in a command like
+     * /pc or /msg?" (UTF-8 byte count vs. the command-packet ceiling, which
+     * is what Hypixel Watchdog closes the connection on).
      *
      * Both fail independently -- the chat textbox rejects at 256 chars
      * regardless of bytes, and the server's command cap is 256 BYTES which
      * with 3-byte CJK glyphs trips long before the char cap does. Surfacing
      * only the char cap (as this screen previously did) meant routes that
-     * looked "safe to share" disconnected the sender on /pc.
+     * looked "safe to share" disconnected the sender on a command.
+     *
+     * The order matters: command-fit first (the thing that can disconnect
+     * you) and chat-fit second (the safe fallback). When a command won't
+     * fit but chat will, we say so inline so the user doesn't have to
+     * cross-reference two lines to figure out "so can I still share this?".
      *
      * The user-visible strings are deliberately plain-language -- no byte
      * counts, no "cap", no "wire" -- because almost nobody pasting a route
@@ -367,27 +372,36 @@ public final class ExportScreen extends Screen {
         boolean chatOk = chars <= CHAT_INPUT_LIMIT;
         boolean commandOk = commandBytes <= COMMAND_WIRE_LIMIT_BYTES;
 
-        int chatColor = chatOk ? 0xFF88DD88 : 0xFFDD7070;
-        String chatLine = chatOk
-                ? "Fits in a chat message"
-                : "Too long for chat -- paste it somewhere else (like Discord)";
-        g.drawString(font, chatLine, x, y, chatColor, false);
+        // Line 1: command-fit. This is the check that can disconnect the
+        // sender, so it leads. When the command path is blocked but chat
+        // still works, we point that out on the same line so the remedy
+        // is obvious without reading further.
+        int cmdColor = commandOk ? 0xFF88DD88 : 0xFFDD7070;
+        String cmdLine;
+        if (commandOk) {
+            cmdLine = "OK to send in a command (/pc, /msg, etc.)";
+        } else if (chatOk) {
+            cmdLine = "Too long for a command -- paste it straight into chat instead";
+        } else {
+            cmdLine = "Too long for a command -- would kick you from the server";
+        }
+        g.drawString(font, cmdLine, x, y, cmdColor, false);
 
         String sanitized = WaypointCodec.Options.sanitizeLabel(currentLabel);
         if (!sanitized.isEmpty()) {
             int gap = font.width("  ");
             g.drawString(font,
                     "label: \"" + sanitized + "\"",
-                    x + font.width(chatLine) + gap, y, 0xFF88AACC, false);
+                    x + font.width(cmdLine) + gap, y, 0xFF88AACC, false);
         }
 
-        // Second line: can this be shared with /pc? This is the check that
-        // actually prevents a disconnect, so it has to be obvious.
-        int cmdColor = commandOk ? 0xFF88DD88 : 0xFFDD7070;
-        String cmdLine = commandOk
-                ? "OK to send in /pc"
-                : "Too long for /pc -- would kick you from the server";
-        g.drawString(font, cmdLine, x, y + LINE_H, cmdColor, false);
+        // Line 2: chat-fit. Always shown so users see the ceiling they're
+        // approaching even before they hit it.
+        int chatColor = chatOk ? 0xFF88DD88 : 0xFFDD7070;
+        String chatLine = chatOk
+                ? "Fits in a chat message"
+                : "Too long for chat -- share somewhere else (like Discord)";
+        g.drawString(font, chatLine, x, y + LINE_H, chatColor, false);
     }
 
     private void drawPreview(GuiGraphics g, int x1, int y1, int x2, int y2) {

--- a/src/client/java/dev/ethan/waypointer/screen/ExportScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/ExportScreen.java
@@ -340,16 +340,24 @@ public final class ExportScreen extends Screen {
     }
 
     /**
-     * Render the two-line fit summary: chars-in-chat-textbox on the first line,
-     * wire-bytes-in-a-command on the second.
+     * Render the two-line fit summary.
      *
-     * Both checks matter and they fail independently. The chat textbox rejects
-     * at 256 characters regardless of byte count, so a purely-ASCII export can
-     * squeak through the textbox but still never be relevant; meanwhile the
-     * server's command packet cap is 256 BYTES, which with 3-byte CJK glyphs
-     * trips long before the chat-char cap does. Surfacing only the char cap
-     * (as this screen previously did) meant routes that looked "safe to share"
-     * disconnected the sender the moment they typed {@code /pc <codec>}.
+     * Line 1 answers "can I paste this into chat?" (character count vs. the
+     * chat textbox cap). Line 2 answers "can I send this in /pc?" (UTF-8
+     * byte count vs. the command-packet ceiling, which is what Hypixel
+     * Watchdog closes the connection on).
+     *
+     * Both fail independently -- the chat textbox rejects at 256 chars
+     * regardless of bytes, and the server's command cap is 256 BYTES which
+     * with 3-byte CJK glyphs trips long before the char cap does. Surfacing
+     * only the char cap (as this screen previously did) meant routes that
+     * looked "safe to share" disconnected the sender on /pc.
+     *
+     * The user-visible strings are deliberately plain-language -- no byte
+     * counts, no "cap", no "wire" -- because almost nobody pasting a route
+     * to a friend wants to reason about UTF-8 size limits. The underlying
+     * numbers stay in comments here so future maintainers can still find
+     * them.
      */
     private void drawSizeSummary(GuiGraphics g, int x, int y) {
         int chars = encoded.length();
@@ -360,29 +368,26 @@ public final class ExportScreen extends Screen {
         boolean commandOk = commandBytes <= COMMAND_WIRE_LIMIT_BYTES;
 
         int chatColor = chatOk ? 0xFF88DD88 : 0xFFDD7070;
-        String chatFit = chatOk ? "fits in a chat message" : "exceeds " + CHAT_INPUT_LIMIT + "-char chat input cap";
-        String chatLine = chars + " chars (" + chatFit + ")";
+        String chatLine = chatOk
+                ? "Fits in a chat message"
+                : "Too long for chat -- paste it somewhere else (like Discord)";
         g.drawString(font, chatLine, x, y, chatColor, false);
 
         String sanitized = WaypointCodec.Options.sanitizeLabel(currentLabel);
         if (!sanitized.isEmpty()) {
             int gap = font.width("  ");
-            int labelBytes = sanitized.getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
             g.drawString(font,
-                    "label: " + labelBytes + "B sanitized",
+                    "label: \"" + sanitized + "\"",
                     x + font.width(chatLine) + gap, y, 0xFF88AACC, false);
         }
 
-        // Second line: wire-byte budget for sharing via a command. The user
-        // thinks in "can I paste this into /pc?" terms; we answer that
-        // directly instead of making them translate a character count into
-        // UTF-8 bytes in their head.
+        // Second line: can this be shared with /pc? This is the check that
+        // actually prevents a disconnect, so it has to be obvious.
         int cmdColor = commandOk ? 0xFF88DD88 : 0xFFDD7070;
-        String cmdFit = commandOk
-                ? "fits after /pc (" + commandBytes + "/" + COMMAND_WIRE_LIMIT_BYTES + " B on the wire)"
-                : "too long to share via /pc -- would disconnect you ("
-                        + commandBytes + "/" + COMMAND_WIRE_LIMIT_BYTES + " B)";
-        g.drawString(font, wireBytes + " B  " + cmdFit, x, y + LINE_H, cmdColor, false);
+        String cmdLine = commandOk
+                ? "OK to send in /pc"
+                : "Too long for /pc -- would kick you from the server";
+        g.drawString(font, cmdLine, x, y + LINE_H, cmdColor, false);
     }
 
     private void drawPreview(GuiGraphics g, int x1, int y1, int x2, int y2) {

--- a/src/client/java/dev/ethan/waypointer/screen/GuiTokens.java
+++ b/src/client/java/dev/ethan/waypointer/screen/GuiTokens.java
@@ -1,6 +1,7 @@
 package dev.ethan.waypointer.screen;
 
 import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.network.chat.Component;
 
 import java.util.ArrayList;
@@ -68,9 +69,17 @@ public final class GuiTokens {
 
     // --- responsive footer ------------------------------------------------------------------
 
-    /** A button to place in the footer. {@code width <= 0} means "auto-size from label". */
-    public record ButtonSpec(String label, int width, Runnable onClick) {
-        public ButtonSpec(String label, Runnable onClick) { this(label, -1, onClick); }
+    /**
+     * A button to place in the footer. {@code width <= 0} means "auto-size from label".
+     * {@code tooltip} is optional hover help (e.g. the settings screen Done button).
+     */
+    public record ButtonSpec(String label, int width, Runnable onClick, Tooltip tooltip) {
+        public ButtonSpec(String label, Runnable onClick) {
+            this(label, -1, onClick, null);
+        }
+        public ButtonSpec(String label, int width, Runnable onClick) {
+            this(label, width, onClick, null);
+        }
     }
 
     /**
@@ -156,7 +165,11 @@ public final class GuiTokens {
     }
 
     private static Button buildButton(ButtonSpec spec, int x, int y, int w) {
-        return Button.builder(Component.literal(spec.label), b -> spec.onClick.run())
-                .bounds(x, y, w, BTN_H).build();
+        var builder = Button.builder(Component.literal(spec.label), b -> spec.onClick.run())
+                .bounds(x, y, w, BTN_H);
+        if (spec.tooltip != null) {
+            builder = builder.tooltip(spec.tooltip);
+        }
+        return builder.build();
     }
 }

--- a/src/main/java/dev/ethan/waypointer/chat/CodecSendGuard.java
+++ b/src/main/java/dev/ethan/waypointer/chat/CodecSendGuard.java
@@ -1,0 +1,88 @@
+package dev.ethan.waypointer.chat;
+
+import dev.ethan.waypointer.codec.WaypointCodec;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Pure decision: does this chat command carry a Waypointer codec that would
+ * disconnect the sender on delivery?
+ *
+ * Why this exists: Hypixel's Watchdog closes the TCP socket the instant a
+ * {@code ServerboundChatCommandPacket} serialises past {@value #COMMAND_WIRE_LIMIT_BYTES}
+ * UTF-8 bytes, with no kick reason. The client doesn't enforce the cap, so the
+ * connection just dies. The codec uses CJK glyphs at 3 UTF-8 bytes apiece, so
+ * a route that looks visually short (86 characters, "just a paste") can punch
+ * the ceiling the moment it's prefixed with {@code /pc } and dropkick the
+ * sender out of the lobby. This class owns the "would that send kill us?"
+ * question; the client-side installer wires it to Fabric's allow-command hook
+ * and handles the cancel + chat warning.
+ *
+ * Keeping the decision here (no Minecraft imports) means it lives in the main
+ * source set and stays unit-testable without bootstrapping a client.
+ *
+ * Scope:
+ *
+ *   - Only commands are inspected. Regular chat input is already capped at
+ *     256 characters by the textbox, which is a safe over-estimate for
+ *     vanilla-server chat payloads; the specific disconnect we're defending
+ *     against is the command-packet path.
+ *   - Only commands that contain the {@link WaypointCodec#MAGIC} prefix are
+ *     considered. We deliberately do NOT police every oversized command --
+ *     other mods or pasteable macros may produce long commands the server
+ *     does accept, and silently cancelling them would look like a bug in
+ *     Waypointer rather than a safety net.
+ */
+public final class CodecSendGuard {
+
+    /**
+     * Serverbound command-packet byte ceiling. Strings at {@code <= 256}
+     * UTF-8 bytes deliver; strings past it sever the connection with no kick
+     * message. Vanilla clients don't apply this check themselves.
+     */
+    public static final int COMMAND_WIRE_LIMIT_BYTES = 256;
+
+    private CodecSendGuard() {}
+
+    /**
+     * Outcome of inspecting a candidate command string. Exposes enough state
+     * to render a user-facing warning (byte count, overage, command verb)
+     * without pulling any chat formatting into the decision layer.
+     *
+     * The {@link #commandLeader} is the first whitespace-delimited token of
+     * the command (e.g. {@code "pc"}, {@code "msg"}) -- the verb we want to
+     * echo back in the warning so the user knows what was cancelled, without
+     * quoting the whole codec body at them.
+     */
+    public record Decision(boolean shouldBlock, int wireBytes, int overByBytes, String commandLeader) {
+
+        public static Decision allow() { return new Decision(false, 0, 0, ""); }
+
+        public static Decision block(int wireBytes, String commandLeader) {
+            return new Decision(true, wireBytes, wireBytes - COMMAND_WIRE_LIMIT_BYTES, commandLeader);
+        }
+    }
+
+    /**
+     * Decide whether to cancel {@code command}, the payload as the server
+     * will see it (no leading slash).
+     *
+     * Short-circuits on the cheap containment check first so non-codec
+     * commands pay almost nothing on the send hot path -- this fires for
+     * every {@code /<anything>} the user types, not just ours.
+     */
+    public static Decision inspect(String command) {
+        if (command == null || command.isEmpty()) return Decision.allow();
+        if (!command.contains(WaypointCodec.MAGIC)) return Decision.allow();
+
+        int wireBytes = command.getBytes(StandardCharsets.UTF_8).length;
+        if (wireBytes <= COMMAND_WIRE_LIMIT_BYTES) return Decision.allow();
+
+        return Decision.block(wireBytes, leadingWord(command));
+    }
+
+    private static String leadingWord(String command) {
+        int sp = command.indexOf(' ');
+        return sp < 0 ? command : command.substring(0, sp);
+    }
+}

--- a/src/main/java/dev/ethan/waypointer/config/WaypointerConfig.java
+++ b/src/main/java/dev/ethan/waypointer/config/WaypointerConfig.java
@@ -74,6 +74,13 @@ public final class WaypointerConfig {
     private boolean showCompleted = true;
     private boolean showTracer = true;
     /**
+     * When {@code true} (default), groups in {@link dev.ethan.waypointer.core.WaypointGroup.LoadMode#STATIC}
+     * do not draw the crosshair tracer. Static routes already surface every waypoint, so the
+     * line is often visual noise; {@link dev.ethan.waypointer.core.WaypointGroup.LoadMode#SEQUENCE}
+     * groups still get a tracer to the active breadcrumb target.
+     */
+    private boolean hideTracerOnStaticRoutes = true;
+    /**
      * When {@code true}, each waypoint label draws a translucent black rectangle
      * behind its text for readability. Some players find it obtrusive in busy
      * routes where labels stack -- turning it off lets the text sit directly
@@ -258,6 +265,7 @@ public final class WaypointerConfig {
     public boolean showWaypointNames()        { return showWaypointNames; }
     public boolean showCompleted()            { return showCompleted; }
     public boolean showTracer()               { return showTracer; }
+    public boolean hideTracerOnStaticRoutes() { return hideTracerOnStaticRoutes; }
     public boolean showLabelBackdrop()        { return showLabelBackdrop; }
     public BoxStyle boxStyle()                { return boxStyle == null ? BoxStyle.OUTLINED : boxStyle; }
     public boolean windowedRendering()        { return windowedRendering; }
@@ -285,6 +293,7 @@ public final class WaypointerConfig {
     public void setShowWaypointNames(boolean v)        { this.showWaypointNames = v; save(); }
     public void setShowCompleted(boolean v)            { this.showCompleted = v; save(); }
     public void setShowTracer(boolean v)               { this.showTracer = v; save(); }
+    public void setHideTracerOnStaticRoutes(boolean v) { this.hideTracerOnStaticRoutes = v; save(); }
     public void setPreferScoreboardFallback(boolean v) { this.preferScoreboardFallback = v; save(); }
     public void setChatCoordDetection(boolean v)       { this.chatCoordDetection = v; save(); }
     public void setChatCodecDetection(boolean v)       { this.chatCodecDetection = v; save(); }

--- a/src/main/java/dev/ethan/waypointer/config/WaypointerConfig.java
+++ b/src/main/java/dev/ethan/waypointer/config/WaypointerConfig.java
@@ -88,22 +88,6 @@ public final class WaypointerConfig {
      */
     private boolean showLabelBackdrop = true;
     private BoxStyle boxStyle = BoxStyle.OUTLINED;
-    /**
-     * When {@code true}, every group renders only a three-waypoint sliding
-     * window ({@code currentIndex - 1}, {@code currentIndex}, {@code currentIndex + 1}),
-     * regardless of the group's load mode. Reduces label clutter on dense
-     * static routes where every checkpoint otherwise fights for screen space.
-     *
-     * <p>This is stricter than {@link dev.ethan.waypointer.core.WaypointGroup.LoadMode#SEQUENCE}
-     * already does for sequence groups -- the flag extends the same behavior
-     * to {@link dev.ethan.waypointer.core.WaypointGroup.LoadMode#STATIC}
-     * groups without forcing the user to convert their route and lose the
-     * "see the whole path at once" option.
-     *
-     * <p>Off by default so users don't silently lose visibility of their
-     * existing static routes on upgrade.
-     */
-    private boolean windowedRendering = false;
 
     // Zone detection
     private boolean preferScoreboardFallback = false;
@@ -268,7 +252,6 @@ public final class WaypointerConfig {
     public boolean hideTracerOnStaticRoutes() { return hideTracerOnStaticRoutes; }
     public boolean showLabelBackdrop()        { return showLabelBackdrop; }
     public BoxStyle boxStyle()                { return boxStyle == null ? BoxStyle.OUTLINED : boxStyle; }
-    public boolean windowedRendering()        { return windowedRendering; }
     public boolean preferScoreboardFallback() { return preferScoreboardFallback; }
     public boolean chatCoordDetection()       { return chatCoordDetection; }
     public boolean chatCodecDetection()       { return chatCodecDetection; }
@@ -304,7 +287,6 @@ public final class WaypointerConfig {
     public void setExportIncludeGroupMeta(boolean v)    { this.exportIncludeGroupMeta = v; save(); }
     public void setShowLabelBackdrop(boolean v)        { this.showLabelBackdrop = v; save(); }
     public void setBoxStyle(BoxStyle v)                { this.boxStyle = v == null ? BoxStyle.OUTLINED : v; save(); }
-    public void setWindowedRendering(boolean v)        { this.windowedRendering = v; save(); }
     public void setSkipAheadMechanicEnabled(boolean v) { this.skipAheadMechanicEnabled = v; save(); }
     public void setDisableGroupSkipAheadOnWaypointAdd(boolean v) { this.disableGroupSkipAheadOnWaypointAdd = v; save(); }
     public void setCheckForUpdates(boolean v)          { this.checkForUpdates = v; save(); }

--- a/src/main/java/dev/ethan/waypointer/core/WaypointGroup.java
+++ b/src/main/java/dev/ethan/waypointer/core/WaypointGroup.java
@@ -184,25 +184,10 @@ public final class WaypointGroup {
      * {@code action} with each index inline, producing zero garbage.
      */
     public void forEachVisibleIndex(IntConsumer action) {
-        forEachVisibleIndex(action, false);
-    }
-
-    /**
-     * Sibling of {@link #forEachVisibleIndex(IntConsumer)} that lets the caller
-     * force the prev/current/next window even on STATIC groups. Used by the
-     * renderer when the user has enabled the "windowed rendering" config
-     * toggle so dense static routes stop drawing every checkpoint at once
-     * without the user having to convert the group's load mode (which would
-     * also change navigation semantics, not just visuals).
-     *
-     * @param forceWindow when {@code true}, always emit the three-index
-     *                    sliding window regardless of {@link #loadMode}
-     */
-    public void forEachVisibleIndex(IntConsumer action, boolean forceWindow) {
         int n = waypoints.size();
         if (n == 0) return;
 
-        if (loadMode == LoadMode.STATIC && !forceWindow) {
+        if (loadMode == LoadMode.STATIC) {
             for (int i = 0; i < n; i++) action.accept(i);
             return;
         }

--- a/src/test/java/dev/ethan/waypointer/chat/CodecSendGuardTest.java
+++ b/src/test/java/dev/ethan/waypointer/chat/CodecSendGuardTest.java
@@ -1,0 +1,108 @@
+package dev.ethan.waypointer.chat;
+
+import dev.ethan.waypointer.codec.WaypointCodec;
+import dev.ethan.waypointer.core.Waypoint;
+import dev.ethan.waypointer.core.WaypointGroup;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Decision logic for the command-send guard. Covers the disconnect-prevention
+ * hot path: the guard must (a) pass through anything unrelated untouched,
+ * (b) fire when a WP: command would punch the 256-byte ceiling, and
+ * (c) report enough context to build a useful chat warning.
+ */
+class CodecSendGuardTest {
+
+    @Test
+    void allows_empty_and_non_codec_commands() {
+        assertFalse(CodecSendGuard.inspect(null).shouldBlock());
+        assertFalse(CodecSendGuard.inspect("").shouldBlock());
+        assertFalse(CodecSendGuard.inspect("pc hello friend").shouldBlock());
+        // A command the same length as our ceiling but without WP: must not be
+        // policed -- other mods / macros may legitimately send long commands.
+        String benign = "say " + "x".repeat(300);
+        assertFalse(CodecSendGuard.inspect(benign).shouldBlock(),
+                "only WP: codec commands are our concern");
+    }
+
+    @Test
+    void allows_codec_commands_under_the_byte_ceiling() {
+        String small = "pc " + WaypointCodec.MAGIC + "0123456789";
+        CodecSendGuard.Decision d = CodecSendGuard.inspect(small);
+        assertFalse(d.shouldBlock(),
+                "codec commands well below the cap must not be cancelled");
+    }
+
+    @Test
+    void blocks_codec_command_that_exceeds_the_byte_ceiling() {
+        // Build a codec large enough to punch the ceiling even with no
+        // command prefix. Using the real encoder proves the guard agrees
+        // with the codec's actual on-the-wire representation.
+        String encoded = encodeLargeRoute();
+        assertTrue(encoded.getBytes(StandardCharsets.UTF_8).length > CodecSendGuard.COMMAND_WIRE_LIMIT_BYTES,
+                "test precondition: real encoded route must be over the limit");
+
+        String command = "pc " + encoded;
+        int expectedBytes = command.getBytes(StandardCharsets.UTF_8).length;
+
+        CodecSendGuard.Decision d = CodecSendGuard.inspect(command);
+        assertTrue(d.shouldBlock(), "oversized WP: command must be cancelled");
+        assertEquals(expectedBytes, d.wireBytes(),
+                "decision must report the real wire-byte count so the warning is accurate");
+        assertEquals(expectedBytes - CodecSendGuard.COMMAND_WIRE_LIMIT_BYTES, d.overByBytes(),
+                "overBy must match bytes - cap");
+        assertEquals("pc", d.commandLeader(),
+                "commandLeader must echo the verb so the warning says which command was blocked");
+    }
+
+    @Test
+    void reports_leader_for_long_prefix_commands() {
+        // /msg <name> <codec> is a legit way to share routes DM-style; when it
+        // overflows, the user needs to see "msg" in the warning, not "pc".
+        String command = "msg " + "a".repeat(20) + " " + WaypointCodec.MAGIC + "\u4E00".repeat(100);
+        CodecSendGuard.Decision d = CodecSendGuard.inspect(command);
+        assertTrue(d.shouldBlock());
+        assertEquals("msg", d.commandLeader());
+    }
+
+    @Test
+    void exact_byte_boundary_is_allowed() {
+        // Boundary matters: the server accepts <=256, rejects >256. A guard
+        // that blocked at the boundary would false-positive on maximally
+        // packed exports that are actually safe to send.
+        String padded = "a".repeat(CodecSendGuard.COMMAND_WIRE_LIMIT_BYTES - WaypointCodec.MAGIC.length())
+                + WaypointCodec.MAGIC;
+        assertEquals(CodecSendGuard.COMMAND_WIRE_LIMIT_BYTES,
+                padded.getBytes(StandardCharsets.UTF_8).length,
+                "test precondition: crafted string must sit exactly at the cap");
+        assertFalse(CodecSendGuard.inspect(padded).shouldBlock(),
+                "exactly at the ceiling must pass");
+
+        String oneOver = padded + "x";
+        assertTrue(CodecSendGuard.inspect(oneOver).shouldBlock(),
+                "one byte over the ceiling must block");
+    }
+
+    /**
+     * Build a codec whose encoded form is guaranteed to exceed the byte cap.
+     * Uses waypoints with distinct names so the dictionary-aided DEFLATE has
+     * no chance of compressing the payload below the ceiling.
+     */
+    private static String encodeLargeRoute() {
+        WaypointGroup g = WaypointGroup.create("Big Route for Byte-Cap Test", "dungeon_f7");
+        List<Waypoint> pts = new ArrayList<>();
+        for (int i = 0; i < 60; i++) {
+            pts.add(new Waypoint(100 + i * 7, 60 + (i % 9), 200 - i * 3,
+                    "waypt_" + i + "_" + (i * 31 % 97),
+                    Waypoint.DEFAULT_COLOR, 0, 0));
+        }
+        for (Waypoint w : pts) g.add(w);
+        return WaypointCodec.encode(List.of(g));
+    }
+}

--- a/src/test/java/dev/ethan/waypointer/core/WaypointGroupTest.java
+++ b/src/test/java/dev/ethan/waypointer/core/WaypointGroupTest.java
@@ -185,50 +185,6 @@ class WaypointGroupTest {
     }
 
     @Test
-    void forEachVisibleIndex_forceWindow_overridesStaticMode() {
-        // The windowed-rendering config toggle calls forEachVisibleIndex with
-        // forceWindow=true so dense STATIC routes stop drawing every
-        // checkpoint. Must produce the same prev/current/next slice SEQUENCE
-        // groups get, without mutating the group's load mode.
-        WaypointGroup g = route();
-        g.setLoadMode(WaypointGroup.LoadMode.STATIC);
-        g.setCurrentIndex(2);
-
-        java.util.List<Integer> seen = new java.util.ArrayList<>();
-        g.forEachVisibleIndex(seen::add, true);
-        assertEquals(java.util.List.of(1, 2, 3), seen,
-                "forceWindow should window a STATIC route without changing its load mode");
-        assertEquals(WaypointGroup.LoadMode.STATIC, g.loadMode(),
-                "forceWindow must not mutate loadMode -- it's a pure render-time hint");
-    }
-
-    @Test
-    void forEachVisibleIndex_forceWindow_respectsCompletionAndBounds() {
-        // Same boundary semantics as the SEQUENCE path: completed routes
-        // collapse to the last marker, start/end indices drop the missing
-        // neighbour cleanly. Locking these in because the window path now has
-        // two callers (load-mode-driven and config-driven) and a regression
-        // in either is silent -- labels just disappear or duplicate.
-        WaypointGroup g = route();
-        g.setLoadMode(WaypointGroup.LoadMode.STATIC);
-
-        g.setCurrentIndex(0);
-        java.util.List<Integer> atStart = new java.util.ArrayList<>();
-        g.forEachVisibleIndex(atStart::add, true);
-        assertEquals(java.util.List.of(0, 1), atStart);
-
-        g.setCurrentIndex(g.size() - 1);
-        java.util.List<Integer> atEnd = new java.util.ArrayList<>();
-        g.forEachVisibleIndex(atEnd::add, true);
-        assertEquals(java.util.List.of(g.size() - 2, g.size() - 1), atEnd);
-
-        g.setCurrentIndex(g.size()); // past the end -> isComplete()
-        java.util.List<Integer> done = new java.util.ArrayList<>();
-        g.forEachVisibleIndex(done::add, true);
-        assertEquals(java.util.List.of(g.size() - 1), done);
-    }
-
-    @Test
     void loadMode_defaultsToStatic() {
         WaypointGroup g = WaypointGroup.create("r", "z");
         assertEquals(WaypointGroup.LoadMode.STATIC, g.loadMode(),


### PR DESCRIPTION
Hypixel Watchdog severs the connection with no kick reason the moment a ServerboundChatCommandPacket exceeds 256 UTF-8 bytes. The codec uses CJK glyphs (3 bytes each), so a visually-short /pc WP:... could silently drop the sender out of the lobby.

Two mitigations, no codec changes:

- ExportScreen now renders a second fit line showing wire bytes vs. the 256-byte command cap (red when a /pc share would disconnect), so users see the danger before pasting anywhere.
- CodecSendGuard (pure, unit-tested in main) inspects outbound commands containing WP: and returns a block Decision when they overflow. ClientCodecSendGuard wires that to Fabric ALLOW_COMMAND, cancels the send, and posts a red inline warning explaining what happened and how to shrink the export.