### PR TITLE
Prepare waypoint fixes and dungeon secrets beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,21 +29,24 @@ Fabric mod for Hypixel Skyblock that aims to be the best possible waypoint manag
 
 ## Requirements
 
-- Minecraft 1.21.11
+- Minecraft 1.21.11 through 26.1.2
 - Fabric Loader 0.18.2+
 - [Fabric API](https://modrinth.com/mod/fabric-api)
 - [owo-lib](https://modrinth.com/mod/owo-lib) 0.13.0+
 - *(optional)* Hypixel Mod API 1.0+. Improves zone detection
 
-Minecraft 26.1 is a tracked port target. Mojang/Fabric metadata list it as a
-stable release, but it requires Java 25 and cannot be verified from a Java 21
-Gradle environment yet.
+Minecraft 26.1.2 requires Java 25 at runtime. The project still compiles with
+Java 21 because that is the 1.21.11 baseline.
 
 ## Building
 
 ```powershell
 ./gradlew build
 ```
+
+- `build/libs/waypointer-<version>-1.21.11.jar` — standard Fabric/intermediary jar.
+- `build/libs/waypointer-<version>-26.x.jar` — official-namespace jar for
+  26.x runtimes that report `official` as their loader namespace.
 
 ## Testing
 

--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,10 @@ tasks.withType(JavaCompile).configureEach {
 	it.options.release = 21
 }
 
+tasks.named("remapJar") {
+	archiveVersion = "${project.version}-1.21.11"
+}
+
 java {
 	withSourcesJar()
 
@@ -87,6 +91,36 @@ jar {
 		rename { "${it}_${inputs.properties.archivesName}" }
 	}
 }
+
+tasks.register("officialJar", Jar) {
+	group = "build"
+	description = "Assembles an official-namespace jar for 26.x Fabric runtimes."
+
+	dependsOn tasks.jar
+	archiveBaseName = project.base.archivesName
+	archiveVersion = "${project.version}-26.x"
+	destinationDirectory = layout.buildDirectory.dir("libs")
+
+	from(zipTree(tasks.jar.archiveFile)) {
+		exclude "waypointer.accesswidener"
+	}
+	from(layout.buildDirectory.file("generated/officialJar/waypointer.accesswidener")) {
+		into ""
+	}
+
+	inputs.file("src/main/resources/waypointer.accesswidener")
+	outputs.file(layout.buildDirectory.file("generated/officialJar/waypointer.accesswidener"))
+
+	doFirst {
+		def source = file("src/main/resources/waypointer.accesswidener")
+		def target = layout.buildDirectory.file("generated/officialJar/waypointer.accesswidener").get().asFile
+		target.parentFile.mkdirs()
+		target.text = source.getText("UTF-8")
+				.replace("accessWidener\tv2\tnamed", "accessWidener\tv2\tofficial")
+	}
+}
+
+assemble.dependsOn tasks.named("officialJar")
 
 publishing {
 	publications {

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ loader_version=0.18.2
 loom_version=1.15-SNAPSHOT
 
 # Mod Properties
-mod_version=1.3.0
+mod_version=1.4.0
 maven_group=dev.ethan.waypointer
 archives_base_name=waypointer
 

--- a/src/client/java/dev/ethan/waypointer/WaypointerClient.java
+++ b/src/client/java/dev/ethan/waypointer/WaypointerClient.java
@@ -9,8 +9,11 @@ import dev.ethan.waypointer.config.WaypointerConfig;
 import dev.ethan.waypointer.core.ActiveGroupManager;
 import dev.ethan.waypointer.dungeon.DungeonCommands;
 import dev.ethan.waypointer.dungeon.DungeonHighlightRenderer;
+import dev.ethan.waypointer.dungeon.DungeonRouteSession;
 import dev.ethan.waypointer.dungeon.DungeonStateTracker;
+import dev.ethan.waypointer.dungeon.DungeonTriggerDetector;
 import dev.ethan.waypointer.dungeon.config.DungeonConfig;
+import dev.ethan.waypointer.dungeon.data.DungeonRoomData;
 import dev.ethan.waypointer.input.WaypointerKeybinds;
 import dev.ethan.waypointer.location.LocationTracker;
 import dev.ethan.waypointer.progression.ProximityTracker;
@@ -38,12 +41,14 @@ public final class WaypointerClient implements ClientModInitializer {
     private static WaypointerConfig config;
     private static DungeonConfig dungeonConfig;
     private static DungeonStateTracker dungeonTracker;
+    private static DungeonRouteSession dungeonRouteSession;
 
     public static ActiveGroupManager manager()        { return manager; }
     public static Storage storage()                   { return storage; }
     public static WaypointerConfig config()           { return config; }
     public static DungeonConfig dungeonConfig()       { return dungeonConfig; }
     public static DungeonStateTracker dungeonTracker(){ return dungeonTracker; }
+    public static DungeonRouteSession dungeonRouteSession(){ return dungeonRouteSession; }
 
     @Override
     public void onInitializeClient() {
@@ -65,15 +70,21 @@ public final class WaypointerClient implements ClientModInitializer {
         // the merge surface with sibling work on `main` (issues #4/#7) stays
         // narrow -- no shared files beyond this wiring point.
         dungeonConfig = DungeonConfig.load();
+        DungeonRoomData.loadDefaultCustomStore();
         dungeonTracker = new DungeonStateTracker(manager, dungeonConfig);
+        dungeonRouteSession = new DungeonRouteSession();
+        dungeonTracker.addRoomListener(room -> {
+            if (room == null && !dungeonTracker.inDungeon()) dungeonRouteSession.resetAll();
+        });
         dungeonTracker.install();
-        new DungeonHighlightRenderer(dungeonTracker, dungeonConfig).install();
-        new DungeonCommands(dungeonTracker, dungeonConfig).install();
+        new DungeonHighlightRenderer(dungeonTracker, dungeonConfig, dungeonRouteSession).install();
+        new DungeonTriggerDetector(dungeonTracker, dungeonRouteSession).install();
+        new DungeonCommands(dungeonTracker, dungeonConfig, dungeonRouteSession).install();
 
         ChatImportCache chatImportCache = new ChatImportCache();
         new WaypointerCommands(manager, storage, config, chatImportCache, WaypointerClient::openGui).install();
         new WaypointerKeybinds(WaypointerClient::openGui, manager, config).install();
-        new ChatCoordDetector(config).install();
+        new ChatCoordDetector(config, manager).install();
         new ChatImportDetector(config, chatImportCache).install();
 
         ClientLifecycleEvents.CLIENT_STOPPING.register(client -> {
@@ -83,6 +94,7 @@ public final class WaypointerClient implements ClientModInitializer {
             storage.flush();
             config.flush();
             if (dungeonConfig != null) dungeonConfig.flush();
+            DungeonRoomData.flush();
         });
 
         // Fire-and-forget update check. Runs on a daemon thread with a 5s

--- a/src/client/java/dev/ethan/waypointer/chat/ChatCoordDetector.java
+++ b/src/client/java/dev/ethan/waypointer/chat/ChatCoordDetector.java
@@ -1,6 +1,7 @@
 package dev.ethan.waypointer.chat;
 
 import dev.ethan.waypointer.config.WaypointerConfig;
+import dev.ethan.waypointer.core.ActiveGroupManager;
 import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.ClickEvent;
@@ -15,9 +16,10 @@ import java.util.Optional;
 
 /**
  * Sniffs incoming game chat for "x y z" coordinate triples and recolors the coord
- * numbers themselves into clickable aqua-underlined runs. Clicking runs
- * {@code /wp addtemp at <x> <y> <z>}, which drops a session-scoped temporary
- * waypoint (expires on disconnect) into the zone's temp bucket.
+ * numbers themselves into clickable aqua-underlined runs. By default, each
+ * detected coordinate also drops a session-scoped temporary waypoint (expires
+ * on disconnect) into the zone's temp bucket; users can turn that automatic
+ * creation off and keep the click-to-add chip only.
  *
  * <p>Chat-shared coords are almost always one-offs -- "meet me at 100 64 200"
  * -- so committing them to the permanent route was the wrong default and
@@ -36,9 +38,11 @@ import java.util.Optional;
 public final class ChatCoordDetector {
 
     private final WaypointerConfig config;
+    private final ActiveGroupManager manager;
 
-    public ChatCoordDetector(WaypointerConfig config) {
+    public ChatCoordDetector(WaypointerConfig config, ActiveGroupManager manager) {
         this.config = config;
+        this.manager = manager;
     }
 
     public void install() {
@@ -54,6 +58,12 @@ public final class ChatCoordDetector {
         String flat = msg.getString();
         List<CoordScanner.Match> matches = CoordScanner.scanWithPositions(flat);
         if (matches.isEmpty()) return msg;
+
+        if (config.autoAddChatTempWaypoints()) {
+            for (CoordScanner.Match match : matches) {
+                manager.addTempWaypoint(match.x(), match.y(), match.z());
+            }
+        }
 
         return rebuildWithHighlights(msg, matches);
     }

--- a/src/client/java/dev/ethan/waypointer/commands/CommandSuggestionHelpers.java
+++ b/src/client/java/dev/ethan/waypointer/commands/CommandSuggestionHelpers.java
@@ -1,0 +1,39 @@
+package dev.ethan.waypointer.commands;
+
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import net.minecraft.network.chat.Component;
+
+import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.IntFunction;
+
+/**
+ * Shared Brigadier suggestion helpers for client commands.
+ */
+public final class CommandSuggestionHelpers {
+
+    private CommandSuggestionHelpers() {}
+
+    /**
+     * Emit integer suggestions {@code 0..count-1} matching the typed prefix, each with a tooltip.
+     */
+    public static CompletableFuture<Suggestions> suggestIndexed(
+            SuggestionsBuilder builder, int count, IntFunction<String> tooltipFor) {
+        String prefix = builder.getRemaining();
+        for (int i = 0; i < count; i++) {
+            String value = Integer.toString(i);
+            if (value.startsWith(prefix)) {
+                builder.suggest(i, Component.literal(tooltipFor.apply(i)));
+            }
+        }
+        return builder.buildFuture();
+    }
+
+    public static void suggestText(SuggestionsBuilder builder, String value, String tooltip) {
+        if (value == null || value.isBlank()) return;
+        if (value.toLowerCase(Locale.ROOT).startsWith(builder.getRemainingLowerCase())) {
+            builder.suggest(value, Component.literal(tooltip));
+        }
+    }
+}

--- a/src/client/java/dev/ethan/waypointer/commands/WaypointerCommands.java
+++ b/src/client/java/dev/ethan/waypointer/commands/WaypointerCommands.java
@@ -111,8 +111,11 @@ public final class WaypointerCommands {
                         .executes(ctx -> runAdd(ctx.getSource(), ""))
                         .then(literal("at")
                                 .then(argument("x", IntegerArgumentType.integer())
+                                        .suggests(suggestPlayerCoord(Axis.X))
                                         .then(argument("y", IntegerArgumentType.integer())
+                                                .suggests(suggestPlayerCoord(Axis.Y))
                                                 .then(argument("z", IntegerArgumentType.integer())
+                                                        .suggests(suggestPlayerCoord(Axis.Z))
                                                         .executes(ctx -> runAddAt(ctx.getSource(),
                                                                 IntegerArgumentType.getInteger(ctx, "x"),
                                                                 IntegerArgumentType.getInteger(ctx, "y"),
@@ -135,8 +138,11 @@ public final class WaypointerCommands {
                 .then(literal("addtemp")
                         .then(literal("at")
                                 .then(argument("x", IntegerArgumentType.integer())
+                                        .suggests(suggestPlayerCoord(Axis.X))
                                         .then(argument("y", IntegerArgumentType.integer())
+                                                .suggests(suggestPlayerCoord(Axis.Y))
                                                 .then(argument("z", IntegerArgumentType.integer())
+                                                        .suggests(suggestPlayerCoord(Axis.Z))
                                                         .executes(ctx -> runAddTempAt(ctx.getSource(),
                                                                 IntegerArgumentType.getInteger(ctx, "x"),
                                                                 IntegerArgumentType.getInteger(ctx, "y"),
@@ -170,10 +176,12 @@ public final class WaypointerCommands {
                 .then(literal("import")
                         .executes(ctx -> runImportFromClipboard(ctx.getSource()))
                         .then(argument("payload", StringArgumentType.greedyString())
+                                .suggests(suggestImportPayloads())
                                 .executes(ctx -> runImport(ctx.getSource(),
                                         StringArgumentType.getString(ctx, "payload"), "argument"))))
                 .then(literal("importfile")
                         .then(argument("path", StringArgumentType.greedyString())
+                                .suggests(suggestImportFiles())
                                 .executes(ctx -> runImportFile(ctx.getSource(),
                                         StringArgumentType.getString(ctx, "path")))))
                 .then(literal("debug").executes(ctx -> { scheduleOpenDebugInspector(); return 1; }))
@@ -185,6 +193,7 @@ public final class WaypointerCommands {
                 .then(literal("group")
                         .then(literal("create")
                                 .then(argument("name", StringArgumentType.greedyString())
+                                        .suggests(suggestGroupNames())
                                         .executes(ctx -> runCreateGroup(ctx.getSource(),
                                                 StringArgumentType.getString(ctx, "name")))))
                         .then(literal("list").executes(ctx -> runListGroups(ctx.getSource())))
@@ -268,6 +277,53 @@ public final class WaypointerCommands {
         };
     }
 
+    private SuggestionProvider<FabricClientCommandSource> suggestPlayerCoord(Axis axis) {
+        return (ctx, builder) -> {
+            LocalPlayer player = Minecraft.getInstance().player;
+            if (player == null) return builder.buildFuture();
+            int value = switch (axis) {
+                case X -> (int) Math.floor(player.getX());
+                case Y -> (int) Math.floor(player.getY());
+                case Z -> (int) Math.floor(player.getZ());
+            };
+            String raw = Integer.toString(value);
+            if (raw.startsWith(builder.getRemaining())) {
+                builder.suggest(value, Component.literal("current player " + axis.name().toLowerCase(Locale.ROOT)));
+            }
+            return builder.buildFuture();
+        };
+    }
+
+    private SuggestionProvider<FabricClientCommandSource> suggestImportPayloads() {
+        return (ctx, builder) -> {
+            for (String handle : chatImportCache.handles()) {
+                suggestText(builder, handle, "cached chat import; or use /wp importchat " + handle);
+            }
+            return builder.buildFuture();
+        };
+    }
+
+    private SuggestionProvider<FabricClientCommandSource> suggestImportFiles() {
+        return (ctx, builder) -> {
+            suggestText(builder, storage.file().toString(), "current waypoint storage file");
+            Path parent = storage.file().getParent();
+            if (parent != null) suggestText(builder, parent.toString(), "waypointer config folder");
+            return builder.buildFuture();
+        };
+    }
+
+    private SuggestionProvider<FabricClientCommandSource> suggestGroupNames() {
+        return (ctx, builder) -> {
+            Zone zone = manager.currentZone();
+            if (zone != null) {
+                suggestText(builder, "Route -- " + zone.displayName().toLowerCase(Locale.ROOT),
+                        "default route name for current zone");
+            }
+            suggestText(builder, "Route", "generic route name");
+            return builder.buildFuture();
+        };
+    }
+
     /**
      * Shared helper: emit integer suggestions 0..count-1 that match the prefix
      * the user has typed so far, each annotated with a tooltip produced by
@@ -287,10 +343,19 @@ public final class WaypointerCommands {
         return builder.buildFuture();
     }
 
+    private static void suggestText(SuggestionsBuilder builder, String value, String tooltip) {
+        if (value == null || value.isBlank()) return;
+        if (value.toLowerCase(Locale.ROOT).startsWith(builder.getRemainingLowerCase())) {
+            builder.suggest(value, Component.literal(tooltip));
+        }
+    }
+
     private static String describeWaypoint(Waypoint w) {
         String coords = w.x() + ", " + w.y() + ", " + w.z();
         return w.hasName() ? w.name() + "  " + coords : coords;
     }
+
+    private enum Axis { X, Y, Z }
 
     // --- subcommands --------------------------------------------------------------------------
 
@@ -580,10 +645,7 @@ public final class WaypointerCommands {
      *     log off" contract the chat context implies.
      */
     private int runAddTempAt(FabricClientCommandSource src, int x, int y, int z) {
-        WaypointGroup target = manager.getOrCreateTempGroup();
-        Waypoint w = Waypoint.at(x, y, z).withTemp(Waypoint.TEMP_UNTIL_LEAVE, 0L);
-        target.add(w);
-        manager.fireDataChanged();
+        WaypointGroup target = manager.addTempWaypoint(x, y, z);
 
         success(src, "Added temp waypoint to \"" + target.name()
                 + "\" at " + x + ", " + y + ", " + z + " (expires on disconnect)");

--- a/src/client/java/dev/ethan/waypointer/commands/WaypointerCommands.java
+++ b/src/client/java/dev/ethan/waypointer/commands/WaypointerCommands.java
@@ -6,9 +6,9 @@ import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
-import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import dev.ethan.waypointer.Waypointer;
+import dev.ethan.waypointer.commands.CommandSuggestionHelpers;
 import dev.ethan.waypointer.chat.ChatImportCache;
 import dev.ethan.waypointer.codec.WaypointCodec;
 import dev.ethan.waypointer.codec.WaypointImporter;
@@ -43,7 +43,6 @@ import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.CompletableFuture;
 
 import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.argument;
 import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.literal;
@@ -217,7 +216,7 @@ public final class WaypointerCommands {
         return (ctx, builder) -> {
             WaypointGroup g = manager.firstActiveGroup();
             if (g == null) return builder.buildFuture();
-            return suggestIndexed(builder, g.size(), i -> describeWaypoint(g.get(i)));
+            return CommandSuggestionHelpers.suggestIndexed(builder, g.size(), i -> describeWaypoint(g.get(i)));
         };
     }
 
@@ -254,7 +253,7 @@ public final class WaypointerCommands {
     private SuggestionProvider<FabricClientCommandSource> suggestAllGroupIndices() {
         return (ctx, builder) -> {
             List<WaypointGroup> all = manager.allGroupsList();
-            return suggestIndexed(builder, all.size(),
+            return CommandSuggestionHelpers.suggestIndexed(builder, all.size(),
                     i -> all.get(i).name() + " (" + all.get(i).size() + " pts)");
         };
     }
@@ -297,7 +296,7 @@ public final class WaypointerCommands {
     private SuggestionProvider<FabricClientCommandSource> suggestImportPayloads() {
         return (ctx, builder) -> {
             for (String handle : chatImportCache.handles()) {
-                suggestText(builder, handle, "cached chat import; or use /wp importchat " + handle);
+                CommandSuggestionHelpers.suggestText(builder, handle, "cached chat import; or use /wp importchat " + handle);
             }
             return builder.buildFuture();
         };
@@ -305,9 +304,12 @@ public final class WaypointerCommands {
 
     private SuggestionProvider<FabricClientCommandSource> suggestImportFiles() {
         return (ctx, builder) -> {
-            suggestText(builder, storage.file().toString(), "current waypoint storage file");
+            CommandSuggestionHelpers.suggestText(builder, storage.file().toString(),
+                    "current waypoint storage file");
             Path parent = storage.file().getParent();
-            if (parent != null) suggestText(builder, parent.toString(), "waypointer config folder");
+            if (parent != null) {
+                CommandSuggestionHelpers.suggestText(builder, parent.toString(), "waypointer config folder");
+            }
             return builder.buildFuture();
         };
     }
@@ -316,38 +318,12 @@ public final class WaypointerCommands {
         return (ctx, builder) -> {
             Zone zone = manager.currentZone();
             if (zone != null) {
-                suggestText(builder, "Route -- " + zone.displayName().toLowerCase(Locale.ROOT),
+                CommandSuggestionHelpers.suggestText(builder, "Route -- " + zone.displayName().toLowerCase(Locale.ROOT),
                         "default route name for current zone");
             }
-            suggestText(builder, "Route", "generic route name");
+            CommandSuggestionHelpers.suggestText(builder, "Route", "generic route name");
             return builder.buildFuture();
         };
-    }
-
-    /**
-     * Shared helper: emit integer suggestions 0..count-1 that match the prefix
-     * the user has typed so far, each annotated with a tooltip produced by
-     * {@code tooltipFor}. Brigadier only re-sorts numerically when the raw
-     * suggestion is parseable as an int, so we pass the number as a string
-     * and let the framework handle the ordering.
-     */
-    private static CompletableFuture<Suggestions> suggestIndexed(
-            SuggestionsBuilder builder, int count,
-            java.util.function.IntFunction<String> tooltipFor) {
-        String prefix = builder.getRemaining();
-        for (int i = 0; i < count; i++) {
-            String s = Integer.toString(i);
-            if (!s.startsWith(prefix)) continue;
-            builder.suggest(i, Component.literal(tooltipFor.apply(i)));
-        }
-        return builder.buildFuture();
-    }
-
-    private static void suggestText(SuggestionsBuilder builder, String value, String tooltip) {
-        if (value == null || value.isBlank()) return;
-        if (value.toLowerCase(Locale.ROOT).startsWith(builder.getRemainingLowerCase())) {
-            builder.suggest(value, Component.literal(tooltip));
-        }
     }
 
     private static String describeWaypoint(Waypoint w) {

--- a/src/client/java/dev/ethan/waypointer/dungeon/DungeonCommands.java
+++ b/src/client/java/dev/ethan/waypointer/dungeon/DungeonCommands.java
@@ -393,15 +393,16 @@ public final class DungeonCommands {
             error(src, "No demo data registered for shape " + room.shape() + ".");
             return 0;
         }
+        String id = room.hasRoomId() && DungeonRoomData.isCustomDefinition(room.roomId())
+                ? room.roomId()
+                : "test-" + Math.abs(room.identityKey().hashCode());
+        if (!room.hasRoomId() || !DungeonRoomData.isCustomDefinition(room.roomId())) {
+            DungeonRoomDefinition def = DungeonRoomData.defineRoom(id, room.displayName(), room);
+            tracker.applyCurrentRoomDefinition(def.id(), def.displayName());
+            room = tracker.currentRoom();
+            id = def.id();
+        }
         for (DungeonWaypoint wp : demo) {
-            String id = room.hasRoomId() && DungeonRoomData.isCustomDefinition(room.roomId())
-                    ? room.roomId()
-                    : "test-" + Math.abs(room.identityKey().hashCode());
-            if (!room.hasRoomId() || !DungeonRoomData.isCustomDefinition(room.roomId())) {
-                DungeonRoomDefinition def = DungeonRoomData.defineRoom(id, room.displayName(), room);
-                tracker.applyCurrentRoomDefinition(def.id(), def.displayName());
-                room = tracker.currentRoom();
-            }
             DungeonRoomData.addWaypoint(id, wp);
         }
         success(src, "Added " + demo.size() + " demo waypoint(s) for shape "

--- a/src/client/java/dev/ethan/waypointer/dungeon/DungeonCommands.java
+++ b/src/client/java/dev/ethan/waypointer/dungeon/DungeonCommands.java
@@ -1,15 +1,31 @@
 package dev.ethan.waypointer.dungeon;
 
 import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import dev.ethan.waypointer.Waypointer;
 import dev.ethan.waypointer.dungeon.config.DungeonConfig;
+import dev.ethan.waypointer.dungeon.data.DungeonRoomDefinition;
+import dev.ethan.waypointer.dungeon.data.DungeonRoomFingerprint;
 import dev.ethan.waypointer.dungeon.data.DungeonRoomData;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
+
+import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.argument;
 import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.literal;
 
 /**
@@ -43,10 +59,13 @@ public final class DungeonCommands {
 
     private final DungeonStateTracker tracker;
     private final DungeonConfig config;
+    private final DungeonRouteSession session;
 
-    public DungeonCommands(DungeonStateTracker tracker, DungeonConfig config) {
+    public DungeonCommands(DungeonStateTracker tracker, DungeonConfig config,
+                           DungeonRouteSession session) {
         this.tracker = tracker;
         this.config = config;
+        this.session = session;
     }
 
     public void install() {
@@ -62,6 +81,123 @@ public final class DungeonCommands {
                 .then(literal("info").executes(ctx -> runInfo(ctx.getSource())))
                 .then(literal("test").executes(ctx -> runTest(ctx.getSource())))
                 .then(literal("reset").executes(ctx -> runReset(ctx.getSource())))
+                .then(literal("room")
+                        .then(literal("create")
+                                .then(argument("id", StringArgumentType.word())
+                                        .suggests(suggestRoomIds())
+                                        .executes(ctx -> runRoomCreate(ctx.getSource(),
+                                                StringArgumentType.getString(ctx, "id"), ""))
+                                        .then(argument("name", StringArgumentType.greedyString())
+                                                .suggests(suggestCurrentRoomNames())
+                                                .executes(ctx -> runRoomCreate(ctx.getSource(),
+                                                        StringArgumentType.getString(ctx, "id"),
+                                                        StringArgumentType.getString(ctx, "name"))))))
+                        .then(literal("rename")
+                                .then(argument("name", StringArgumentType.greedyString())
+                                        .suggests(suggestCurrentRoomNames())
+                                        .executes(ctx -> runRoomRename(ctx.getSource(),
+                                                StringArgumentType.getString(ctx, "name")))))
+                        .then(literal("fingerprint")
+                                .then(literal("add").executes(ctx -> runFingerprintAdd(ctx.getSource()))))
+                        .then(literal("list").executes(ctx -> runRoomList(ctx.getSource()))))
+                .then(literal("waypoint")
+                        .then(literal("list").executes(ctx -> runWaypointList(ctx.getSource())))
+                        .then(literal("add")
+                                .then(argument("category", StringArgumentType.word())
+                                        .suggests(suggestCategories())
+                                        .executes(ctx -> runWaypointAdd(ctx.getSource(),
+                                                StringArgumentType.getString(ctx, "category"), ""))
+                                        .then(argument("name", StringArgumentType.greedyString())
+                                                .suggests(suggestWaypointNames())
+                                                .executes(ctx -> runWaypointAdd(ctx.getSource(),
+                                                        StringArgumentType.getString(ctx, "category"),
+                                                        StringArgumentType.getString(ctx, "name"))))))
+                        .then(literal("remove")
+                                .then(argument("index", IntegerArgumentType.integer(0))
+                                        .suggests(suggestWaypointIndices())
+                                        .executes(ctx -> runWaypointRemove(ctx.getSource(),
+                                                IntegerArgumentType.getInteger(ctx, "index")))))
+                        .then(literal("move")
+                                .then(argument("index", IntegerArgumentType.integer(0))
+                                        .suggests(suggestWaypointIndices())
+                                        .executes(ctx -> runWaypointMove(ctx.getSource(),
+                                                IntegerArgumentType.getInteger(ctx, "index")))))
+                        .then(literal("trigger")
+                                .then(argument("index", IntegerArgumentType.integer(0))
+                                        .suggests(suggestWaypointIndices())
+                                        .then(literal("manual").executes(ctx -> runWaypointTrigger(ctx.getSource(),
+                                                IntegerArgumentType.getInteger(ctx, "index"),
+                                                DungeonWaypointTrigger.MANUAL)))
+                                        .then(literal("interact").executes(ctx -> runWaypointTrigger(ctx.getSource(),
+                                                IntegerArgumentType.getInteger(ctx, "index"),
+                                                DungeonWaypointTrigger.INTERACT_BLOCK)))
+                                        .then(literal("chest").executes(ctx -> runWaypointTrigger(ctx.getSource(),
+                                                IntegerArgumentType.getInteger(ctx, "index"),
+                                                DungeonWaypointTrigger.OPEN_CHEST)))
+                                        .then(literal("lever").executes(ctx -> runWaypointTrigger(ctx.getSource(),
+                                                IntegerArgumentType.getInteger(ctx, "index"),
+                                                DungeonWaypointTrigger.FLIP_LEVER)))
+                                        .then(literal("superboom").executes(ctx -> runWaypointTrigger(ctx.getSource(),
+                                                IntegerArgumentType.getInteger(ctx, "index"),
+                                                DungeonWaypointTrigger.USE_SUPERBOOM)))
+                                        .then(literal("pickup").executes(ctx -> runWaypointTrigger(ctx.getSource(),
+                                                IntegerArgumentType.getInteger(ctx, "index"),
+                                                DungeonWaypointTrigger.PICKUP_ITEM)))
+                                        .then(literal("bat").executes(ctx -> runWaypointTrigger(ctx.getSource(),
+                                                IntegerArgumentType.getInteger(ctx, "index"),
+                                                DungeonWaypointTrigger.KILL_BAT)))
+                                        .then(literal("break").executes(ctx -> runWaypointTrigger(ctx.getSource(),
+                                                IntegerArgumentType.getInteger(ctx, "index"),
+                                                DungeonWaypointTrigger.BREAK_BLOCKS)))
+                                        .then(literal("dungeonbreaker").executes(ctx -> runWaypointTrigger(ctx.getSource(),
+                                                IntegerArgumentType.getInteger(ctx, "index"),
+                                                DungeonWaypointTrigger.DUNGEONBREAKER)))
+                                        .then(literal("chat").executes(ctx -> runWaypointTrigger(ctx.getSource(),
+                                                IntegerArgumentType.getInteger(ctx, "index"),
+                                                DungeonWaypointTrigger.CHAT_MESSAGE))))))
+                .then(literal("highlight")
+                        .then(literal("list")
+                                .then(argument("waypoint", IntegerArgumentType.integer(0))
+                                        .suggests(suggestWaypointIndices())
+                                        .executes(ctx -> runHighlightList(ctx.getSource(),
+                                                IntegerArgumentType.getInteger(ctx, "waypoint")))))
+                        .then(literal("add")
+                                .then(argument("waypoint", IntegerArgumentType.integer(0))
+                                        .suggests(suggestWaypointIndices())
+                                        .executes(ctx -> runHighlightAdd(ctx.getSource(),
+                                                IntegerArgumentType.getInteger(ctx, "waypoint"),
+                                                DungeonHighlightStyle.OUTLINE))
+                                        .then(literal("outline").executes(ctx -> runHighlightAdd(ctx.getSource(),
+                                                IntegerArgumentType.getInteger(ctx, "waypoint"),
+                                                DungeonHighlightStyle.OUTLINE)))
+                                        .then(literal("filled").executes(ctx -> runHighlightAdd(ctx.getSource(),
+                                                IntegerArgumentType.getInteger(ctx, "waypoint"),
+                                                DungeonHighlightStyle.FILLED)))
+                                        .then(literal("both").executes(ctx -> runHighlightAdd(ctx.getSource(),
+                                                IntegerArgumentType.getInteger(ctx, "waypoint"),
+                                                DungeonHighlightStyle.OUTLINE_FILLED)))))
+                        .then(literal("remove")
+                                .then(argument("waypoint", IntegerArgumentType.integer(0))
+                                        .suggests(suggestWaypointIndices())
+                                        .then(argument("highlight", IntegerArgumentType.integer(0))
+                                                .suggests(suggestHighlightIndices())
+                                                .executes(ctx -> runHighlightRemove(ctx.getSource(),
+                                                        IntegerArgumentType.getInteger(ctx, "waypoint"),
+                                                        IntegerArgumentType.getInteger(ctx, "highlight")))))))
+                .then(literal("breakbox")
+                        .then(literal("add")
+                                .then(argument("waypoint", IntegerArgumentType.integer(0))
+                                        .suggests(suggestWaypointIndices())
+                                        .executes(ctx -> runBreakBoxAdd(ctx.getSource(),
+                                                IntegerArgumentType.getInteger(ctx, "waypoint"))))))
+                .then(literal("route")
+                        .then(literal("next").executes(ctx -> runRouteNext(ctx.getSource())))
+                        .then(literal("reset").executes(ctx -> runRouteReset(ctx.getSource())))
+                        .then(literal("found")
+                                .then(argument("secretIndex", IntegerArgumentType.integer(1))
+                                        .suggests(suggestSecretIndices())
+                                        .executes(ctx -> runRouteFound(ctx.getSource(),
+                                                IntegerArgumentType.getInteger(ctx, "secretIndex"))))))
                 .then(literal("rotate")
                         .then(literal("nw").executes(ctx -> runRotate(ctx.getSource(), Direction.NW)))
                         .then(literal("ne").executes(ctx -> runRotate(ctx.getSource(), Direction.NE)))
@@ -71,9 +207,153 @@ public final class DungeonCommands {
                         .then(literal("enabled").executes(ctx -> runToggle(ctx.getSource(), "enabled")))
                         .then(literal("waypoints").executes(ctx -> runToggle(ctx.getSource(), "waypoints")))
                         .then(literal("highlights").executes(ctx -> runToggle(ctx.getSource(), "highlights")))
+                        .then(literal("found").executes(ctx -> runToggle(ctx.getSource(), "found")))
+                        .then(literal("mode").executes(ctx -> runToggle(ctx.getSource(), "mode")))
                         .then(literal("bounds").executes(ctx -> runToggle(ctx.getSource(), "bounds")))
                         .then(literal("debug").executes(ctx -> runToggle(ctx.getSource(), "debug"))));
         d.register(cmd);
+    }
+
+    // ---- tab-complete suggestion providers -------------------------------
+
+    private SuggestionProvider<FabricClientCommandSource> suggestRoomIds() {
+        return (ctx, builder) -> {
+            DungeonRoom room = tracker.currentRoom();
+            if (room != null) {
+                String generated = room.hasRoomId()
+                        ? room.roomId()
+                        : "room-" + Math.abs(room.identityKey().hashCode());
+                suggestText(builder, generated, "current detected room");
+            }
+            for (DungeonRoomDefinition definition : DungeonRoomData.customDefinitions()) {
+                suggestText(builder, definition.id(), definition.displayName());
+            }
+            return builder.buildFuture();
+        };
+    }
+
+    private SuggestionProvider<FabricClientCommandSource> suggestCategories() {
+        return (ctx, builder) -> {
+            for (DungeonSecretCategory category : DungeonSecretCategory.values()) {
+                suggestText(builder, category.id, "secret category");
+            }
+            return builder.buildFuture();
+        };
+    }
+
+    private SuggestionProvider<FabricClientCommandSource> suggestCurrentRoomNames() {
+        return (ctx, builder) -> {
+            DungeonRoom room = tracker.currentRoom();
+            if (room != null) suggestText(builder, room.displayName(), "current room display name");
+            return builder.buildFuture();
+        };
+    }
+
+    private SuggestionProvider<FabricClientCommandSource> suggestWaypointNames() {
+        return (ctx, builder) -> {
+            String categoryId;
+            try {
+                categoryId = StringArgumentType.getString(ctx, "category");
+            } catch (IllegalArgumentException ignored) {
+                categoryId = "secret";
+            }
+            DungeonSecretCategory category = DungeonSecretCategory.fromId(categoryId);
+            suggestText(builder, category.id + " secret", "category-based name");
+            if (category == DungeonSecretCategory.SUPERBOOM) {
+                suggestText(builder, "Superboom wall", "common superboom marker");
+            } else if (category == DungeonSecretCategory.DUNGEONBREAKER) {
+                suggestText(builder, "Break tunnel", "common dungeonbreaker marker");
+            } else if (category == DungeonSecretCategory.LEVER) {
+                suggestText(builder, "Lever", "common lever marker");
+            } else if (category == DungeonSecretCategory.CHEST) {
+                suggestText(builder, "Chest", "common chest marker");
+            }
+            return builder.buildFuture();
+        };
+    }
+
+    private SuggestionProvider<FabricClientCommandSource> suggestWaypointIndices() {
+        return (ctx, builder) -> {
+            DungeonRoomDefinition definition = currentDefinition();
+            if (definition == null) return builder.buildFuture();
+            return suggestIndexed(builder, definition.waypoints().size(),
+                    i -> describeWaypoint(definition.waypoints().get(i)));
+        };
+    }
+
+    private SuggestionProvider<FabricClientCommandSource> suggestHighlightIndices() {
+        return (ctx, builder) -> {
+            DungeonRoomDefinition definition = currentDefinition();
+            if (definition == null) return builder.buildFuture();
+            int waypointIndex;
+            try {
+                waypointIndex = IntegerArgumentType.getInteger(ctx, "waypoint");
+            } catch (IllegalArgumentException ignored) {
+                return builder.buildFuture();
+            }
+            if (waypointIndex < 0 || waypointIndex >= definition.waypoints().size()) {
+                return builder.buildFuture();
+            }
+            List<DungeonHighlight> highlights = definition.waypoints().get(waypointIndex).highlights();
+            return suggestIndexed(builder, highlights.size(),
+                    i -> describeHighlight(highlights.get(i)));
+        };
+    }
+
+    private SuggestionProvider<FabricClientCommandSource> suggestSecretIndices() {
+        return (ctx, builder) -> {
+            DungeonRoomDefinition definition = currentDefinition();
+            if (definition == null) return builder.buildFuture();
+            String prefix = builder.getRemaining();
+            java.util.Set<Integer> seen = new java.util.TreeSet<>();
+            for (DungeonWaypoint waypoint : definition.waypoints()) {
+                if (!seen.add(waypoint.secretIndex())) continue;
+                String value = Integer.toString(waypoint.secretIndex());
+                if (value.startsWith(prefix)) {
+                    builder.suggest(waypoint.secretIndex(),
+                            Component.literal("secret #" + waypoint.secretIndex()));
+                }
+            }
+            return builder.buildFuture();
+        };
+    }
+
+    private DungeonRoomDefinition currentDefinition() {
+        DungeonRoom room = tracker.currentRoom();
+        if (room == null || !room.hasRoomId()) return null;
+        return DungeonRoomData.definition(room.roomId());
+    }
+
+    private static CompletableFuture<Suggestions> suggestIndexed(
+            SuggestionsBuilder builder, int count,
+            java.util.function.IntFunction<String> tooltipFor) {
+        String prefix = builder.getRemaining();
+        for (int i = 0; i < count; i++) {
+            String value = Integer.toString(i);
+            if (value.startsWith(prefix)) {
+                builder.suggest(i, Component.literal(tooltipFor.apply(i)));
+            }
+        }
+        return builder.buildFuture();
+    }
+
+    private static void suggestText(SuggestionsBuilder builder, String value, String tooltip) {
+        if (value == null || value.isBlank()) return;
+        if (value.toLowerCase(Locale.ROOT).startsWith(builder.getRemainingLowerCase())) {
+            builder.suggest(value, Component.literal(tooltip));
+        }
+    }
+
+    private static String describeWaypoint(DungeonWaypoint waypoint) {
+        String name = waypoint.hasName() ? waypoint.name() + " " : "";
+        return name + "#" + waypoint.secretIndex() + " "
+                + waypoint.category().id + " "
+                + waypoint.trigger().name().toLowerCase(Locale.ROOT);
+    }
+
+    private static String describeHighlight(DungeonHighlight highlight) {
+        return highlight.style() + " "
+                + highlight.x() + ", " + highlight.y() + ", " + highlight.z();
     }
 
     // ---- subcommands -------------------------------------------------------
@@ -88,8 +368,10 @@ public final class DungeonCommands {
             info(src, "In Catacombs, but no room detected (between rooms? map not yet anchored).");
             return 1;
         }
-        info(src, "Dungeon room: " + room.type() + " " + room.shape()
+        info(src, "Dungeon room: " + room.displayName()
+                + " (" + room.type() + " " + room.shape() + ")"
                 + " dir=" + room.direction()
+                + (room.hasRoomId() ? " id=" + room.roomId() : " id=<unmatched>")
                 + " corner=(" + room.physicalCornerX() + ", " + room.physicalCornerZ() + ")"
                 + " segments=" + room.segments().size());
         return 1;
@@ -112,10 +394,264 @@ public final class DungeonCommands {
             return 0;
         }
         for (DungeonWaypoint wp : demo) {
-            DungeonRoomData.addCustom(room.identityKey(), wp);
+            String id = room.hasRoomId() && DungeonRoomData.isCustomDefinition(room.roomId())
+                    ? room.roomId()
+                    : "test-" + Math.abs(room.identityKey().hashCode());
+            if (!room.hasRoomId() || !DungeonRoomData.isCustomDefinition(room.roomId())) {
+                DungeonRoomDefinition def = DungeonRoomData.defineRoom(id, room.displayName(), room);
+                tracker.applyCurrentRoomDefinition(def.id(), def.displayName());
+                room = tracker.currentRoom();
+            }
+            DungeonRoomData.addWaypoint(id, wp);
         }
         success(src, "Added " + demo.size() + " demo waypoint(s) for shape "
                 + room.shape() + " in current room.");
+        return 1;
+    }
+
+    private int runRoomCreate(FabricClientCommandSource src, String id, String name) {
+        DungeonRoom room = requireRoom(src);
+        if (room == null) return 0;
+        DungeonRoomDefinition definition = DungeonRoomData.defineRoom(id,
+                name == null || name.isBlank() ? room.displayName() : name, room);
+        tracker.applyCurrentRoomDefinition(definition.id(), definition.displayName());
+        success(src, "Dungeon room definition \"" + definition.displayName()
+                + "\" created as " + definition.id());
+        return 1;
+    }
+
+    private int runRoomRename(FabricClientCommandSource src, String name) {
+        DungeonRoom room = requireAuthoredRoom(src);
+        if (room == null) return 0;
+        DungeonRoomDefinition definition = DungeonRoomData.renameRoom(room.roomId(), name);
+        tracker.applyCurrentRoomDefinition(definition.id(), definition.displayName());
+        success(src, "Renamed room to \"" + definition.displayName() + "\".");
+        return 1;
+    }
+
+    private int runFingerprintAdd(FabricClientCommandSource src) {
+        DungeonRoom room = requireAuthoredRoom(src);
+        LocalPlayer player = Minecraft.getInstance().player;
+        if (room == null || player == null) {
+            if (player == null) error(src, "Not in a world.");
+            return 0;
+        }
+        int wx = (int) Math.floor(player.getX());
+        int wy = (int) Math.floor(player.getY());
+        int wz = (int) Math.floor(player.getZ());
+        int[] relative = DungeonMapMath.actualToRelative(
+                room.direction(), room.physicalCornerX(), room.physicalCornerZ(), wx, wy, wz);
+        String blockId = BuiltInRegistries.BLOCK
+                .getKey(player.level().getBlockState(new BlockPos(wx, wy, wz)).getBlock())
+                .toString();
+        DungeonRoomData.addFingerprint(room.roomId(),
+                new DungeonRoomFingerprint(relative[0], relative[1], relative[2], blockId));
+        success(src, "Added fingerprint " + blockId + " at relative "
+                + relative[0] + ", " + relative[1] + ", " + relative[2]);
+        return 1;
+    }
+
+    private int runRoomList(FabricClientCommandSource src) {
+        int count = 0;
+        for (DungeonRoomDefinition definition : DungeonRoomData.customDefinitions()) {
+            info(src, definition.id() + " -- " + definition.displayName()
+                    + " (" + definition.type() + " " + definition.shape()
+                    + ", " + definition.waypoints().size() + " waypoint(s), "
+                    + definition.fingerprints().size() + " fingerprint(s))");
+            count++;
+        }
+        if (count == 0) info(src, "No custom dungeon room definitions yet.");
+        return count;
+    }
+
+    private int runWaypointList(FabricClientCommandSource src) {
+        DungeonRoomDefinition definition = requireDefinition(src);
+        if (definition == null) return 0;
+        List<DungeonWaypoint> waypoints = definition.waypoints();
+        if (waypoints.isEmpty()) {
+            info(src, "No secret waypoints in " + definition.displayName() + ".");
+            return 0;
+        }
+        for (int i = 0; i < waypoints.size(); i++) {
+            DungeonWaypoint waypoint = waypoints.get(i);
+            info(src, "[" + i + "] #" + waypoint.secretIndex() + " "
+                    + waypoint.category().id + " " + waypoint.x() + ", "
+                    + waypoint.y() + ", " + waypoint.z()
+                    + " trigger=" + waypoint.trigger().name().toLowerCase(java.util.Locale.ROOT)
+                    + (waypoint.hasName() ? " -- " + waypoint.name() : "")
+                    + " (" + waypoint.highlights().size() + " highlight(s))");
+        }
+        return waypoints.size();
+    }
+
+    private int runWaypointAdd(FabricClientCommandSource src, String categoryId, String name) {
+        DungeonRoom room = requireAuthoredRoom(src);
+        LocalPlayer player = Minecraft.getInstance().player;
+        if (room == null || player == null) {
+            if (player == null) error(src, "Not in a world.");
+            return 0;
+        }
+        DungeonRoomDefinition definition = DungeonRoomData.definition(room.roomId());
+        int[] relative = DungeonMapMath.actualToRelative(
+                room.direction(), room.physicalCornerX(), room.physicalCornerZ(),
+                (int) Math.floor(player.getX()),
+                (int) Math.floor(player.getY()),
+                (int) Math.floor(player.getZ()));
+        int secretIndex = nextSecretIndex(definition.waypoints());
+        DungeonSecretCategory category = DungeonSecretCategory.fromId(categoryId);
+        DungeonWaypoint waypoint = new DungeonWaypoint(
+                room.roomId() + ":" + secretIndex,
+                secretIndex,
+                category,
+                DungeonWaypoint.defaultTrigger(category),
+                relative[0], relative[1], relative[2],
+                name,
+                List.of());
+        DungeonRoomData.addWaypoint(room.roomId(), waypoint);
+        session.resetRoom(room);
+        success(src, "Added secret #" + secretIndex + " to " + room.displayName()
+                + " at relative " + relative[0] + ", " + relative[1] + ", " + relative[2]);
+        return 1;
+    }
+
+    private int runWaypointRemove(FabricClientCommandSource src, int index) {
+        DungeonRoom room = requireAuthoredRoom(src);
+        DungeonRoomDefinition definition = room == null ? null : DungeonRoomData.definition(room.roomId());
+        if (definition == null) return 0;
+        if (index >= definition.waypoints().size()) {
+            error(src, "Waypoint index out of range (0.." + (definition.waypoints().size() - 1) + ").");
+            return 0;
+        }
+        DungeonRoomData.removeWaypoint(room.roomId(), index);
+        session.resetRoom(room);
+        success(src, "Removed dungeon waypoint [" + index + "].");
+        return 1;
+    }
+
+    private int runWaypointMove(FabricClientCommandSource src, int index) {
+        DungeonRoom room = requireAuthoredRoom(src);
+        LocalPlayer player = Minecraft.getInstance().player;
+        DungeonRoomDefinition definition = room == null ? null : DungeonRoomData.definition(room.roomId());
+        if (room == null || definition == null || player == null) {
+            if (player == null) error(src, "Not in a world.");
+            return 0;
+        }
+        if (index >= definition.waypoints().size()) {
+            error(src, "Waypoint index out of range.");
+            return 0;
+        }
+        int[] relative = DungeonMapMath.actualToRelative(
+                room.direction(), room.physicalCornerX(), room.physicalCornerZ(),
+                (int) Math.floor(player.getX()),
+                (int) Math.floor(player.getY()),
+                (int) Math.floor(player.getZ()));
+        DungeonRoomData.moveWaypoint(room.roomId(), index, relative[0], relative[1], relative[2]);
+        session.resetRoom(room);
+        success(src, "Moved waypoint [" + index + "] to relative "
+                + relative[0] + ", " + relative[1] + ", " + relative[2]);
+        return 1;
+    }
+
+    private int runWaypointTrigger(FabricClientCommandSource src, int index,
+                                   DungeonWaypointTrigger trigger) {
+        DungeonRoom room = requireAuthoredRoom(src);
+        DungeonRoomDefinition definition = room == null ? null : DungeonRoomData.definition(room.roomId());
+        if (room == null || definition == null) return 0;
+        if (index >= definition.waypoints().size()) {
+            error(src, "Waypoint index out of range.");
+            return 0;
+        }
+        DungeonRoomData.setWaypointTrigger(room.roomId(), index, trigger);
+        session.resetRoom(room);
+        success(src, "Waypoint [" + index + "] trigger -> "
+                + trigger.name().toLowerCase(java.util.Locale.ROOT));
+        return 1;
+    }
+
+    private int runHighlightList(FabricClientCommandSource src, int waypointIndex) {
+        DungeonWaypoint waypoint = waypointAt(src, waypointIndex);
+        if (waypoint == null) return 0;
+        for (int i = 0; i < waypoint.highlights().size(); i++) {
+            DungeonHighlight highlight = waypoint.highlights().get(i);
+            info(src, "[" + i + "] " + highlight.style() + " "
+                    + highlight.x() + ", " + highlight.y() + ", " + highlight.z());
+        }
+        if (waypoint.highlights().isEmpty()) info(src, "No highlights on this waypoint.");
+        return waypoint.highlights().size();
+    }
+
+    private int runHighlightAdd(FabricClientCommandSource src, int waypointIndex,
+                                DungeonHighlightStyle style) {
+        DungeonRoom room = requireAuthoredRoom(src);
+        LocalPlayer player = Minecraft.getInstance().player;
+        if (room == null || player == null) {
+            if (player == null) error(src, "Not in a world.");
+            return 0;
+        }
+        DungeonRoomDefinition definition = DungeonRoomData.definition(room.roomId());
+        if (definition == null || waypointIndex >= definition.waypoints().size()) {
+            error(src, "Waypoint index out of range.");
+            return 0;
+        }
+        int[] relative = DungeonMapMath.actualToRelative(
+                room.direction(), room.physicalCornerX(), room.physicalCornerZ(),
+                (int) Math.floor(player.getX()),
+                (int) Math.floor(player.getY()),
+                (int) Math.floor(player.getZ()));
+        DungeonRoomData.addHighlight(room.roomId(), waypointIndex,
+                new DungeonHighlight(relative[0], relative[1], relative[2],
+                        style, DungeonHighlight.INHERIT_COLOR));
+        success(src, "Added " + style + " highlight to waypoint [" + waypointIndex + "].");
+        return 1;
+    }
+
+    private int runBreakBoxAdd(FabricClientCommandSource src, int waypointIndex) {
+        DungeonRoom room = requireAuthoredRoom(src);
+        int result = runHighlightAdd(src, waypointIndex, DungeonHighlightStyle.OUTLINE_FILLED);
+        if (result == 1 && room != null) {
+            DungeonRoomData.setWaypointTrigger(room.roomId(), waypointIndex,
+                    DungeonWaypointTrigger.DUNGEONBREAKER);
+            success(src, "Waypoint [" + waypointIndex
+                    + "] now uses dungeonbreaker trigger for its break boxes.");
+        }
+        return result;
+    }
+
+    private int runHighlightRemove(FabricClientCommandSource src, int waypointIndex,
+                                   int highlightIndex) {
+        DungeonWaypoint waypoint = waypointAt(src, waypointIndex);
+        DungeonRoom room = tracker.currentRoom();
+        if (waypoint == null || room == null) return 0;
+        if (highlightIndex >= waypoint.highlights().size()) {
+            error(src, "Highlight index out of range (0.." + (waypoint.highlights().size() - 1) + ").");
+            return 0;
+        }
+        DungeonRoomData.removeHighlight(room.roomId(), waypointIndex, highlightIndex);
+        success(src, "Removed highlight [" + highlightIndex + "] from waypoint [" + waypointIndex + "].");
+        return 1;
+    }
+
+    private int runRouteNext(FabricClientCommandSource src) {
+        DungeonRoom room = requireRoom(src);
+        if (room == null) return 0;
+        session.advance(room);
+        success(src, "Advanced dungeon route to secret #" + session.currentSecretIndex(room) + ".");
+        return 1;
+    }
+
+    private int runRouteReset(FabricClientCommandSource src) {
+        DungeonRoom room = requireRoom(src);
+        if (room == null) return 0;
+        session.resetRoom(room);
+        success(src, "Reset route progress for " + room.displayName() + ".");
+        return 1;
+    }
+
+    private int runRouteFound(FabricClientCommandSource src, int secretIndex) {
+        DungeonRoom room = requireRoom(src);
+        if (room == null) return 0;
+        session.markFound(room, secretIndex);
+        success(src, "Marked secret #" + secretIndex + " found.");
         return 1;
     }
 
@@ -154,6 +690,16 @@ public final class DungeonCommands {
                 config.setDrawRoomBounds(v);
                 yield v;
             }
+            case "found" -> {
+                boolean v = !config.showFoundSecrets();
+                config.setShowFoundSecrets(v);
+                yield v;
+            }
+            case "mode" -> {
+                boolean active = !"ACTIVE".equalsIgnoreCase(config.routeRenderMode());
+                config.setRouteRenderMode(active ? "ACTIVE" : "ALL");
+                yield active;
+            }
             case "debug" -> {
                 boolean v = !config.debugLogRoomChanges();
                 config.setDebugLogRoomChanges(v);
@@ -164,6 +710,45 @@ public final class DungeonCommands {
         success(src, "Dungeon " + which + " -> " + newValue);
         Waypointer.LOGGER.info("Dungeon toggle: {} -> {}", which, newValue);
         return 1;
+    }
+
+    private DungeonRoom requireRoom(FabricClientCommandSource src) {
+        DungeonRoom room = tracker.currentRoom();
+        if (room == null) error(src, "No room detected. Stand in a Catacombs room and try again.");
+        return room;
+    }
+
+    private DungeonRoom requireAuthoredRoom(FabricClientCommandSource src) {
+        DungeonRoom room = requireRoom(src);
+        if (room == null) return null;
+        if (!room.hasRoomId() || DungeonRoomData.definition(room.roomId()) == null) {
+            error(src, "Create a room definition first with /wpd room create <id> [name].");
+            return null;
+        }
+        return room;
+    }
+
+    private DungeonRoomDefinition requireDefinition(FabricClientCommandSource src) {
+        DungeonRoom room = requireAuthoredRoom(src);
+        return room == null ? null : DungeonRoomData.definition(room.roomId());
+    }
+
+    private DungeonWaypoint waypointAt(FabricClientCommandSource src, int waypointIndex) {
+        DungeonRoomDefinition definition = requireDefinition(src);
+        if (definition == null) return null;
+        if (waypointIndex >= definition.waypoints().size()) {
+            error(src, "Waypoint index out of range (0.." + (definition.waypoints().size() - 1) + ").");
+            return null;
+        }
+        return definition.waypoints().get(waypointIndex);
+    }
+
+    private static int nextSecretIndex(List<DungeonWaypoint> waypoints) {
+        int max = 0;
+        for (DungeonWaypoint waypoint : waypoints) {
+            if (waypoint.secretIndex() > max) max = waypoint.secretIndex();
+        }
+        return max + 1;
     }
 
     // ---- styled feedback (matches WaypointerCommands' palette) -------------

--- a/src/client/java/dev/ethan/waypointer/dungeon/DungeonCommands.java
+++ b/src/client/java/dev/ethan/waypointer/dungeon/DungeonCommands.java
@@ -5,9 +5,9 @@ import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
-import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import dev.ethan.waypointer.Waypointer;
+import dev.ethan.waypointer.commands.CommandSuggestionHelpers;
 import dev.ethan.waypointer.dungeon.config.DungeonConfig;
 import dev.ethan.waypointer.dungeon.data.DungeonRoomDefinition;
 import dev.ethan.waypointer.dungeon.data.DungeonRoomFingerprint;
@@ -23,7 +23,6 @@ import net.minecraft.network.chat.Component;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.CompletableFuture;
 
 import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.argument;
 import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.literal;
@@ -223,10 +222,10 @@ public final class DungeonCommands {
                 String generated = room.hasRoomId()
                         ? room.roomId()
                         : "room-" + Math.abs(room.identityKey().hashCode());
-                suggestText(builder, generated, "current detected room");
+                CommandSuggestionHelpers.suggestText(builder, generated, "current detected room");
             }
             for (DungeonRoomDefinition definition : DungeonRoomData.customDefinitions()) {
-                suggestText(builder, definition.id(), definition.displayName());
+                CommandSuggestionHelpers.suggestText(builder, definition.id(), definition.displayName());
             }
             return builder.buildFuture();
         };
@@ -235,7 +234,7 @@ public final class DungeonCommands {
     private SuggestionProvider<FabricClientCommandSource> suggestCategories() {
         return (ctx, builder) -> {
             for (DungeonSecretCategory category : DungeonSecretCategory.values()) {
-                suggestText(builder, category.id, "secret category");
+                CommandSuggestionHelpers.suggestText(builder, category.id, "secret category");
             }
             return builder.buildFuture();
         };
@@ -244,7 +243,7 @@ public final class DungeonCommands {
     private SuggestionProvider<FabricClientCommandSource> suggestCurrentRoomNames() {
         return (ctx, builder) -> {
             DungeonRoom room = tracker.currentRoom();
-            if (room != null) suggestText(builder, room.displayName(), "current room display name");
+            if (room != null) CommandSuggestionHelpers.suggestText(builder, room.displayName(), "current room display name");
             return builder.buildFuture();
         };
     }
@@ -258,15 +257,15 @@ public final class DungeonCommands {
                 categoryId = "secret";
             }
             DungeonSecretCategory category = DungeonSecretCategory.fromId(categoryId);
-            suggestText(builder, category.id + " secret", "category-based name");
+            CommandSuggestionHelpers.suggestText(builder, category.id + " secret", "category-based name");
             if (category == DungeonSecretCategory.SUPERBOOM) {
-                suggestText(builder, "Superboom wall", "common superboom marker");
+                CommandSuggestionHelpers.suggestText(builder, "Superboom wall", "common superboom marker");
             } else if (category == DungeonSecretCategory.DUNGEONBREAKER) {
-                suggestText(builder, "Break tunnel", "common dungeonbreaker marker");
+                CommandSuggestionHelpers.suggestText(builder, "Break tunnel", "common dungeonbreaker marker");
             } else if (category == DungeonSecretCategory.LEVER) {
-                suggestText(builder, "Lever", "common lever marker");
+                CommandSuggestionHelpers.suggestText(builder, "Lever", "common lever marker");
             } else if (category == DungeonSecretCategory.CHEST) {
-                suggestText(builder, "Chest", "common chest marker");
+                CommandSuggestionHelpers.suggestText(builder, "Chest", "common chest marker");
             }
             return builder.buildFuture();
         };
@@ -276,7 +275,7 @@ public final class DungeonCommands {
         return (ctx, builder) -> {
             DungeonRoomDefinition definition = currentDefinition();
             if (definition == null) return builder.buildFuture();
-            return suggestIndexed(builder, definition.waypoints().size(),
+            return CommandSuggestionHelpers.suggestIndexed(builder, definition.waypoints().size(),
                     i -> describeWaypoint(definition.waypoints().get(i)));
         };
     }
@@ -295,7 +294,7 @@ public final class DungeonCommands {
                 return builder.buildFuture();
             }
             List<DungeonHighlight> highlights = definition.waypoints().get(waypointIndex).highlights();
-            return suggestIndexed(builder, highlights.size(),
+            return CommandSuggestionHelpers.suggestIndexed(builder, highlights.size(),
                     i -> describeHighlight(highlights.get(i)));
         };
     }
@@ -322,26 +321,6 @@ public final class DungeonCommands {
         DungeonRoom room = tracker.currentRoom();
         if (room == null || !room.hasRoomId()) return null;
         return DungeonRoomData.definition(room.roomId());
-    }
-
-    private static CompletableFuture<Suggestions> suggestIndexed(
-            SuggestionsBuilder builder, int count,
-            java.util.function.IntFunction<String> tooltipFor) {
-        String prefix = builder.getRemaining();
-        for (int i = 0; i < count; i++) {
-            String value = Integer.toString(i);
-            if (value.startsWith(prefix)) {
-                builder.suggest(i, Component.literal(tooltipFor.apply(i)));
-            }
-        }
-        return builder.buildFuture();
-    }
-
-    private static void suggestText(SuggestionsBuilder builder, String value, String tooltip) {
-        if (value == null || value.isBlank()) return;
-        if (value.toLowerCase(Locale.ROOT).startsWith(builder.getRemainingLowerCase())) {
-            builder.suggest(value, Component.literal(tooltip));
-        }
     }
 
     private static String describeWaypoint(DungeonWaypoint waypoint) {
@@ -607,13 +586,15 @@ public final class DungeonCommands {
     }
 
     private int runBreakBoxAdd(FabricClientCommandSource src, int waypointIndex) {
-        DungeonRoom room = requireAuthoredRoom(src);
         int result = runHighlightAdd(src, waypointIndex, DungeonHighlightStyle.OUTLINE_FILLED);
-        if (result == 1 && room != null) {
-            DungeonRoomData.setWaypointTrigger(room.roomId(), waypointIndex,
-                    DungeonWaypointTrigger.DUNGEONBREAKER);
-            success(src, "Waypoint [" + waypointIndex
-                    + "] now uses dungeonbreaker trigger for its break boxes.");
+        if (result == 1) {
+            DungeonRoom room = tracker.currentRoom();
+            if (room != null && room.hasRoomId()) {
+                DungeonRoomData.setWaypointTrigger(room.roomId(), waypointIndex,
+                        DungeonWaypointTrigger.DUNGEONBREAKER);
+                success(src, "Waypoint [" + waypointIndex
+                        + "] now uses dungeonbreaker trigger for its break boxes.");
+            }
         }
         return result;
     }

--- a/src/client/java/dev/ethan/waypointer/dungeon/DungeonHighlightRenderer.java
+++ b/src/client/java/dev/ethan/waypointer/dungeon/DungeonHighlightRenderer.java
@@ -5,13 +5,12 @@ import com.mojang.blaze3d.vertex.VertexConsumer;
 import dev.ethan.waypointer.Waypointer;
 import dev.ethan.waypointer.dungeon.config.DungeonConfig;
 import dev.ethan.waypointer.dungeon.data.DungeonRoomData;
+import dev.ethan.waypointer.render.RenderEventCompat;
 import dev.ethan.waypointer.render.RenderHelpers;
 import dev.ethan.waypointer.render.WaypointerRenderPipelines;
 import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElement;
 import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElementRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.hud.VanillaHudElements;
-import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderContext;
-import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderEvents;
 import net.minecraft.client.Camera;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.Minecraft;
@@ -34,7 +33,7 @@ import java.util.List;
  * <p>Two render paths, mirroring {@code WaypointRenderer}:
  *
  * <ul>
- *   <li>3D outlines / fills via {@link WorldRenderEvents#END_MAIN}.</li>
+ *   <li>3D outlines / fills via Fabric's end-main world render event.</li>
  *   <li>2D labels via {@link HudElementRegistry} so they always face the
  *       camera and stay legible against any biome backdrop.</li>
  * </ul>
@@ -53,6 +52,8 @@ public final class DungeonHighlightRenderer implements HudElement {
 
     private static final float PARENT_ALPHA = 1.0f;
     private static final float CHILD_ALPHA = 0.85f;
+    private static final float FOUND_ALPHA = 0.25f;
+    private static final float UPCOMING_ALPHA = 0.55f;
     private static final float FILLED_ALPHA_SCALE = 0.30f;
 
     /** How high above a parent waypoint cube the 2D label anchors. Same lift as the main renderer. */
@@ -66,14 +67,17 @@ public final class DungeonHighlightRenderer implements HudElement {
 
     private final DungeonStateTracker tracker;
     private final DungeonConfig config;
+    private final DungeonRouteSession session;
 
-    public DungeonHighlightRenderer(DungeonStateTracker tracker, DungeonConfig config) {
+    public DungeonHighlightRenderer(DungeonStateTracker tracker, DungeonConfig config,
+                                    DungeonRouteSession session) {
         this.tracker = tracker;
         this.config = config;
+        this.session = session;
     }
 
     public void install() {
-        WorldRenderEvents.END_MAIN.register(this::onWorldRender);
+        RenderEventCompat.registerEndMain("dungeon highlights", this::onWorldRender);
         // Attach BEFORE the chat layer so the F1 hide-GUI toggle hides the
         // labels in the same way the main renderer does -- consistent UX
         // for the player.
@@ -82,7 +86,7 @@ public final class DungeonHighlightRenderer implements HudElement {
 
     // ---- world-space outlines + fills ---------------------------------
 
-    private void onWorldRender(WorldRenderContext ctx) {
+    private void onWorldRender(Object ctx) {
         if (!config.enabled()) return;
         DungeonRoom room = tracker.currentRoom();
         if (room == null) return;
@@ -90,10 +94,11 @@ public final class DungeonHighlightRenderer implements HudElement {
         List<DungeonWaypoint> waypoints = DungeonRoomData.waypointsFor(room);
         if (waypoints.isEmpty() && !config.drawRoomBounds()) return;
 
-        MultiBufferSource buffers = ctx.consumers();
+        MultiBufferSource buffers = RenderEventCompat.bufferSource(ctx);
         if (buffers == null) return;
 
-        PoseStack ps = ctx.matrices();
+        PoseStack ps = RenderEventCompat.poseStack(ctx);
+        if (ps == null) return;
         Vec3 cam = Minecraft.getInstance().gameRenderer.getMainCamera().position();
 
         ps.pushPose();
@@ -117,11 +122,14 @@ public final class DungeonHighlightRenderer implements HudElement {
         VertexConsumer quads = buffers.getBuffer(type);
         boolean any = false;
         for (DungeonWaypoint wp : waypoints) {
+            if (!shouldRender(wp, room)) continue;
+            float parentAlpha = parentAlpha(wp, room);
+            float childAlpha = parentAlpha == FOUND_ALPHA ? FOUND_ALPHA : CHILD_ALPHA;
             if (config.showSecretWaypoints()) {
                 int[] world = DungeonMapMath.relativeToActual(
                         room.direction(), room.physicalCornerX(), room.physicalCornerZ(),
                         wp.x(), wp.y(), wp.z());
-                emitFill(quads, ps, world[0], world[1], world[2], wp.color(), PARENT_ALPHA);
+                emitFill(quads, ps, world[0], world[1], world[2], wp.color(), parentAlpha);
                 any = true;
             }
             if (config.showHighlights()) {
@@ -131,7 +139,7 @@ public final class DungeonHighlightRenderer implements HudElement {
                             room.direction(), room.physicalCornerX(), room.physicalCornerZ(),
                             h.x(), h.y(), h.z());
                     int color = h.hasOwnColor() ? h.color() : wp.color();
-                    emitFill(quads, ps, world[0], world[1], world[2], color, CHILD_ALPHA);
+                    emitFill(quads, ps, world[0], world[1], world[2], color, childAlpha);
                     any = true;
                 }
             }
@@ -149,11 +157,14 @@ public final class DungeonHighlightRenderer implements HudElement {
             any = true;
         }
         for (DungeonWaypoint wp : waypoints) {
+            if (!shouldRender(wp, room)) continue;
+            float parentAlpha = parentAlpha(wp, room);
+            float childAlpha = parentAlpha == FOUND_ALPHA ? FOUND_ALPHA : CHILD_ALPHA;
             if (config.showSecretWaypoints()) {
                 int[] world = DungeonMapMath.relativeToActual(
                         room.direction(), room.physicalCornerX(), room.physicalCornerZ(),
                         wp.x(), wp.y(), wp.z());
-                emitOutline(lines, ps, world[0], world[1], world[2], wp.color(), PARENT_ALPHA);
+                emitOutline(lines, ps, world[0], world[1], world[2], wp.color(), parentAlpha);
                 any = true;
             }
             if (config.showHighlights()) {
@@ -163,7 +174,7 @@ public final class DungeonHighlightRenderer implements HudElement {
                             room.direction(), room.physicalCornerX(), room.physicalCornerZ(),
                             h.x(), h.y(), h.z());
                     int color = h.hasOwnColor() ? h.color() : wp.color();
-                    emitOutline(lines, ps, world[0], world[1], world[2], color, CHILD_ALPHA);
+                    emitOutline(lines, ps, world[0], world[1], world[2], color, childAlpha);
                     any = true;
                 }
             }
@@ -214,7 +225,11 @@ public final class DungeonHighlightRenderer implements HudElement {
         int sh = g.guiHeight();
 
         for (DungeonWaypoint wp : waypoints) {
+            if (!shouldRender(wp, room)) continue;
             String name = wp.hasName() ? wp.name() : wp.category().id;
+            if (session.status(room, wp) == DungeonRouteSession.Status.CURRENT) {
+                name = "Next: " + name;
+            }
             int[] world = DungeonMapMath.relativeToActual(
                     room.direction(), room.physicalCornerX(), room.physicalCornerZ(),
                     wp.x(), wp.y(), wp.z());
@@ -232,6 +247,21 @@ public final class DungeonHighlightRenderer implements HudElement {
             int sy = (int) Math.round((0.5 - ndc.y * 0.5) * sh);
             drawCenteredLabel(g, font, name, sx, sy);
         }
+    }
+
+    private boolean shouldRender(DungeonWaypoint waypoint, DungeonRoom room) {
+        DungeonRouteSession.Status status = session.status(room, waypoint);
+        if (status == DungeonRouteSession.Status.FOUND && !config.showFoundSecrets()) return false;
+        return !"ACTIVE".equalsIgnoreCase(config.routeRenderMode())
+                || status == DungeonRouteSession.Status.CURRENT;
+    }
+
+    private float parentAlpha(DungeonWaypoint waypoint, DungeonRoom room) {
+        return switch (session.status(room, waypoint)) {
+            case FOUND -> FOUND_ALPHA;
+            case CURRENT -> PARENT_ALPHA;
+            case UPCOMING -> UPCOMING_ALPHA;
+        };
     }
 
     private void drawCenteredLabel(GuiGraphics g, Font font, String text, int cx, int top) {

--- a/src/client/java/dev/ethan/waypointer/dungeon/DungeonStateTracker.java
+++ b/src/client/java/dev/ethan/waypointer/dungeon/DungeonStateTracker.java
@@ -4,10 +4,13 @@ import dev.ethan.waypointer.Waypointer;
 import dev.ethan.waypointer.core.ActiveGroupManager;
 import dev.ethan.waypointer.core.Zone;
 import dev.ethan.waypointer.dungeon.config.DungeonConfig;
+import dev.ethan.waypointer.dungeon.data.DungeonRoomData;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.Entity;
@@ -107,6 +110,14 @@ public final class DungeonStateTracker {
     public DungeonRoom currentRoom()       { return currentRoom; }
     public Direction directionOverride()   { return directionOverride; }
 
+    public void applyCurrentRoomDefinition(String id, String name) {
+        DungeonRoom prev = currentRoom;
+        if (prev == null) return;
+        DungeonRoom updated = prev.withDefinition(id, name);
+        currentRoom = updated;
+        fireRoomChanged(updated);
+    }
+
     /** Cycle the active room's assumed direction. Resets to config default when null. */
     public void setDirectionOverride(Direction dir) {
         this.directionOverride = dir;
@@ -119,7 +130,9 @@ public final class DungeonStateTracker {
                     dir == null ? defaultDirection() : dir,
                     prev.physicalCornerX(),
                     prev.physicalCornerZ(),
-                    prev.segments());
+                    prev.segments(),
+                    prev.roomId(),
+                    prev.roomName());
             currentRoom = rotated;
             fireRoomChanged(rotated);
         }
@@ -128,7 +141,9 @@ public final class DungeonStateTracker {
     // ---- zone -> dungeon state -----------------------------------------
 
     private void onZoneChanged(Zone zone) {
-        boolean nowDungeon = zone != null && zone.id() != null && zone.id().startsWith("dungeon_");
+        boolean nowDungeon = zone != null
+                && zone.id() != null
+                && (zone.id().equals("dungeon") || zone.id().startsWith("dungeon_"));
         if (nowDungeon == inDungeon) return;
         inDungeon = nowDungeon;
         // Reset every cached anchor so a re-entry picks them up fresh -- the
@@ -185,7 +200,7 @@ public final class DungeonStateTracker {
         // Flood-fill segments to find the room's full footprint, then build
         // the immutable DungeonRoom record.
         List<int[]> mapSegments = DungeonMapMath.floodSegments(map, mapPixel[0], mapPixel[1], mapRoomSize, color);
-        DungeonRoom built = buildRoom(type, mapSegments);
+        DungeonRoom built = buildRoom(type, mapSegments, level);
         if (built == null) return;
 
         DungeonRoom prev = currentRoom;
@@ -195,7 +210,7 @@ public final class DungeonStateTracker {
         }
     }
 
-    private DungeonRoom buildRoom(DungeonRoomType type, List<int[]> mapSegments) {
+    private DungeonRoom buildRoom(DungeonRoomType type, List<int[]> mapSegments, ClientLevel level) {
         if (mapSegments.isEmpty()) return null;
 
         // Convert each map-pixel segment to its physical NW corner so shape
@@ -225,7 +240,10 @@ public final class DungeonStateTracker {
 
         Direction dir = directionOverride != null ? directionOverride : defaultDirection();
         int[] corner = DungeonMapMath.physicalCorner(dir, minSegX, minSegZ, maxSegX, maxSegZ);
-        return new DungeonRoom(type, shape, dir, corner[0], corner[1], packed);
+        DungeonRoom room = new DungeonRoom(type, shape, dir, corner[0], corner[1], packed);
+        return DungeonRoomData.withMatchedDefinition(room, (x, y, z) ->
+                BuiltInRegistries.BLOCK.getKey(level.getBlockState(new BlockPos(x, y, z)).getBlock())
+                        .toString());
     }
 
     // ---- anchors -------------------------------------------------------

--- a/src/client/java/dev/ethan/waypointer/dungeon/DungeonTriggerDetector.java
+++ b/src/client/java/dev/ethan/waypointer/dungeon/DungeonTriggerDetector.java
@@ -1,0 +1,229 @@
+package dev.ethan.waypointer.dungeon;
+
+import dev.ethan.waypointer.Waypointer;
+import dev.ethan.waypointer.dungeon.data.DungeonRoomData;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
+import net.fabricmc.fabric.api.event.player.AttackBlockCallback;
+import net.fabricmc.fabric.api.event.player.UseBlockCallback;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.ambient.AmbientCreature;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Converts normal client-observable dungeon actions into secret progress.
+ *
+ * <p>This deliberately stays client-side and best-effort. It never sends
+ * packets or automates actions; it only watches the player interact with
+ * authored targets and advances the local route when the expected evidence is
+ * visible to the client.
+ */
+public final class DungeonTriggerDetector {
+
+    private static final int SCAN_INTERVAL_TICKS = 4;
+    private static final double ENTITY_TRIGGER_RANGE_SQ = 36.0;
+
+    private final DungeonStateTracker tracker;
+    private final DungeonRouteSession session;
+    private final Set<Integer> nearbyItemIds = new HashSet<>();
+    private final Set<Integer> nearbyBatIds = new HashSet<>();
+
+    private int tickCounter;
+
+    public DungeonTriggerDetector(DungeonStateTracker tracker, DungeonRouteSession session) {
+        this.tracker = tracker;
+        this.session = session;
+    }
+
+    public void install() {
+        UseBlockCallback.EVENT.register((player, world, hand, hit) -> {
+            if (world.isClientSide()) {
+                onUseBlock(hit.getBlockPos(), player.getItemInHand(hand));
+            }
+            return InteractionResult.PASS;
+        });
+        AttackBlockCallback.EVENT.register((player, world, hand, pos, direction) -> {
+            if (world.isClientSide()) onAttackBlock(pos);
+            return InteractionResult.PASS;
+        });
+        ClientReceiveMessageEvents.GAME.register(this::onChatMessage);
+        ClientTickEvents.END_CLIENT_TICK.register(this::onTick);
+    }
+
+    private void onUseBlock(BlockPos pos, ItemStack held) {
+        DungeonRoom room = tracker.currentRoom();
+        if (room == null) return;
+
+        ClientLevel level = Minecraft.getInstance().level;
+        BlockState state = level == null ? null : level.getBlockState(pos);
+        for (DungeonWaypoint waypoint : DungeonRoomData.waypointsFor(room)) {
+            if (!matchesAnyTarget(room, waypoint, pos)) continue;
+            if (useMatchesTrigger(waypoint, held, state)) {
+                session.markFound(room, waypoint.secretIndex());
+            }
+        }
+    }
+
+    private void onAttackBlock(BlockPos pos) {
+        DungeonRoom room = tracker.currentRoom();
+        if (room == null) return;
+        for (DungeonWaypoint waypoint : DungeonRoomData.waypointsFor(room)) {
+            if ((waypoint.trigger() == DungeonWaypointTrigger.BREAK_BLOCKS
+                    || waypoint.trigger() == DungeonWaypointTrigger.DUNGEONBREAKER)
+                    && matchesAnyTarget(room, waypoint, pos)) {
+                session.markFound(room, waypoint.secretIndex());
+            }
+        }
+    }
+
+    private void onChatMessage(Component message, boolean overlay) {
+        DungeonRoom room = tracker.currentRoom();
+        if (room == null) return;
+
+        String text = message.getString().toLowerCase(Locale.ROOT);
+        for (DungeonWaypoint waypoint : DungeonRoomData.waypointsFor(room)) {
+            if (waypoint.trigger() != DungeonWaypointTrigger.CHAT_MESSAGE) continue;
+            String needle = waypoint.hasName() ? waypoint.name() : waypoint.category().id;
+            if (!needle.isBlank() && text.contains(needle.toLowerCase(Locale.ROOT))) {
+                session.markFound(room, waypoint.secretIndex());
+            }
+        }
+    }
+
+    private void onTick(Minecraft client) {
+        if (++tickCounter < SCAN_INTERVAL_TICKS) return;
+        tickCounter = 0;
+
+        DungeonRoom room = tracker.currentRoom();
+        ClientLevel level = client.level;
+        if (room == null || level == null) {
+            nearbyItemIds.clear();
+            nearbyBatIds.clear();
+            return;
+        }
+
+        checkBreakTargets(level, room);
+        checkEntityDisappearance(level, room);
+    }
+
+    private void checkBreakTargets(ClientLevel level, DungeonRoom room) {
+        for (DungeonWaypoint waypoint : DungeonRoomData.waypointsFor(room)) {
+            if (waypoint.trigger() != DungeonWaypointTrigger.BREAK_BLOCKS
+                    && waypoint.trigger() != DungeonWaypointTrigger.DUNGEONBREAKER
+                    && waypoint.trigger() != DungeonWaypointTrigger.USE_SUPERBOOM) {
+                continue;
+            }
+            List<BlockPos> targets = worldTargets(room, waypoint);
+            if (targets.isEmpty()) continue;
+            boolean allCleared = true;
+            for (BlockPos target : targets) {
+                if (!level.getBlockState(target).isAir()) {
+                    allCleared = false;
+                    break;
+                }
+            }
+            if (allCleared) session.markFound(room, waypoint.secretIndex());
+        }
+    }
+
+    private void checkEntityDisappearance(ClientLevel level, DungeonRoom room) {
+        Set<Integer> itemsNow = new HashSet<>();
+        Set<Integer> batsNow = new HashSet<>();
+        for (Entity entity : level.entitiesForRendering()) {
+            if (entity instanceof ItemEntity && nearAnyEntityTrigger(room, entity, DungeonWaypointTrigger.PICKUP_ITEM)) {
+                itemsNow.add(entity.getId());
+            } else if (entity instanceof AmbientCreature
+                    && nearAnyEntityTrigger(room, entity, DungeonWaypointTrigger.KILL_BAT)) {
+                batsNow.add(entity.getId());
+            }
+        }
+
+        if (!nearbyItemIds.isEmpty() && itemsNow.size() < nearbyItemIds.size()) {
+            markNearestEntityTrigger(room, DungeonWaypointTrigger.PICKUP_ITEM);
+        }
+        if (!nearbyBatIds.isEmpty() && batsNow.size() < nearbyBatIds.size()) {
+            markNearestEntityTrigger(room, DungeonWaypointTrigger.KILL_BAT);
+        }
+        nearbyItemIds.clear();
+        nearbyItemIds.addAll(itemsNow);
+        nearbyBatIds.clear();
+        nearbyBatIds.addAll(batsNow);
+    }
+
+    private boolean useMatchesTrigger(DungeonWaypoint waypoint, ItemStack held, BlockState state) {
+        return switch (waypoint.trigger()) {
+            case INTERACT_BLOCK -> true;
+            case OPEN_CHEST -> state != null && (state.is(Blocks.CHEST) || state.is(Blocks.TRAPPED_CHEST));
+            case FLIP_LEVER -> state != null && state.is(Blocks.LEVER);
+            case USE_SUPERBOOM -> itemNameContains(held, "superboom");
+            default -> false;
+        };
+    }
+
+    private static boolean itemNameContains(ItemStack stack, String needle) {
+        if (stack == null || stack.isEmpty()) return false;
+        return stack.getHoverName().getString().toLowerCase(Locale.ROOT).contains(needle);
+    }
+
+    private static boolean nearAnyEntityTrigger(DungeonRoom room, Entity entity,
+                                                DungeonWaypointTrigger trigger) {
+        for (DungeonWaypoint waypoint : DungeonRoomData.waypointsFor(room)) {
+            if (waypoint.trigger() == trigger && distanceToWaypoint(room, waypoint, entity) <= ENTITY_TRIGGER_RANGE_SQ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void markNearestEntityTrigger(DungeonRoom room, DungeonWaypointTrigger trigger) {
+        for (DungeonWaypoint waypoint : DungeonRoomData.waypointsFor(room)) {
+            if (waypoint.trigger() == trigger) {
+                session.markFound(room, waypoint.secretIndex());
+                return;
+            }
+        }
+    }
+
+    private static double distanceToWaypoint(DungeonRoom room, DungeonWaypoint waypoint, Entity entity) {
+        BlockPos pos = worldPos(room, waypoint.x(), waypoint.y(), waypoint.z());
+        double dx = entity.getX() - (pos.getX() + 0.5);
+        double dy = entity.getY() - (pos.getY() + 0.5);
+        double dz = entity.getZ() - (pos.getZ() + 0.5);
+        return dx * dx + dy * dy + dz * dz;
+    }
+
+    private static boolean matchesAnyTarget(DungeonRoom room, DungeonWaypoint waypoint, BlockPos pos) {
+        for (BlockPos target : worldTargets(room, waypoint)) {
+            if (target.equals(pos)) return true;
+        }
+        return false;
+    }
+
+    private static List<BlockPos> worldTargets(DungeonRoom room, DungeonWaypoint waypoint) {
+        if (!waypoint.highlights().isEmpty()) {
+            return waypoint.highlights().stream()
+                    .map(h -> worldPos(room, h.x(), h.y(), h.z()))
+                    .toList();
+        }
+        return List.of(worldPos(room, waypoint.x(), waypoint.y(), waypoint.z()));
+    }
+
+    private static BlockPos worldPos(DungeonRoom room, int x, int y, int z) {
+        int[] world = DungeonMapMath.relativeToActual(
+                room.direction(), room.physicalCornerX(), room.physicalCornerZ(), x, y, z);
+        return new BlockPos(world[0], world[1], world[2]);
+    }
+}

--- a/src/client/java/dev/ethan/waypointer/dungeon/DungeonTriggerDetector.java
+++ b/src/client/java/dev/ethan/waypointer/dungeon/DungeonTriggerDetector.java
@@ -17,10 +17,13 @@ import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.Vec3;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -38,8 +41,8 @@ public final class DungeonTriggerDetector {
 
     private final DungeonStateTracker tracker;
     private final DungeonRouteSession session;
-    private final Set<Integer> nearbyItemIds = new HashSet<>();
-    private final Set<Integer> nearbyBatIds = new HashSet<>();
+    private final Map<Integer, Vec3> nearbyItemLastPositions = new HashMap<>();
+    private final Map<Integer, Vec3> nearbyBatLastPositions = new HashMap<>();
 
     private int tickCounter;
 
@@ -110,8 +113,8 @@ public final class DungeonTriggerDetector {
         DungeonRoom room = tracker.currentRoom();
         ClientLevel level = client.level;
         if (room == null || level == null) {
-            nearbyItemIds.clear();
-            nearbyBatIds.clear();
+            nearbyItemLastPositions.clear();
+            nearbyBatLastPositions.clear();
             return;
         }
 
@@ -140,27 +143,33 @@ public final class DungeonTriggerDetector {
     }
 
     private void checkEntityDisappearance(ClientLevel level, DungeonRoom room) {
-        Set<Integer> itemsNow = new HashSet<>();
-        Set<Integer> batsNow = new HashSet<>();
+        Map<Integer, Vec3> itemsNow = new HashMap<>();
+        Map<Integer, Vec3> batsNow = new HashMap<>();
         for (Entity entity : level.entitiesForRendering()) {
             if (entity instanceof ItemEntity && nearAnyEntityTrigger(room, entity, DungeonWaypointTrigger.PICKUP_ITEM)) {
-                itemsNow.add(entity.getId());
+                itemsNow.put(entity.getId(), entity.position());
             } else if (entity instanceof AmbientCreature
                     && nearAnyEntityTrigger(room, entity, DungeonWaypointTrigger.KILL_BAT)) {
-                batsNow.add(entity.getId());
+                batsNow.put(entity.getId(), entity.position());
             }
         }
 
-        if (!nearbyItemIds.isEmpty() && itemsNow.size() < nearbyItemIds.size()) {
-            markNearestEntityTrigger(room, DungeonWaypointTrigger.PICKUP_ITEM);
+        for (Integer id : nearbyItemLastPositions.keySet()) {
+            if (!itemsNow.containsKey(id)) {
+                Vec3 lastPos = nearbyItemLastPositions.get(id);
+                markNearestWaypointForEntityTrigger(room, DungeonWaypointTrigger.PICKUP_ITEM, lastPos);
+            }
         }
-        if (!nearbyBatIds.isEmpty() && batsNow.size() < nearbyBatIds.size()) {
-            markNearestEntityTrigger(room, DungeonWaypointTrigger.KILL_BAT);
+        for (Integer id : nearbyBatLastPositions.keySet()) {
+            if (!batsNow.containsKey(id)) {
+                Vec3 lastPos = nearbyBatLastPositions.get(id);
+                markNearestWaypointForEntityTrigger(room, DungeonWaypointTrigger.KILL_BAT, lastPos);
+            }
         }
-        nearbyItemIds.clear();
-        nearbyItemIds.addAll(itemsNow);
-        nearbyBatIds.clear();
-        nearbyBatIds.addAll(batsNow);
+        nearbyItemLastPositions.clear();
+        nearbyItemLastPositions.putAll(itemsNow);
+        nearbyBatLastPositions.clear();
+        nearbyBatLastPositions.putAll(batsNow);
     }
 
     private boolean useMatchesTrigger(DungeonWaypoint waypoint, ItemStack held, BlockState state) {
@@ -188,20 +197,33 @@ public final class DungeonTriggerDetector {
         return false;
     }
 
-    private void markNearestEntityTrigger(DungeonRoom room, DungeonWaypointTrigger trigger) {
+    private void markNearestWaypointForEntityTrigger(DungeonRoom room, DungeonWaypointTrigger trigger,
+                                                     Vec3 entityPos) {
+        if (entityPos == null) return;
+        DungeonWaypoint best = null;
+        double bestDistSq = Double.MAX_VALUE;
         for (DungeonWaypoint waypoint : DungeonRoomData.waypointsFor(room)) {
-            if (waypoint.trigger() == trigger) {
-                session.markFound(room, waypoint.secretIndex());
-                return;
+            if (waypoint.trigger() != trigger) continue;
+            double distSq = distanceToWaypoint(room, waypoint, entityPos);
+            if (distSq < bestDistSq) {
+                bestDistSq = distSq;
+                best = waypoint;
             }
+        }
+        if (best != null && bestDistSq <= ENTITY_TRIGGER_RANGE_SQ) {
+            session.markFound(room, best.secretIndex());
         }
     }
 
     private static double distanceToWaypoint(DungeonRoom room, DungeonWaypoint waypoint, Entity entity) {
+        return distanceToWaypoint(room, waypoint, entity.position());
+    }
+
+    private static double distanceToWaypoint(DungeonRoom room, DungeonWaypoint waypoint, Vec3 entityPos) {
         BlockPos pos = worldPos(room, waypoint.x(), waypoint.y(), waypoint.z());
-        double dx = entity.getX() - (pos.getX() + 0.5);
-        double dy = entity.getY() - (pos.getY() + 0.5);
-        double dz = entity.getZ() - (pos.getZ() + 0.5);
+        double dx = entityPos.x - (pos.getX() + 0.5);
+        double dy = entityPos.y - (pos.getY() + 0.5);
+        double dz = entityPos.z - (pos.getZ() + 0.5);
         return dx * dx + dy * dy + dz * dz;
     }
 

--- a/src/client/java/dev/ethan/waypointer/render/RenderEventCompat.java
+++ b/src/client/java/dev/ethan/waypointer/render/RenderEventCompat.java
@@ -39,6 +39,19 @@ public final class RenderEventCompat {
                     listenerType.getClassLoader(),
                     new Class<?>[] { listenerType },
                     (proxy, method, args) -> {
+                        if (method.getDeclaringClass() == Object.class) {
+                            return switch (method.getName()) {
+                                case "hashCode" -> System.identityHashCode(proxy);
+                                case "equals" ->
+                                        proxy == (args != null && args.length > 0 ? args[0] : null);
+                                case "toString" ->
+                                        listenerType.getName()
+                                                + "@"
+                                                + Integer.toHexString(
+                                                        System.identityHashCode(proxy));
+                                default -> null;
+                            };
+                        }
                         if (args != null && args.length > 0) callback.accept(args[0]);
                         return null;
                     });

--- a/src/client/java/dev/ethan/waypointer/render/RenderEventCompat.java
+++ b/src/client/java/dev/ethan/waypointer/render/RenderEventCompat.java
@@ -1,0 +1,80 @@
+package dev.ethan.waypointer.render;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import dev.ethan.waypointer.Waypointer;
+import net.minecraft.client.renderer.MultiBufferSource;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.function.Consumer;
+
+/**
+ * Small bridge over Fabric's 1.21.11 -> 26.x world-render event rename.
+ *
+ * <p>Fabric API 26.1 moved {@code WorldRenderEvents} to
+ * {@code LevelRenderEvents} and renamed the context accessors. Keeping this
+ * reflection boundary in one place lets the renderers stay source-compatible
+ * with the 1.21.11 compile classpath while the 26.x official jar can still
+ * register against the newer runtime API.
+ */
+public final class RenderEventCompat {
+
+    private static final String LEVEL_EVENTS =
+            "net.fabricmc.fabric.api.client.rendering.v1.level.LevelRenderEvents";
+    private static final String WORLD_EVENTS =
+            "net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderEvents";
+
+    private RenderEventCompat() {}
+
+    public static void registerEndMain(String owner, Consumer<Object> callback) {
+        try {
+            Class<?> events = findEventsClass();
+            Field field = events.getField("END_MAIN");
+            Object event = field.get(null);
+
+            Method register = event.getClass().getMethod("register", Object.class);
+            Class<?> listenerType = register.getParameterTypes()[0];
+            Object listener = Proxy.newProxyInstance(
+                    listenerType.getClassLoader(),
+                    new Class<?>[] { listenerType },
+                    (proxy, method, args) -> {
+                        if (args != null && args.length > 0) callback.accept(args[0]);
+                        return null;
+                    });
+            register.invoke(event, listener);
+        } catch (Throwable t) {
+            Waypointer.LOGGER.error("Failed to register {} world render callback", owner, t);
+        }
+    }
+
+    public static PoseStack poseStack(Object context) {
+        Object value = invokeFirst(context, "poseStack", "matrices");
+        return value instanceof PoseStack ps ? ps : null;
+    }
+
+    public static MultiBufferSource bufferSource(Object context) {
+        Object value = invokeFirst(context, "bufferSource", "consumers");
+        return value instanceof MultiBufferSource buffers ? buffers : null;
+    }
+
+    private static Class<?> findEventsClass() throws ClassNotFoundException {
+        try {
+            return Class.forName(LEVEL_EVENTS);
+        } catch (ClassNotFoundException ignored) {
+            return Class.forName(WORLD_EVENTS);
+        }
+    }
+
+    private static Object invokeFirst(Object target, String first, String second) {
+        if (target == null) return null;
+        for (String name : new String[] { first, second }) {
+            try {
+                Method method = target.getClass().getMethod(name);
+                return method.invoke(target);
+            } catch (ReflectiveOperationException ignored) {
+            }
+        }
+        return null;
+    }
+}

--- a/src/client/java/dev/ethan/waypointer/render/TracerRenderer.java
+++ b/src/client/java/dev/ethan/waypointer/render/TracerRenderer.java
@@ -6,8 +6,6 @@ import dev.ethan.waypointer.config.WaypointerConfig;
 import dev.ethan.waypointer.core.ActiveGroupManager;
 import dev.ethan.waypointer.core.Waypoint;
 import dev.ethan.waypointer.core.WaypointGroup;
-import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderContext;
-import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderEvents;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
@@ -51,18 +49,19 @@ public final class TracerRenderer {
     }
 
     public void install() {
-        WorldRenderEvents.END_MAIN.register(this::onRender);
+        RenderEventCompat.registerEndMain("tracers", this::onRender);
     }
 
-    private void onRender(WorldRenderContext ctx) {
+    private void onRender(Object ctx) {
         if (!config.showTracer()) return;
         var groups = manager.activeGroups();
         if (groups.isEmpty()) return;
 
-        PoseStack ps = ctx.matrices();
+        PoseStack ps = RenderEventCompat.poseStack(ctx);
+        if (ps == null) return;
         Camera cam = Minecraft.getInstance().gameRenderer.getMainCamera();
         Vec3 camPos = cam.position();
-        MultiBufferSource buffers = ctx.consumers();
+        MultiBufferSource buffers = RenderEventCompat.bufferSource(ctx);
         if (buffers == null) return;
 
         RenderType lineType = WaypointerRenderPipelines.linesThroughWalls();

--- a/src/client/java/dev/ethan/waypointer/render/WaypointRenderer.java
+++ b/src/client/java/dev/ethan/waypointer/render/WaypointRenderer.java
@@ -10,8 +10,6 @@ import dev.ethan.waypointer.core.WaypointGroup;
 import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElement;
 import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElementRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.hud.VanillaHudElements;
-import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderContext;
-import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderEvents;
 import net.minecraft.client.Camera;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.Minecraft;
@@ -117,7 +115,7 @@ public final class WaypointRenderer implements HudElement {
     }
 
     public void install() {
-        WorldRenderEvents.END_MAIN.register(this::onWorldRender);
+        RenderEventCompat.registerEndMain("waypoints", this::onWorldRender);
         // Attaching before CHAT inherits chat's render condition, which means the
         // labels respect the "hide GUI" (F1) toggle the same way chat does. That
         // matches player expectation for any in-world HUD overlay.
@@ -135,11 +133,11 @@ public final class WaypointRenderer implements HudElement {
      */
     private static final float FILLED_ALPHA_SCALE = 0.35f;
 
-    private void onWorldRender(WorldRenderContext ctx) {
+    private void onWorldRender(Object ctx) {
         var groups = manager.activeGroups();
         if (groups.isEmpty()) return;
 
-        MultiBufferSource buffers = ctx.consumers();
+        MultiBufferSource buffers = RenderEventCompat.bufferSource(ctx);
         if (buffers == null) return;
 
         WaypointerConfig.BoxStyle style = config.boxStyle();
@@ -147,7 +145,8 @@ public final class WaypointRenderer implements HudElement {
         boolean drawFill  = style != WaypointerConfig.BoxStyle.OUTLINED;
         if (!drawLines && !drawFill) return;
 
-        PoseStack ps = ctx.matrices();
+        PoseStack ps = RenderEventCompat.poseStack(ctx);
+        if (ps == null) return;
         Vec3 camPos = Minecraft.getInstance().gameRenderer.getMainCamera().position();
 
         ps.pushPose();

--- a/src/client/java/dev/ethan/waypointer/screen/ConfigScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/ConfigScreen.java
@@ -93,8 +93,8 @@ public final class ConfigScreen extends Screen {
         addNumberRow(col1, y, colW, "Label height offset (blocks)",
                 config.labelHeightOffset(), config::setLabelHeightOffset,
                 "Extra blocks to push each waypoint label above its marker. 0 keeps the\n"
-              + "default placement; raise it (e.g. 3-5) so labels stop covering the box\n"
-              + "when viewed from far away. Range -2 to +10.");
+              + "default placement. Use large values if distant labels still cover the\n"
+              + "box; finite numbers only, no arbitrary clamp.");
         y += rowH;
         addBoxStyleRow(col1, y, colW);
 
@@ -110,6 +110,11 @@ public final class ConfigScreen extends Screen {
         addBoolRow(col2, y2, "Chat coord detection", config.chatCoordDetection(), config::setChatCoordDetection,
                 "Scans incoming chat for coordinates and can offer quick-add flows for\n"
               + "temporary or permanent waypoints (no effect when chat has no coords).");
+        y2 += rowH;
+        addBoolRow(col2, y2, "Auto-add chat temp waypoints",
+                config.autoAddChatTempWaypoints(), config::setAutoAddChatTempWaypoints,
+                "When chat coord detection finds a coordinate, immediately creates a\n"
+              + "session-scoped temp waypoint. Turn off to keep click-to-add behavior only.");
         y2 += rowH;
         addBoolRow(col2, y2, "Chat codec detection (imports)",
                 config.chatCodecDetection(), config::setChatCodecDetection,
@@ -267,7 +272,10 @@ public final class ConfigScreen extends Screen {
     }
 
     private static String stripTrailingZeros(double v) {
-        if (v == Math.floor(v)) return Integer.toString((int) v);
+        if (v == Math.floor(v)) {
+            String raw = Double.toString(v);
+            return raw.endsWith(".0") ? raw.substring(0, raw.length() - 2) : raw;
+        }
         return String.format("%.2f", v);
     }
 }

--- a/src/main/java/dev/ethan/waypointer/config/WaypointerConfig.java
+++ b/src/main/java/dev/ethan/waypointer/config/WaypointerConfig.java
@@ -94,13 +94,12 @@ public final class WaypointerConfig {
      * but, by user report, not enough at distance where the label projects
      * directly over the marker. Players can dial this up so the label rides
      * higher and stops obscuring the cube from far away. Default {@code 0}
-     * preserves the historical placement; range {@code [-2, +10]} keeps the
-     * label within the visually plausible neighborhood of the waypoint.
+     * preserves the historical placement.
      *
-     * <p>Static offset only -- a distance-scaled offset would handle far-away
-     * waypoints more elegantly but adds a second knob and a toggle for what
-     * is functionally the same control; revisit if the static offset proves
-     * insufficient in practice.
+     * <p>Intentionally unclamped: users testing long-distance routes need to
+     * push labels much farther than a small "reasonable" range. We only reject
+     * NaN / infinity in the setter so JSON stays valid and the renderer never
+     * receives a non-finite coordinate.
      */
     private double labelHeightOffset = 0.0;
     private BoxStyle boxStyle = BoxStyle.OUTLINED;
@@ -110,6 +109,13 @@ public final class WaypointerConfig {
 
     // Quality-of-life
     private boolean chatCoordDetection = true;
+    /**
+     * When {@code true}, detected chat coordinate callouts immediately create
+     * session-scoped temp waypoints. The chat text remains clickable either way
+     * so users who dislike automatic markers can turn this off and opt in per
+     * message.
+     */
+    private boolean autoAddChatTempWaypoints = true;
     private boolean chatCodecDetection = true;
     /** Default exports drop names; set to {@code true} to include them at the cost of length. */
     private boolean exportIncludeNames = false;
@@ -271,6 +277,7 @@ public final class WaypointerConfig {
     public BoxStyle boxStyle()                { return boxStyle == null ? BoxStyle.OUTLINED : boxStyle; }
     public boolean preferScoreboardFallback() { return preferScoreboardFallback; }
     public boolean chatCoordDetection()       { return chatCoordDetection; }
+    public boolean autoAddChatTempWaypoints() { return autoAddChatTempWaypoints; }
     public boolean chatCodecDetection()       { return chatCodecDetection; }
     public boolean exportIncludeNames()        { return exportIncludeNames; }
     public boolean exportIncludeColors()       { return exportIncludeColors; }
@@ -296,6 +303,7 @@ public final class WaypointerConfig {
     public void setHideTracerOnStaticRoutes(boolean v) { this.hideTracerOnStaticRoutes = v; save(); }
     public void setPreferScoreboardFallback(boolean v) { this.preferScoreboardFallback = v; save(); }
     public void setChatCoordDetection(boolean v)       { this.chatCoordDetection = v; save(); }
+    public void setAutoAddChatTempWaypoints(boolean v) { this.autoAddChatTempWaypoints = v; save(); }
     public void setChatCodecDetection(boolean v)       { this.chatCodecDetection = v; save(); }
     public void setExportIncludeNames(boolean v)        { this.exportIncludeNames = v; save(); }
     public void setExportIncludeColors(boolean v)       { this.exportIncludeColors = v; save(); }
@@ -303,7 +311,11 @@ public final class WaypointerConfig {
     public void setExportIncludeWaypointFlags(boolean v){ this.exportIncludeWaypointFlags = v; save(); }
     public void setExportIncludeGroupMeta(boolean v)    { this.exportIncludeGroupMeta = v; save(); }
     public void setShowLabelBackdrop(boolean v)        { this.showLabelBackdrop = v; save(); }
-    public void setLabelHeightOffset(double v)         { this.labelHeightOffset = clamp(v, -2.0, 10.0); save(); }
+    public void setLabelHeightOffset(double v) {
+        if (!Double.isFinite(v)) return;
+        this.labelHeightOffset = v;
+        save();
+    }
     public void setBoxStyle(BoxStyle v)                { this.boxStyle = v == null ? BoxStyle.OUTLINED : v; save(); }
     public void setSkipAheadMechanicEnabled(boolean v) { this.skipAheadMechanicEnabled = v; save(); }
     public void setDisableGroupSkipAheadOnWaypointAdd(boolean v) { this.disableGroupSkipAheadOnWaypointAdd = v; save(); }

--- a/src/main/java/dev/ethan/waypointer/core/ActiveGroupManager.java
+++ b/src/main/java/dev/ethan/waypointer/core/ActiveGroupManager.java
@@ -172,6 +172,20 @@ public final class ActiveGroupManager {
         return g;
     }
 
+    /**
+     * Add a session-scoped temporary waypoint in the current zone's isolated
+     * temp bucket. Chat coordinate detection and the {@code /wp addtemp}
+     * command share this path so automatic and click-to-add temp markers behave
+     * identically: static rendering, no proximity progression, and cleanup on
+     * disconnect via {@link dev.ethan.waypointer.progression.TempWaypointCleaner}.
+     */
+    public WaypointGroup addTempWaypoint(int x, int y, int z) {
+        WaypointGroup target = getOrCreateTempGroup();
+        target.add(Waypoint.at(x, y, z).withTemp(Waypoint.TEMP_UNTIL_LEAVE, 0L));
+        fireDataChanged();
+        return target;
+    }
+
     public List<WaypointGroup> groupsForZone(String zoneId) {
         List<WaypointGroup> out = new ArrayList<>();
         for (WaypointGroup g : byId.values()) {

--- a/src/main/java/dev/ethan/waypointer/core/Zone.java
+++ b/src/main/java/dev/ethan/waypointer/core/Zone.java
@@ -100,6 +100,18 @@ public record Zone(String id, String displayName) {
         };
     }
 
+    /**
+     * Fallback for Hypixel payloads that only say "dungeon" in both fields
+     * before a floor id is available. Without this, the sanitize fallback
+     * displays the ugly "Dungeon Dungeon" zone the user hit in live testing.
+     * Floor-specific definitions below still win whenever F1/M7/etc. is
+     * present because this matcher requires both populated fields to be the
+     * generic dungeon token.
+     */
+    private static boolean genericDungeon(String map, String mode) {
+        return equalsIC(map, "dungeon") && equalsIC(mode, "dungeon");
+    }
+
     private static Predicate<String> anyDisplay(String... names) {
         return name -> {
             if (name == null) return false;
@@ -222,6 +234,8 @@ public record Zone(String id, String displayName) {
                     prefixTokens("foraging_2", "Galatea"),
                     displayStartsWithAny("Galatea")),
 
+            new Def("dungeon", "Catacombs", Zone::genericDungeon,
+                    anyDisplay("Catacombs", "Dungeon")),
             new Def("dungeon_f1", "Catacombs F1",     dungeonFloor("F1")),
             new Def("dungeon_f2", "Catacombs F2",     dungeonFloor("F2")),
             new Def("dungeon_f3", "Catacombs F3",     dungeonFloor("F3")),

--- a/src/main/java/dev/ethan/waypointer/dungeon/DungeonRoom.java
+++ b/src/main/java/dev/ethan/waypointer/dungeon/DungeonRoom.java
@@ -27,13 +27,22 @@ public record DungeonRoom(
         Direction direction,
         int physicalCornerX,
         int physicalCornerZ,
-        List<Long> segments) {
+        List<Long> segments,
+        String roomId,
+        String roomName) {
 
     public DungeonRoom {
         Objects.requireNonNull(type, "type");
         Objects.requireNonNull(shape, "shape");
         if (direction == null) direction = Direction.NW;
         segments = segments == null ? List.of() : List.copyOf(segments);
+        roomId = roomId == null ? "" : roomId;
+        roomName = roomName == null ? "" : roomName;
+    }
+
+    public DungeonRoom(DungeonRoomType type, DungeonRoomShape shape, Direction direction,
+                       int physicalCornerX, int physicalCornerZ, List<Long> segments) {
+        this(type, shape, direction, physicalCornerX, physicalCornerZ, segments, "", "");
     }
 
     public static long packSegment(int x, int z) {
@@ -52,5 +61,51 @@ public record DungeonRoom(
         return type.name() + ":" + shape.name() + ":" + direction.name()
                 + ":" + physicalCornerX + "," + physicalCornerZ
                 + ":n=" + segments.size();
+    }
+
+    public boolean hasRoomId() {
+        return !roomId.isBlank();
+    }
+
+    public DungeonRoom withDefinition(String id, String name) {
+        return new DungeonRoom(type, shape, direction, physicalCornerX, physicalCornerZ,
+                segments, id, name);
+    }
+
+    /**
+     * Human-readable fallback while named-room fingerprinting is still absent.
+     * This deliberately says "1x2 Room" rather than inventing a named room like
+     * "Lava Ravine"; real names require block-skeleton matching against a
+     * curated room dataset.
+     */
+    public String displayName() {
+        if (!roomName.isBlank()) return roomName;
+        if (type != DungeonRoomType.ROOM) return friendlyType(type);
+        return friendlyShape(shape) + " Room";
+    }
+
+    private static String friendlyType(DungeonRoomType type) {
+        return switch (type) {
+            case ENTRANCE -> "Entrance Room";
+            case ROOM -> "Room";
+            case PUZZLE -> "Puzzle Room";
+            case TRAP -> "Trap Room";
+            case MINIBOSS -> "Miniboss Room";
+            case FAIRY -> "Fairy Room";
+            case BLOOD -> "Blood Room";
+            case UNKNOWN -> "Unknown Room";
+        };
+    }
+
+    private static String friendlyShape(DungeonRoomShape shape) {
+        return switch (shape) {
+            case ONE_BY_ONE -> "1x1";
+            case ONE_BY_TWO -> "1x2";
+            case ONE_BY_THREE -> "1x3";
+            case ONE_BY_FOUR -> "1x4";
+            case TWO_BY_TWO -> "2x2";
+            case L_SHAPE -> "L-shaped";
+            case UNKNOWN -> "Unknown";
+        };
     }
 }

--- a/src/main/java/dev/ethan/waypointer/dungeon/DungeonRouteSession.java
+++ b/src/main/java/dev/ethan/waypointer/dungeon/DungeonRouteSession.java
@@ -1,0 +1,103 @@
+package dev.ethan.waypointer.dungeon;
+
+import dev.ethan.waypointer.dungeon.data.DungeonRoomData;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Per-run progress for dungeon secret routes.
+ *
+ * <p>The catalog is persistent, but found/current state is deliberately not:
+ * Catacombs rooms are regenerated every run and a saved "found" bit from the
+ * previous run would hide useful waypoints in the next one.
+ */
+public final class DungeonRouteSession {
+
+    public enum Status { FOUND, CURRENT, UPCOMING }
+
+    private final Map<String, RoomProgress> progressByRoom = new HashMap<>();
+
+    public void resetAll() {
+        progressByRoom.clear();
+    }
+
+    public void resetRoom(DungeonRoom room) {
+        String key = routeKey(room);
+        if (!key.isEmpty()) progressByRoom.remove(key);
+    }
+
+    public void markFound(DungeonRoom room, int secretIndex) {
+        if (room == null) return;
+        RoomProgress progress = progressFor(room);
+        progress.foundSecretIndices.add(secretIndex);
+        if (secretIndex == progress.currentSecretIndex) {
+            progress.currentSecretIndex = nextUnfoundSecret(room, progress);
+        }
+    }
+
+    public void advance(DungeonRoom room) {
+        if (room == null) return;
+        RoomProgress progress = progressFor(room);
+        progress.foundSecretIndices.add(progress.currentSecretIndex);
+        progress.currentSecretIndex = nextUnfoundSecret(room, progress);
+    }
+
+    public int currentSecretIndex(DungeonRoom room) {
+        return progressFor(room).currentSecretIndex;
+    }
+
+    public Status status(DungeonRoom room, DungeonWaypoint waypoint) {
+        RoomProgress progress = progressFor(room);
+        if (progress.foundSecretIndices.contains(waypoint.secretIndex())) return Status.FOUND;
+        if (waypoint.secretIndex() == progress.currentSecretIndex) return Status.CURRENT;
+        return Status.UPCOMING;
+    }
+
+    private RoomProgress progressFor(DungeonRoom room) {
+        String key = routeKey(room);
+        return progressByRoom.computeIfAbsent(key, ignored -> {
+            RoomProgress progress = new RoomProgress();
+            progress.currentSecretIndex = firstSecretIndex(room);
+            return progress;
+        });
+    }
+
+    private static int firstSecretIndex(DungeonRoom room) {
+        List<DungeonWaypoint> waypoints = DungeonRoomData.waypointsFor(room);
+        int min = Integer.MAX_VALUE;
+        for (DungeonWaypoint waypoint : waypoints) {
+            if (waypoint.secretIndex() > 0 && waypoint.secretIndex() < min) {
+                min = waypoint.secretIndex();
+            }
+        }
+        return min == Integer.MAX_VALUE ? 1 : min;
+    }
+
+    private static int nextUnfoundSecret(DungeonRoom room, RoomProgress progress) {
+        int next = Integer.MAX_VALUE;
+        for (DungeonWaypoint waypoint : DungeonRoomData.waypointsFor(room)) {
+            int index = waypoint.secretIndex();
+            if (index > 0
+                    && index > progress.currentSecretIndex
+                    && !progress.foundSecretIndices.contains(index)
+                    && index < next) {
+                next = index;
+            }
+        }
+        return next == Integer.MAX_VALUE ? progress.currentSecretIndex + 1 : next;
+    }
+
+    private static String routeKey(DungeonRoom room) {
+        if (room == null) return "";
+        return room.hasRoomId() ? room.roomId() : room.identityKey();
+    }
+
+    private static final class RoomProgress {
+        private int currentSecretIndex = 1;
+        private final Set<Integer> foundSecretIndices = new HashSet<>();
+    }
+}

--- a/src/main/java/dev/ethan/waypointer/dungeon/DungeonSecretCategory.java
+++ b/src/main/java/dev/ethan/waypointer/dungeon/DungeonSecretCategory.java
@@ -24,6 +24,7 @@ public enum DungeonSecretCategory {
     LEVER        ("lever",     0xFF8A2E),
     FAIRYSOUL    ("fairysoul", 0xFF61F2),
     STONK        ("stonk",     0x4FE05A),
+    DUNGEONBREAKER("dungeonbreaker", 0x6EE7B7),
     AOTV         ("aotv",      0x9C2EFF),
     PEARL        ("pearl",     0xC0C0FF),
     PRINCE       ("prince",    0xFFC0CB),

--- a/src/main/java/dev/ethan/waypointer/dungeon/DungeonWaypoint.java
+++ b/src/main/java/dev/ethan/waypointer/dungeon/DungeonWaypoint.java
@@ -21,6 +21,7 @@ public record DungeonWaypoint(
         String id,
         int secretIndex,
         DungeonSecretCategory category,
+        DungeonWaypointTrigger trigger,
         int x, int y, int z,
         String name,
         List<DungeonHighlight> highlights) {
@@ -28,8 +29,15 @@ public record DungeonWaypoint(
     public DungeonWaypoint {
         Objects.requireNonNull(id, "id");
         if (category == null) category = DungeonSecretCategory.DEFAULT;
+        if (trigger == null) trigger = defaultTrigger(category);
         name = name == null ? "" : name;
         highlights = highlights == null ? List.of() : List.copyOf(highlights);
+    }
+
+    public DungeonWaypoint(String id, int secretIndex, DungeonSecretCategory category,
+                           int x, int y, int z, String name,
+                           List<DungeonHighlight> highlights) {
+        this(id, secretIndex, category, defaultTrigger(category), x, y, z, name, highlights);
     }
 
     /** Builder helper for waypoints that have no highlights. */
@@ -43,4 +51,29 @@ public record DungeonWaypoint(
     public boolean hasName() { return !name.isEmpty(); }
 
     public int color() { return category.defaultColor; }
+
+    public DungeonWaypoint withTrigger(DungeonWaypointTrigger next) {
+        return new DungeonWaypoint(id, secretIndex, category, next, x, y, z, name, highlights);
+    }
+
+    public DungeonWaypoint withPosition(int nx, int ny, int nz) {
+        return new DungeonWaypoint(id, secretIndex, category, trigger, nx, ny, nz, name, highlights);
+    }
+
+    public DungeonWaypoint withHighlights(List<DungeonHighlight> next) {
+        return new DungeonWaypoint(id, secretIndex, category, trigger, x, y, z, name, next);
+    }
+
+    public static DungeonWaypointTrigger defaultTrigger(DungeonSecretCategory category) {
+        if (category == null) return DungeonWaypointTrigger.MANUAL;
+        return switch (category) {
+            case CHEST, WITHER, REDSTONE_KEY -> DungeonWaypointTrigger.OPEN_CHEST;
+            case LEVER -> DungeonWaypointTrigger.FLIP_LEVER;
+            case ITEM -> DungeonWaypointTrigger.PICKUP_ITEM;
+            case BAT -> DungeonWaypointTrigger.KILL_BAT;
+            case SUPERBOOM -> DungeonWaypointTrigger.USE_SUPERBOOM;
+            case STONK, DUNGEONBREAKER -> DungeonWaypointTrigger.BREAK_BLOCKS;
+            default -> DungeonWaypointTrigger.MANUAL;
+        };
+    }
 }

--- a/src/main/java/dev/ethan/waypointer/dungeon/DungeonWaypointTrigger.java
+++ b/src/main/java/dev/ethan/waypointer/dungeon/DungeonWaypointTrigger.java
@@ -1,0 +1,32 @@
+package dev.ethan.waypointer.dungeon;
+
+import java.util.Locale;
+
+/**
+ * Gameplay condition that marks a dungeon secret waypoint as found.
+ *
+ * <p>Triggers are intentionally data, not subclasses: users can author or
+ * change them per waypoint without Waypointer needing a new Java type for each
+ * room-specific secret variant.
+ */
+public enum DungeonWaypointTrigger {
+    MANUAL,
+    INTERACT_BLOCK,
+    OPEN_CHEST,
+    FLIP_LEVER,
+    USE_SUPERBOOM,
+    PICKUP_ITEM,
+    KILL_BAT,
+    BREAK_BLOCKS,
+    DUNGEONBREAKER,
+    CHAT_MESSAGE;
+
+    public static DungeonWaypointTrigger fromId(String id) {
+        if (id == null || id.isBlank()) return MANUAL;
+        String norm = id.trim().toUpperCase(Locale.ROOT).replace('-', '_');
+        for (DungeonWaypointTrigger trigger : values()) {
+            if (trigger.name().equals(norm)) return trigger;
+        }
+        return MANUAL;
+    }
+}

--- a/src/main/java/dev/ethan/waypointer/dungeon/config/DungeonConfig.java
+++ b/src/main/java/dev/ethan/waypointer/dungeon/config/DungeonConfig.java
@@ -63,6 +63,15 @@ public final class DungeonConfig {
      */
     private boolean drawRoomBounds = false;
 
+    /** When {@code false}, found secrets are hidden instead of rendered dimly. */
+    private boolean showFoundSecrets = true;
+
+    /**
+     * Route rendering mode: ALL shows every secret in the matched room, ACTIVE
+     * shows only the current target plus its highlights.
+     */
+    private String routeRenderMode = "ALL";
+
     /**
      * Default direction to assume for newly-detected rooms. Block-fingerprint
      * matching is not implemented yet (see issue #9 follow-ups), so the
@@ -120,6 +129,8 @@ public final class DungeonConfig {
     public boolean showHighlights()       { return showHighlights; }
     public boolean debugLogRoomChanges()  { return debugLogRoomChanges; }
     public boolean drawRoomBounds()       { return drawRoomBounds; }
+    public boolean showFoundSecrets()     { return showFoundSecrets; }
+    public String  routeRenderMode()      { return routeRenderMode == null ? "ALL" : routeRenderMode; }
     public String  defaultDirection()     { return defaultDirection == null ? "NW" : defaultDirection; }
 
     public void setEnabled(boolean v)             { this.enabled = v; save(); }
@@ -127,6 +138,15 @@ public final class DungeonConfig {
     public void setShowHighlights(boolean v)      { this.showHighlights = v; save(); }
     public void setDebugLogRoomChanges(boolean v) { this.debugLogRoomChanges = v; save(); }
     public void setDrawRoomBounds(boolean v)      { this.drawRoomBounds = v; save(); }
+    public void setShowFoundSecrets(boolean v)    { this.showFoundSecrets = v; save(); }
+    public void setRouteRenderMode(String v) {
+        if (v == null) return;
+        String upper = v.trim().toUpperCase(java.util.Locale.ROOT);
+        if (upper.equals("ALL") || upper.equals("ACTIVE")) {
+            this.routeRenderMode = upper;
+            save();
+        }
+    }
     public void setDefaultDirection(String v) {
         if (v == null) return;
         String upper = v.trim().toUpperCase(java.util.Locale.ROOT);

--- a/src/main/java/dev/ethan/waypointer/dungeon/data/DungeonRoomData.java
+++ b/src/main/java/dev/ethan/waypointer/dungeon/data/DungeonRoomData.java
@@ -1,76 +1,293 @@
 package dev.ethan.waypointer.dungeon.data;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import dev.ethan.waypointer.Waypointer;
+import dev.ethan.waypointer.config.AsyncSaver;
+import dev.ethan.waypointer.dungeon.Direction;
 import dev.ethan.waypointer.dungeon.DungeonHighlight;
+import dev.ethan.waypointer.dungeon.DungeonHighlightStyle;
+import dev.ethan.waypointer.dungeon.DungeonMapMath;
 import dev.ethan.waypointer.dungeon.DungeonRoom;
 import dev.ethan.waypointer.dungeon.DungeonRoomShape;
+import dev.ethan.waypointer.dungeon.DungeonRoomType;
 import dev.ethan.waypointer.dungeon.DungeonSecretCategory;
 import dev.ethan.waypointer.dungeon.DungeonWaypoint;
+import dev.ethan.waypointer.dungeon.DungeonWaypointTrigger;
+import net.fabricmc.loader.api.FabricLoader;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * In-memory store of the dungeon waypoints Waypointer should render in each
- * room.
+ * Catalog of dungeon room definitions and user-authored secret routes.
  *
- * <p>For the issue #9 MVP this is a thin abstraction over a fixed lookup
- * table built in code. It carries a {@link #demoWaypoints()} entry so the end-
- * to-end pipeline (detection -> data lookup -> room-local-to-world transform
- * -> render) can be exercised without any external data file. Real curated
- * data (sourced from Skyblocker's GPL-3.0 secret JSON or the upstream
- * DungeonRoomsMod repo) is deferred until a license-clean ingestion path is
- * decided -- see follow-up issue notes in the PR.
- *
- * <p>The schema is deliberately Skyblocker-compatible: data keys are room
- * "shape", values are lists of waypoints with categorised secrets. Once a
- * data source is wired up (see {@code TODO} below), the loader will populate
- * this table from JSON without callers needing to change.
+ * <p>The bundled catalog is intentionally Waypointer-authored seed/demo data
+ * only. We do not ship Skyblocker/DungeonRoomsMod Catacombs data because their
+ * attribution traces many room skeletons and secret waypoints to GPL-3.0 data,
+ * while this project is PolyForm Noncommercial.
  */
 public final class DungeonRoomData {
 
-    /**
-     * Custom waypoints the user added at runtime via the
-     * {@code /waypointer dungeon mark} client command. Keyed by the
-     * containing {@link DungeonRoom#identityKey()} so they survive a tracker
-     * re-detection of the same room (different physical instance, same
-     * shape + corner) without the user having to redo them.
-     */
-    private static final AtomicReference<Map<String, List<DungeonWaypoint>>> CUSTOM =
-            new AtomicReference<>(Collections.emptyMap());
+    public interface BlockLookup {
+        String blockIdAt(int x, int y, int z);
+    }
 
-    /**
-     * Built-in demo data, used when no curated source is wired up. Maps each
-     * shape to one example waypoint+highlight pair so the renderer has
-     * something to draw when the user types {@code /waypointer dungeon test}.
-     */
+    public static final int SCHEMA_VERSION = 1;
+
+    private static final String CUSTOM_FILE_NAME = "dungeon_rooms.json";
+    private static final String BUNDLED_RESOURCE =
+            "/assets/" + Waypointer.MOD_ID + "/dungeons/catacombs/rooms.json";
+    private static final long SAVE_DEBOUNCE_MS = 400L;
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
+    private static final Map<String, DungeonRoomDefinition> BUNDLED =
+            loadBundledDefinitions();
+    private static final AtomicReference<Map<String, DungeonRoomDefinition>> CUSTOM =
+            new AtomicReference<>(Collections.emptyMap());
     private static final Map<DungeonRoomShape, List<DungeonWaypoint>> DEMO = buildDemo();
+
+    private static Path customFile;
+    private static AsyncSaver saver;
 
     private DungeonRoomData() {}
 
-    /**
-     * Curated waypoints for the given room. MVP returns an empty list -- the
-     * curated dataset is not bundled (Skyblocker's source is GPL-3.0 and the
-     * upstream DungeonRoomsMod data is GPL-3.0 too; bundling either would
-     * relicense Waypointer). Implementers wiring up a JSON loader should
-     * replace this body with a shape-keyed lookup.
-     */
+    public static void loadDefaultCustomStore() {
+        Path dir = FabricLoader.getInstance().getConfigDir().resolve(Waypointer.MOD_ID);
+        loadCustomStore(dir.resolve(CUSTOM_FILE_NAME));
+    }
+
+    public static void loadCustomStore(Path file) {
+        customFile = file;
+        saver = new AsyncSaver("dungeon-rooms", DungeonRoomData::writeCustomStore, SAVE_DEBOUNCE_MS);
+        CUSTOM.set(readDefinitions(file));
+    }
+
+    public static void flush() {
+        if (saver != null) saver.flush();
+    }
+
+    public static Collection<DungeonRoomDefinition> customDefinitions() {
+        return CUSTOM.get().values();
+    }
+
+    public static Collection<DungeonRoomDefinition> allDefinitions() {
+        Map<String, DungeonRoomDefinition> all = new LinkedHashMap<>(BUNDLED);
+        all.putAll(CUSTOM.get());
+        return List.copyOf(all.values());
+    }
+
+    public static DungeonRoomDefinition definition(String id) {
+        String norm = DungeonRoomDefinition.normalizeId(id);
+        DungeonRoomDefinition custom = CUSTOM.get().get(norm);
+        return custom != null ? custom : BUNDLED.get(norm);
+    }
+
+    public static boolean isCustomDefinition(String id) {
+        return CUSTOM.get().containsKey(DungeonRoomDefinition.normalizeId(id));
+    }
+
+    public static DungeonRoom withMatchedDefinition(DungeonRoom room, BlockLookup lookup) {
+        DungeonRoomDefinition definition = match(room, lookup);
+        return definition == null ? room : room.withDefinition(definition.id(), definition.displayName());
+    }
+
+    public static DungeonRoomDefinition match(DungeonRoom room, BlockLookup lookup) {
+        if (room == null) return null;
+        if (room.hasRoomId()) return definition(room.roomId());
+
+        List<DungeonRoomDefinition> customCandidates = matchingDefinitions(room, CUSTOM.get().values());
+        List<DungeonRoomDefinition> candidates = matchingDefinitions(room, allDefinitions());
+        if (candidates.isEmpty()) return null;
+
+        if (lookup != null) {
+            List<DungeonRoomDefinition> fingerprintMatches = new ArrayList<>();
+            for (DungeonRoomDefinition definition : candidates) {
+                if (definition.hasFingerprints() && fingerprintsMatch(room, definition, lookup)) {
+                    fingerprintMatches.add(definition);
+                }
+            }
+            if (fingerprintMatches.size() == 1) return fingerprintMatches.get(0);
+        }
+
+        List<DungeonRoomDefinition> customFallback = withoutFingerprints(customCandidates);
+        if (customFallback.size() == 1) return customFallback.get(0);
+
+        List<DungeonRoomDefinition> fallback = withoutFingerprints(candidates);
+        return fallback.size() == 1 ? fallback.get(0) : null;
+    }
+
+    private static List<DungeonRoomDefinition> matchingDefinitions(
+            DungeonRoom room, Collection<DungeonRoomDefinition> definitions) {
+        List<DungeonRoomDefinition> out = new ArrayList<>();
+        for (DungeonRoomDefinition definition : definitions) {
+            if (definition.type() == room.type() && definition.shape() == room.shape()) {
+                out.add(definition);
+            }
+        }
+        return out;
+    }
+
+    private static List<DungeonRoomDefinition> withoutFingerprints(
+            List<DungeonRoomDefinition> candidates) {
+        List<DungeonRoomDefinition> fallback = new ArrayList<>(candidates.size());
+        for (DungeonRoomDefinition definition : candidates) {
+            if (!definition.hasFingerprints()) fallback.add(definition);
+        }
+        return fallback;
+    }
+
     public static List<DungeonWaypoint> waypointsFor(DungeonRoom room) {
-        if (room == null) return List.of();
-        List<DungeonWaypoint> custom = CUSTOM.get().getOrDefault(room.identityKey(), List.of());
-        if (custom.isEmpty()) return List.of();
-        return custom;
+        DungeonRoomDefinition definition = room == null ? null : definitionForRoom(room);
+        return definition == null ? List.of() : definition.waypoints();
+    }
+
+    public static DungeonRoomDefinition defineRoom(String id, String displayName, DungeonRoom room) {
+        if (room == null) throw new IllegalArgumentException("room is required");
+        DungeonRoomDefinition definition = new DungeonRoomDefinition(
+                id,
+                displayName,
+                room.type(),
+                room.shape(),
+                List.of(),
+                List.of());
+        putCustom(definition);
+        return definition;
+    }
+
+    public static DungeonRoomDefinition renameRoom(String roomId, String displayName) {
+        DungeonRoomDefinition definition = requireCustom(roomId);
+        DungeonRoomDefinition renamed = definition.withDisplayName(displayName);
+        putCustom(renamed);
+        return renamed;
+    }
+
+    public static DungeonRoomDefinition addFingerprint(String roomId, DungeonRoomFingerprint fingerprint) {
+        DungeonRoomDefinition definition = requireCustom(roomId);
+        List<DungeonRoomFingerprint> next = new ArrayList<>(definition.fingerprints());
+        next.add(fingerprint);
+        DungeonRoomDefinition updated = definition.withFingerprints(next);
+        putCustom(updated);
+        return updated;
+    }
+
+    public static DungeonRoomDefinition addWaypoint(String roomId, DungeonWaypoint waypoint) {
+        DungeonRoomDefinition definition = requireCustom(roomId);
+        List<DungeonWaypoint> next = new ArrayList<>(definition.waypoints());
+        next.add(waypoint);
+        DungeonRoomDefinition updated = definition.withWaypoints(next);
+        putCustom(updated);
+        return updated;
+    }
+
+    public static DungeonRoomDefinition removeWaypoint(String roomId, int index) {
+        DungeonRoomDefinition definition = requireCustom(roomId);
+        List<DungeonWaypoint> next = new ArrayList<>(definition.waypoints());
+        next.remove(index);
+        DungeonRoomDefinition updated = definition.withWaypoints(next);
+        putCustom(updated);
+        return updated;
+    }
+
+    public static DungeonRoomDefinition setWaypointTrigger(String roomId, int waypointIndex,
+                                                          DungeonWaypointTrigger trigger) {
+        DungeonRoomDefinition definition = requireCustom(roomId);
+        List<DungeonWaypoint> waypoints = new ArrayList<>(definition.waypoints());
+        waypoints.set(waypointIndex, waypoints.get(waypointIndex).withTrigger(trigger));
+        DungeonRoomDefinition updated = definition.withWaypoints(waypoints);
+        putCustom(updated);
+        return updated;
+    }
+
+    public static DungeonRoomDefinition moveWaypoint(String roomId, int waypointIndex,
+                                                     int x, int y, int z) {
+        DungeonRoomDefinition definition = requireCustom(roomId);
+        List<DungeonWaypoint> waypoints = new ArrayList<>(definition.waypoints());
+        waypoints.set(waypointIndex, waypoints.get(waypointIndex).withPosition(x, y, z));
+        DungeonRoomDefinition updated = definition.withWaypoints(waypoints);
+        putCustom(updated);
+        return updated;
+    }
+
+    public static DungeonRoomDefinition addHighlight(String roomId, int waypointIndex,
+                                                    DungeonHighlight highlight) {
+        DungeonRoomDefinition definition = requireCustom(roomId);
+        List<DungeonWaypoint> waypoints = new ArrayList<>(definition.waypoints());
+        DungeonWaypoint waypoint = waypoints.get(waypointIndex);
+        List<DungeonHighlight> highlights = new ArrayList<>(waypoint.highlights());
+        highlights.add(highlight);
+        waypoints.set(waypointIndex, waypoint.withHighlights(highlights));
+        DungeonRoomDefinition updated = definition.withWaypoints(waypoints);
+        putCustom(updated);
+        return updated;
+    }
+
+    public static DungeonRoomDefinition removeHighlight(String roomId, int waypointIndex,
+                                                       int highlightIndex) {
+        DungeonRoomDefinition definition = requireCustom(roomId);
+        List<DungeonWaypoint> waypoints = new ArrayList<>(definition.waypoints());
+        DungeonWaypoint waypoint = waypoints.get(waypointIndex);
+        List<DungeonHighlight> highlights = new ArrayList<>(waypoint.highlights());
+        highlights.remove(highlightIndex);
+        waypoints.set(waypointIndex, waypoint.withHighlights(highlights));
+        DungeonRoomDefinition updated = definition.withWaypoints(waypoints);
+        putCustom(updated);
+        return updated;
+    }
+
+    public static void clearCustom(String roomId) {
+        String norm = DungeonRoomDefinition.normalizeId(roomId);
+        CUSTOM.updateAndGet(prev -> {
+            if (!prev.containsKey(norm)) return prev;
+            Map<String, DungeonRoomDefinition> next = new LinkedHashMap<>(prev);
+            next.remove(norm);
+            return Map.copyOf(next);
+        });
+        markDirty();
+    }
+
+    public static void clearAllCustom() {
+        CUSTOM.set(Collections.emptyMap());
+        markDirty();
     }
 
     /**
-     * Demo data for the supplied shape. Used by {@code /waypointer dungeon
-     * test} so a player can confirm rendering works in any room without
-     * waiting on curated data being authored.
+     * Compatibility helper for older tests and the `/wpd test` command.
+     * Runtime-only demo entries are converted into a persistent room definition
+     * keyed by {@code roomKey}.
      */
+    public static void addCustom(String roomKey, DungeonWaypoint waypoint) {
+        String id = DungeonRoomDefinition.normalizeId(roomKey);
+        DungeonRoomDefinition existing = CUSTOM.get().get(id);
+        DungeonRoomType type = typeFromIdentityKey(roomKey);
+        DungeonRoomShape shape = shapeFromIdentityKey(roomKey);
+        DungeonRoomDefinition base = existing == null
+                ? new DungeonRoomDefinition(id, roomKey, type, shape, List.of(), List.of())
+                : existing;
+        List<DungeonWaypoint> next = new ArrayList<>(base.waypoints());
+        next.add(waypoint);
+        putCustom(base.withWaypoints(next));
+    }
+
     public static List<DungeonWaypoint> demoFor(DungeonRoomShape shape) {
         return DEMO.getOrDefault(shape, DEMO.get(DungeonRoomShape.ONE_BY_ONE));
     }
@@ -79,37 +296,210 @@ public final class DungeonRoomData {
         return DEMO;
     }
 
-    /** Append a runtime-authored waypoint to the given room's bucket. */
-    public static void addCustom(String roomKey, DungeonWaypoint waypoint) {
-        CUSTOM.updateAndGet(prev -> {
-            Map<String, List<DungeonWaypoint>> next = new java.util.HashMap<>(prev);
-            List<DungeonWaypoint> bucket = new ArrayList<>(next.getOrDefault(roomKey, List.of()));
-            bucket.add(waypoint);
-            next.put(roomKey, List.copyOf(bucket));
-            return Map.copyOf(next);
-        });
+    static Map<String, DungeonRoomDefinition> parseDefinitions(String json) {
+        if (json == null || json.isBlank()) return Collections.emptyMap();
+        JsonObject root = JsonParser.parseString(json).getAsJsonObject();
+        JsonArray rooms = root.has("rooms") ? root.getAsJsonArray("rooms") : new JsonArray();
+        Map<String, DungeonRoomDefinition> out = new LinkedHashMap<>();
+        for (JsonElement element : rooms) {
+            DungeonRoomDefinition definition = definitionFromJson(element.getAsJsonObject());
+            out.put(definition.id(), definition);
+        }
+        return Map.copyOf(out);
     }
 
-    public static void clearCustom(String roomKey) {
-        CUSTOM.updateAndGet(prev -> {
-            if (!prev.containsKey(roomKey)) return prev;
-            Map<String, List<DungeonWaypoint>> next = new java.util.HashMap<>(prev);
-            next.remove(roomKey);
-            return Map.copyOf(next);
-        });
+    static String toJson(Collection<DungeonRoomDefinition> definitions) {
+        JsonObject root = new JsonObject();
+        root.addProperty("schema", SCHEMA_VERSION);
+        JsonArray rooms = new JsonArray();
+        for (DungeonRoomDefinition definition : definitions) {
+            rooms.add(definitionToJson(definition));
+        }
+        root.add("rooms", rooms);
+        return GSON.toJson(root);
     }
 
-    public static void clearAllCustom() {
-        CUSTOM.set(Collections.emptyMap());
+    private static DungeonRoomDefinition definitionForRoom(DungeonRoom room) {
+        if (room.hasRoomId()) return definition(room.roomId());
+        return match(room, null);
+    }
+
+    private static boolean fingerprintsMatch(DungeonRoom room, DungeonRoomDefinition definition,
+                                             BlockLookup lookup) {
+        for (DungeonRoomFingerprint fingerprint : definition.fingerprints()) {
+            int[] world = DungeonMapMath.relativeToActual(
+                    room.direction(), room.physicalCornerX(), room.physicalCornerZ(),
+                    fingerprint.x(), fingerprint.y(), fingerprint.z());
+            String actual = DungeonRoomFingerprint.normalizeBlockId(
+                    lookup.blockIdAt(world[0], world[1], world[2]));
+            if (!fingerprint.blockId().equals(actual)) return false;
+        }
+        return true;
+    }
+
+    private static DungeonRoomDefinition requireCustom(String id) {
+        String norm = DungeonRoomDefinition.normalizeId(id);
+        DungeonRoomDefinition definition = CUSTOM.get().get(norm);
+        if (definition == null) throw new IllegalArgumentException("Unknown custom room: " + id);
+        return definition;
+    }
+
+    private static void putCustom(DungeonRoomDefinition definition) {
+        CUSTOM.updateAndGet(prev -> {
+            Map<String, DungeonRoomDefinition> next = new LinkedHashMap<>(prev);
+            next.put(definition.id(), definition);
+            return Map.copyOf(next);
+        });
+        markDirty();
+    }
+
+    private static void markDirty() {
+        if (saver != null) saver.markDirty();
+    }
+
+    private static void writeCustomStore() {
+        if (customFile == null) return;
+        try {
+            Files.createDirectories(customFile.getParent());
+            Path tmp = customFile.resolveSibling(customFile.getFileName() + ".tmp");
+            Files.writeString(tmp, toJson(CUSTOM.get().values()));
+            Files.move(tmp, customFile, StandardCopyOption.REPLACE_EXISTING,
+                    StandardCopyOption.ATOMIC_MOVE);
+        } catch (IOException e) {
+            Waypointer.LOGGER.error("Failed to save dungeon room data to {}", customFile, e);
+        }
+    }
+
+    private static Map<String, DungeonRoomDefinition> readDefinitions(Path file) {
+        try {
+            if (file == null || !Files.exists(file)) return Collections.emptyMap();
+            return parseDefinitions(Files.readString(file));
+        } catch (Exception e) {
+            Waypointer.LOGGER.error("Failed to load dungeon room data from {}", file, e);
+            return Collections.emptyMap();
+        }
+    }
+
+    private static Map<String, DungeonRoomDefinition> loadBundledDefinitions() {
+        try (InputStream stream = DungeonRoomData.class.getResourceAsStream(BUNDLED_RESOURCE)) {
+            if (stream == null) return Collections.emptyMap();
+            try (InputStreamReader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
+                JsonObject root = JsonParser.parseReader(reader).getAsJsonObject();
+                return parseDefinitions(GSON.toJson(root));
+            }
+        } catch (Exception e) {
+            Waypointer.LOGGER.error("Failed to load bundled dungeon room data", e);
+            return Collections.emptyMap();
+        }
+    }
+
+    private static JsonObject definitionToJson(DungeonRoomDefinition definition) {
+        JsonObject json = new JsonObject();
+        json.addProperty("id", definition.id());
+        json.addProperty("name", definition.displayName());
+        json.addProperty("type", definition.type().name());
+        json.addProperty("shape", definition.shape().name());
+
+        JsonArray fingerprints = new JsonArray();
+        for (DungeonRoomFingerprint fingerprint : definition.fingerprints()) {
+            JsonObject fp = new JsonObject();
+            fp.addProperty("x", fingerprint.x());
+            fp.addProperty("y", fingerprint.y());
+            fp.addProperty("z", fingerprint.z());
+            fp.addProperty("block", fingerprint.blockId());
+            fingerprints.add(fp);
+        }
+        json.add("fingerprints", fingerprints);
+
+        JsonArray waypoints = new JsonArray();
+        for (DungeonWaypoint waypoint : definition.waypoints()) {
+            waypoints.add(waypointToJson(waypoint));
+        }
+        json.add("waypoints", waypoints);
+        return json;
+    }
+
+    private static DungeonRoomDefinition definitionFromJson(JsonObject json) {
+        String id = string(json, "id", "");
+        String name = string(json, "name", id);
+        DungeonRoomType type = parseType(string(json, "type", "ROOM"));
+        DungeonRoomShape shape = parseShape(string(json, "shape", "UNKNOWN"));
+
+        List<DungeonRoomFingerprint> fingerprints = new ArrayList<>();
+        if (json.has("fingerprints")) {
+            for (JsonElement element : json.getAsJsonArray("fingerprints")) {
+                JsonObject fp = element.getAsJsonObject();
+                fingerprints.add(new DungeonRoomFingerprint(
+                        integer(fp, "x", 0),
+                        integer(fp, "y", 70),
+                        integer(fp, "z", 0),
+                        string(fp, "block", "minecraft:air")));
+            }
+        }
+
+        List<DungeonWaypoint> waypoints = new ArrayList<>();
+        if (json.has("waypoints")) {
+            for (JsonElement element : json.getAsJsonArray("waypoints")) {
+                waypoints.add(waypointFromJson(element.getAsJsonObject()));
+            }
+        }
+
+        return new DungeonRoomDefinition(id, name, type, shape, fingerprints, waypoints);
+    }
+
+    private static JsonObject waypointToJson(DungeonWaypoint waypoint) {
+        JsonObject json = new JsonObject();
+        json.addProperty("id", waypoint.id());
+        json.addProperty("secretIndex", waypoint.secretIndex());
+        json.addProperty("category", waypoint.category().id);
+        json.addProperty("trigger", waypoint.trigger().name());
+        json.addProperty("x", waypoint.x());
+        json.addProperty("y", waypoint.y());
+        json.addProperty("z", waypoint.z());
+        if (waypoint.hasName()) json.addProperty("name", waypoint.name());
+
+        JsonArray highlights = new JsonArray();
+        for (DungeonHighlight highlight : waypoint.highlights()) {
+            JsonObject h = new JsonObject();
+            h.addProperty("x", highlight.x());
+            h.addProperty("y", highlight.y());
+            h.addProperty("z", highlight.z());
+            h.addProperty("style", highlight.style().name());
+            if (highlight.hasOwnColor()) h.addProperty("color", highlight.color());
+            highlights.add(h);
+        }
+        json.add("highlights", highlights);
+        return json;
+    }
+
+    private static DungeonWaypoint waypointFromJson(JsonObject json) {
+        List<DungeonHighlight> highlights = new ArrayList<>();
+        if (json.has("highlights")) {
+            for (JsonElement element : json.getAsJsonArray("highlights")) {
+                JsonObject h = element.getAsJsonObject();
+                highlights.add(new DungeonHighlight(
+                        integer(h, "x", 0),
+                        integer(h, "y", 70),
+                        integer(h, "z", 0),
+                        parseHighlightStyle(string(h, "style", "OUTLINE")),
+                        h.has("color") ? h.get("color").getAsInt() : DungeonHighlight.INHERIT_COLOR));
+            }
+        }
+        return new DungeonWaypoint(
+                string(json, "id", "secret-" + integer(json, "secretIndex", 1)),
+                integer(json, "secretIndex", 1),
+                DungeonSecretCategory.fromId(string(json, "category", "default")),
+                DungeonWaypointTrigger.fromId(string(json, "trigger", "")),
+                integer(json, "x", 0),
+                integer(json, "y", 70),
+                integer(json, "z", 0),
+                string(json, "name", ""),
+                highlights);
     }
 
     private static Map<DungeonRoomShape, List<DungeonWaypoint>> buildDemo() {
         Map<DungeonRoomShape, List<DungeonWaypoint>> map = new EnumMap<>(DungeonRoomShape.class);
         for (DungeonRoomShape shape : DungeonRoomShape.values()) {
-            // One CHEST waypoint at the canonical NW segment's centre, with
-            // two outline highlights one block to either side. The category +
-            // multi-highlight setup is the smallest non-trivial example of
-            // the parent->children relationship called out in issue #9.
             DungeonWaypoint demo = new DungeonWaypoint(
                     "demo:" + shape.name(),
                     1,
@@ -123,11 +513,57 @@ public final class DungeonRoomData {
             );
             map.put(shape, List.of(demo));
         }
-        try {
-            Waypointer.LOGGER.debug("Built dungeon demo data for {} shape(s)", map.size());
-        } catch (Throwable ignored) {
-            // LOGGER may be unavailable during early class-init in tests; safe to swallow.
-        }
         return Collections.unmodifiableMap(map);
+    }
+
+    private static DungeonRoomType parseType(String raw) {
+        try {
+            return DungeonRoomType.valueOf(raw.trim().toUpperCase(Locale.ROOT));
+        } catch (Exception ignored) {
+            return DungeonRoomType.ROOM;
+        }
+    }
+
+    private static DungeonRoomShape parseShape(String raw) {
+        String norm = raw.trim().toUpperCase(Locale.ROOT).replace('-', '_');
+        return switch (norm) {
+            case "1X1", "ONE_BY_ONE" -> DungeonRoomShape.ONE_BY_ONE;
+            case "1X2", "ONE_BY_TWO" -> DungeonRoomShape.ONE_BY_TWO;
+            case "1X3", "ONE_BY_THREE" -> DungeonRoomShape.ONE_BY_THREE;
+            case "1X4", "ONE_BY_FOUR" -> DungeonRoomShape.ONE_BY_FOUR;
+            case "2X2", "TWO_BY_TWO" -> DungeonRoomShape.TWO_BY_TWO;
+            case "L_SHAPE", "L" -> DungeonRoomShape.L_SHAPE;
+            default -> DungeonRoomShape.UNKNOWN;
+        };
+    }
+
+    private static DungeonHighlightStyle parseHighlightStyle(String raw) {
+        try {
+            return DungeonHighlightStyle.valueOf(raw.trim().toUpperCase(Locale.ROOT));
+        } catch (Exception ignored) {
+            return DungeonHighlightStyle.OUTLINE;
+        }
+    }
+
+    private static DungeonRoomType typeFromIdentityKey(String key) {
+        if (key == null) return DungeonRoomType.ROOM;
+        int sep = key.indexOf(':');
+        if (sep < 0) return DungeonRoomType.ROOM;
+        return parseType(key.substring(0, sep));
+    }
+
+    private static DungeonRoomShape shapeFromIdentityKey(String key) {
+        if (key == null) return DungeonRoomShape.UNKNOWN;
+        String[] parts = key.split(":");
+        if (parts.length < 2) return DungeonRoomShape.UNKNOWN;
+        return parseShape(parts[1]);
+    }
+
+    private static int integer(JsonObject json, String name, int fallback) {
+        return json.has(name) ? json.get(name).getAsInt() : fallback;
+    }
+
+    private static String string(JsonObject json, String name, String fallback) {
+        return json.has(name) ? json.get(name).getAsString() : fallback;
     }
 }

--- a/src/main/java/dev/ethan/waypointer/dungeon/data/DungeonRoomData.java
+++ b/src/main/java/dev/ethan/waypointer/dungeon/data/DungeonRoomData.java
@@ -22,7 +22,6 @@ import net.fabricmc.loader.api.FabricLoader;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -383,10 +382,7 @@ public final class DungeonRoomData {
     private static Map<String, DungeonRoomDefinition> loadBundledDefinitions() {
         try (InputStream stream = DungeonRoomData.class.getResourceAsStream(BUNDLED_RESOURCE)) {
             if (stream == null) return Collections.emptyMap();
-            try (InputStreamReader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
-                JsonObject root = JsonParser.parseReader(reader).getAsJsonObject();
-                return parseDefinitions(GSON.toJson(root));
-            }
+            return parseDefinitions(new String(stream.readAllBytes(), StandardCharsets.UTF_8));
         } catch (Exception e) {
             Waypointer.LOGGER.error("Failed to load bundled dungeon room data", e);
             return Collections.emptyMap();

--- a/src/main/java/dev/ethan/waypointer/dungeon/data/DungeonRoomDefinition.java
+++ b/src/main/java/dev/ethan/waypointer/dungeon/data/DungeonRoomDefinition.java
@@ -1,0 +1,59 @@
+package dev.ethan.waypointer.dungeon.data;
+
+import dev.ethan.waypointer.dungeon.DungeonRoomShape;
+import dev.ethan.waypointer.dungeon.DungeonRoomType;
+import dev.ethan.waypointer.dungeon.DungeonWaypoint;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Stable, authored description of a dungeon room and its route data.
+ *
+ * <p>{@code DungeonRoom} describes a live physical instance; this class is the
+ * persistent catalog entry that can be matched to many physical instances over
+ * time. Waypoints and fingerprints are room-local, never world-local.
+ */
+public record DungeonRoomDefinition(
+        String id,
+        String displayName,
+        DungeonRoomType type,
+        DungeonRoomShape shape,
+        List<DungeonRoomFingerprint> fingerprints,
+        List<DungeonWaypoint> waypoints) {
+
+    public DungeonRoomDefinition {
+        id = normalizeId(id);
+        Objects.requireNonNull(id, "id");
+        displayName = displayName == null || displayName.isBlank() ? id : displayName.trim();
+        type = type == null ? DungeonRoomType.ROOM : type;
+        shape = shape == null ? DungeonRoomShape.UNKNOWN : shape;
+        fingerprints = fingerprints == null ? List.of() : List.copyOf(fingerprints);
+        waypoints = waypoints == null ? List.of() : List.copyOf(waypoints);
+    }
+
+    public DungeonRoomDefinition withDisplayName(String name) {
+        return new DungeonRoomDefinition(id, name, type, shape, fingerprints, waypoints);
+    }
+
+    public DungeonRoomDefinition withFingerprints(List<DungeonRoomFingerprint> next) {
+        return new DungeonRoomDefinition(id, displayName, type, shape, next, waypoints);
+    }
+
+    public DungeonRoomDefinition withWaypoints(List<DungeonWaypoint> next) {
+        return new DungeonRoomDefinition(id, displayName, type, shape, fingerprints, next);
+    }
+
+    public boolean hasFingerprints() {
+        return !fingerprints.isEmpty();
+    }
+
+    public static String normalizeId(String raw) {
+        if (raw == null) return "";
+        String id = raw.trim().toLowerCase(Locale.ROOT)
+                .replaceAll("[^a-z0-9_.:-]+", "-")
+                .replaceAll("^-+|-+$", "");
+        return id;
+    }
+}

--- a/src/main/java/dev/ethan/waypointer/dungeon/data/DungeonRoomFingerprint.java
+++ b/src/main/java/dev/ethan/waypointer/dungeon/data/DungeonRoomFingerprint.java
@@ -1,0 +1,25 @@
+package dev.ethan.waypointer.dungeon.data;
+
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * A room-local block sample used to distinguish same-shape dungeon rooms.
+ *
+ * <p>Coordinates are authored in the same canonical room frame as
+ * {@link dev.ethan.waypointer.dungeon.DungeonWaypoint}. At runtime they are
+ * rotated through the current room direction and compared against the world.
+ */
+public record DungeonRoomFingerprint(int x, int y, int z, String blockId) {
+
+    public DungeonRoomFingerprint {
+        Objects.requireNonNull(blockId, "blockId");
+        blockId = normalizeBlockId(blockId);
+    }
+
+    public static String normalizeBlockId(String id) {
+        if (id == null || id.isBlank()) return "minecraft:air";
+        String norm = id.trim().toLowerCase(Locale.ROOT);
+        return norm.indexOf(':') >= 0 ? norm : "minecraft:" + norm;
+    }
+}

--- a/src/main/resources/assets/waypointer/dungeons/catacombs/rooms.json
+++ b/src/main/resources/assets/waypointer/dungeons/catacombs/rooms.json
@@ -1,0 +1,28 @@
+{
+  "schema": 1,
+  "rooms": [
+    {
+      "id": "waypointer-seed-1x1",
+      "name": "Waypointer Seed 1x1",
+      "type": "ROOM",
+      "shape": "ONE_BY_ONE",
+      "fingerprints": [],
+      "waypoints": [
+        {
+          "id": "seed-1x1-chest",
+          "secretIndex": 1,
+          "category": "chest",
+          "trigger": "OPEN_CHEST",
+          "x": 16,
+          "y": 70,
+          "z": 16,
+          "name": "Seed secret",
+          "highlights": [
+            { "x": 15, "y": 70, "z": 15, "style": "OUTLINE" },
+            { "x": 17, "y": 70, "z": 17, "style": "OUTLINE" }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -26,7 +26,7 @@
     "accessWidener": "waypointer.accesswidener",
     "depends": {
         "fabricloader": ">=0.18.2",
-        "minecraft": "~1.21.11",
+        "minecraft": ">=1.21.11 <=26.1.2",
         "java": ">=21",
         "fabric-api": "*",
         "owo": ">=0.13.0"

--- a/src/test/java/dev/ethan/waypointer/config/WaypointerConfigTest.java
+++ b/src/test/java/dev/ethan/waypointer/config/WaypointerConfigTest.java
@@ -1,0 +1,113 @@
+package dev.ethan.waypointer.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WaypointerConfigTest {
+
+    @Test
+    void labelHeightOffsetDefaultsToHistoricalPlacement() {
+        WaypointerConfig config = new WaypointerConfig();
+
+        assertEquals(0.0, config.labelHeightOffset());
+    }
+
+    @Test
+    void labelHeightOffsetAcceptsLargeFiniteValues() {
+        WaypointerConfig config = new WaypointerConfig();
+
+        config.setLabelHeightOffset(4.25);
+        assertEquals(4.25, config.labelHeightOffset());
+
+        config.setLabelHeightOffset(-99.0);
+        assertEquals(-99.0, config.labelHeightOffset());
+
+        config.setLabelHeightOffset(1_000.0);
+        assertEquals(1_000.0, config.labelHeightOffset());
+    }
+
+    @Test
+    void labelHeightOffsetRejectsNonFiniteValues() {
+        WaypointerConfig config = new WaypointerConfig();
+        config.setLabelHeightOffset(42.0);
+
+        config.setLabelHeightOffset(Double.NaN);
+        assertEquals(42.0, config.labelHeightOffset());
+
+        config.setLabelHeightOffset(Double.POSITIVE_INFINITY);
+        assertEquals(42.0, config.labelHeightOffset());
+    }
+
+    @Test
+    void nullBoxStyleFallsBackToOutlined() {
+        WaypointerConfig config = new WaypointerConfig();
+
+        config.setBoxStyle(null);
+
+        assertEquals(WaypointerConfig.BoxStyle.OUTLINED, config.boxStyle());
+    }
+
+    @Test
+    void tempWaypointDefaultsStayInsideSupportedModes() {
+        WaypointerConfig config = new WaypointerConfig();
+
+        config.setTempDefaultMode(1);
+        assertEquals(1, config.tempDefaultMode());
+
+        config.setTempDefaultMode(3);
+        assertEquals(3, config.tempDefaultMode());
+
+        config.setTempDefaultMode(0);
+        assertEquals(2, config.tempDefaultMode());
+
+        config.setTempDefaultMode(4);
+        assertEquals(2, config.tempDefaultMode());
+    }
+
+    @Test
+    void tempWaypointDurationClampsToOneMinuteThroughOneDay() {
+        WaypointerConfig config = new WaypointerConfig();
+
+        config.setTempDefaultDurationMin(30);
+        assertEquals(30, config.tempDefaultDurationMin());
+
+        config.setTempDefaultDurationMin(-1);
+        assertEquals(1, config.tempDefaultDurationMin());
+
+        config.setTempDefaultDurationMin(9_999);
+        assertEquals(24 * 60, config.tempDefaultDurationMin());
+    }
+
+    @Test
+    void colorSettersMaskAlphaChannel() {
+        WaypointerConfig config = new WaypointerConfig();
+
+        config.setTracerColor(0xAA112233);
+
+        assertEquals(0x112233, config.tracerColor());
+    }
+
+    @Test
+    void opacitySettingsClampToUnitInterval() {
+        WaypointerConfig config = new WaypointerConfig();
+
+        config.setTracerOpacity(-1.0);
+        config.setBeaconOpacity(2.0);
+
+        assertEquals(0.0, config.tracerOpacity());
+        assertEquals(1.0, config.beaconOpacity());
+    }
+
+    @Test
+    void defaultExportAndDetectionTogglesStayUserFriendly() {
+        WaypointerConfig config = new WaypointerConfig();
+
+        assertTrue(config.chatCoordDetection());
+        assertTrue(config.autoAddChatTempWaypoints());
+        assertTrue(config.chatCodecDetection());
+        assertTrue(config.exportIncludeColors());
+        assertTrue(config.exportIncludeGroupMeta());
+    }
+}

--- a/src/test/java/dev/ethan/waypointer/core/WaypointGroupTest.java
+++ b/src/test/java/dev/ethan/waypointer/core/WaypointGroupTest.java
@@ -190,4 +190,41 @@ class WaypointGroupTest {
         assertEquals(WaypointGroup.LoadMode.STATIC, g.loadMode(),
                 "shared routes default to STATIC so imported groups stay visible");
     }
+
+    @Test
+    void manager_addTempWaypointCreatesStaticLeaveScopedTempBucketForCurrentZone() {
+        ActiveGroupManager manager = new ActiveGroupManager();
+        manager.onZoneChanged(new Zone("dungeon_f7", "Catacombs F7"));
+
+        WaypointGroup bucket = manager.addTempWaypoint(100, 64, -200);
+
+        assertEquals("temp::dungeon_f7", bucket.id());
+        assertEquals("Temp -- Catacombs F7", bucket.name());
+        assertTrue(bucket.temp());
+        assertEquals(WaypointGroup.LoadMode.STATIC, bucket.loadMode());
+        assertEquals(1, bucket.size());
+        assertEquals(bucket, manager.firstActiveGroup());
+
+        Waypoint waypoint = bucket.get(0);
+        assertEquals(100, waypoint.x());
+        assertEquals(64, waypoint.y());
+        assertEquals(-200, waypoint.z());
+        assertTrue(waypoint.isTemp());
+        assertEquals(Waypoint.TEMP_UNTIL_LEAVE, waypoint.tempMode());
+    }
+
+    @Test
+    void manager_addTempWaypointReusesBucketAndInvalidatesActiveCache() {
+        ActiveGroupManager manager = new ActiveGroupManager();
+        manager.onZoneChanged(new Zone("dungeon_f7", "Catacombs F7"));
+
+        WaypointGroup firstBucket = manager.addTempWaypoint(1, 70, 2);
+        assertEquals(1, manager.activeGroups().size());
+
+        WaypointGroup secondBucket = manager.addTempWaypoint(3, 71, 4);
+
+        assertSame(firstBucket, secondBucket);
+        assertEquals(2, manager.activeGroups().get(0).size(),
+                "second temp waypoint should be visible through refreshed active cache");
+    }
 }

--- a/src/test/java/dev/ethan/waypointer/core/ZoneTest.java
+++ b/src/test/java/dev/ethan/waypointer/core/ZoneTest.java
@@ -312,4 +312,12 @@ class ZoneTest {
         assertEquals("dungeon_f7", Zone.resolve("SKYBLOCK", "F7", "dungeon").id());
         assertEquals("dungeon_m4", Zone.resolve("SKYBLOCK", "M4", "dungeon").id());
     }
+
+    @Test
+    void dungeonGenericPayloadDoesNotDisplayDungeonDungeon() {
+        Zone zone = Zone.resolve("SKYBLOCK", "Dungeon", "Dungeon");
+
+        assertEquals("dungeon", zone.id());
+        assertEquals("Catacombs", zone.displayName());
+    }
 }

--- a/src/test/java/dev/ethan/waypointer/dungeon/DungeonDomainModelTest.java
+++ b/src/test/java/dev/ethan/waypointer/dungeon/DungeonDomainModelTest.java
@@ -1,0 +1,189 @@
+package dev.ethan.waypointer.dungeon;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DungeonDomainModelTest {
+
+    @Test
+    void roomDefaultsNullDirectionAndCopiesSegments() {
+        List<Long> segments = new ArrayList<>();
+        segments.add(DungeonRoom.packSegment(-8, 24));
+
+        DungeonRoom room = new DungeonRoom(
+                DungeonRoomType.ROOM,
+                DungeonRoomShape.ONE_BY_ONE,
+                null,
+                -8,
+                24,
+                segments);
+        segments.add(DungeonRoom.packSegment(24, 24));
+
+        assertEquals(Direction.NW, room.direction());
+        assertEquals(List.of(DungeonRoom.packSegment(-8, 24)), room.segments());
+        assertThrows(UnsupportedOperationException.class,
+                () -> room.segments().add(DungeonRoom.packSegment(56, 24)));
+    }
+
+    @Test
+    void packSegmentRoundTripsNegativeAndPositiveCoordinates() {
+        long packed = DungeonRoom.packSegment(-40, 88);
+
+        assertEquals(-40, DungeonRoom.segmentX(packed));
+        assertEquals(88, DungeonRoom.segmentZ(packed));
+    }
+
+    @Test
+    void identityKeyIgnoresSegmentCoordinatesButTracksCount() {
+        DungeonRoom oneSegment = new DungeonRoom(
+                DungeonRoomType.PUZZLE,
+                DungeonRoomShape.ONE_BY_ONE,
+                Direction.SE,
+                100,
+                200,
+                List.of(DungeonRoom.packSegment(100, 200)));
+        DungeonRoom twoSegments = new DungeonRoom(
+                DungeonRoomType.PUZZLE,
+                DungeonRoomShape.ONE_BY_ONE,
+                Direction.SE,
+                100,
+                200,
+                List.of(
+                        DungeonRoom.packSegment(100, 200),
+                        DungeonRoom.packSegment(132, 200)));
+
+        assertEquals("PUZZLE:ONE_BY_ONE:SE:100,200:n=1", oneSegment.identityKey());
+        assertEquals("PUZZLE:ONE_BY_ONE:SE:100,200:n=2", twoSegments.identityKey());
+    }
+
+    @Test
+    void displayNameUsesShapeForGenericRoomsAndTypeForSpecialRooms() {
+        DungeonRoom genericRoom = new DungeonRoom(
+                DungeonRoomType.ROOM,
+                DungeonRoomShape.ONE_BY_TWO,
+                Direction.NW,
+                0,
+                0,
+                List.of());
+        DungeonRoom puzzleRoom = new DungeonRoom(
+                DungeonRoomType.PUZZLE,
+                DungeonRoomShape.ONE_BY_ONE,
+                Direction.NW,
+                0,
+                0,
+                List.of());
+
+        assertEquals("1x2 Room", genericRoom.displayName());
+        assertEquals("Puzzle Room", puzzleRoom.displayName());
+    }
+
+    @Test
+    void roomDefinitionMetadataOverridesFallbackDisplayName() {
+        DungeonRoom room = new DungeonRoom(
+                DungeonRoomType.ROOM,
+                DungeonRoomShape.ONE_BY_TWO,
+                Direction.NW,
+                0,
+                0,
+                List.of()).withDefinition("lava-ravine", "Lava Ravine");
+
+        assertTrue(room.hasRoomId());
+        assertEquals("lava-ravine", room.roomId());
+        assertEquals("Lava Ravine", room.displayName());
+    }
+
+    @Test
+    void waypointDefaultsNullFieldsAndCopiesHighlights() {
+        List<DungeonHighlight> highlights = new ArrayList<>();
+        highlights.add(DungeonHighlight.outline(1, 70, 1));
+
+        DungeonWaypoint waypoint = new DungeonWaypoint(
+                "secret-1",
+                1,
+                null,
+                10,
+                65,
+                20,
+                null,
+                highlights);
+        highlights.add(DungeonHighlight.filled(2, 70, 2));
+
+        assertEquals(DungeonSecretCategory.DEFAULT, waypoint.category());
+        assertEquals(DungeonWaypointTrigger.MANUAL, waypoint.trigger());
+        assertEquals("", waypoint.name());
+        assertFalse(waypoint.hasName());
+        assertTrue(waypoint.hasHighlights());
+        assertEquals(List.of(DungeonHighlight.outline(1, 70, 1)), waypoint.highlights());
+        assertThrows(UnsupportedOperationException.class,
+                () -> waypoint.highlights().add(DungeonHighlight.outline(3, 70, 3)));
+    }
+
+    @Test
+    void plainWaypointHasNoHighlightsAndUsesCategoryColor() {
+        DungeonWaypoint waypoint = DungeonWaypoint.plain(
+                "wither-1",
+                DungeonSecretCategory.WITHER,
+                1,
+                70,
+                2,
+                "Wither essence");
+
+        assertFalse(waypoint.hasHighlights());
+        assertTrue(waypoint.hasName());
+        assertEquals(DungeonSecretCategory.WITHER.defaultColor, waypoint.color());
+    }
+
+    @Test
+    void waypointDefaultTriggerFollowsCategory() {
+        assertEquals(DungeonWaypointTrigger.OPEN_CHEST,
+                DungeonWaypoint.defaultTrigger(DungeonSecretCategory.CHEST));
+        assertEquals(DungeonWaypointTrigger.FLIP_LEVER,
+                DungeonWaypoint.defaultTrigger(DungeonSecretCategory.LEVER));
+        assertEquals(DungeonWaypointTrigger.USE_SUPERBOOM,
+                DungeonWaypoint.defaultTrigger(DungeonSecretCategory.SUPERBOOM));
+        assertEquals(DungeonWaypointTrigger.BREAK_BLOCKS,
+                DungeonWaypoint.defaultTrigger(DungeonSecretCategory.DUNGEONBREAKER));
+        assertEquals(DungeonWaypointTrigger.KILL_BAT,
+                DungeonWaypoint.defaultTrigger(DungeonSecretCategory.BAT));
+    }
+
+    @Test
+    void highlightDefaultsNullStyleAndHelperMethodsInheritParentColor() {
+        DungeonHighlight explicitNullStyle = new DungeonHighlight(1, 2, 3, null, 0x123456);
+        DungeonHighlight outline = DungeonHighlight.outline(4, 5, 6);
+        DungeonHighlight filled = DungeonHighlight.filled(7, 8, 9);
+
+        assertEquals(DungeonHighlightStyle.OUTLINE, explicitNullStyle.style());
+        assertTrue(explicitNullStyle.hasOwnColor());
+        assertEquals(DungeonHighlightStyle.OUTLINE, outline.style());
+        assertEquals(DungeonHighlightStyle.FILLED, filled.style());
+        assertFalse(outline.hasOwnColor());
+        assertFalse(filled.hasOwnColor());
+    }
+
+    @Test
+    void secretCategoryLookupIsCaseInsensitiveAndFallsBackToDefault() {
+        assertEquals(DungeonSecretCategory.CHEST, DungeonSecretCategory.fromId(" chest "));
+        assertEquals(DungeonSecretCategory.FAIRYSOUL, DungeonSecretCategory.fromId("FAIRYSOUL"));
+        assertEquals(DungeonSecretCategory.DEFAULT, DungeonSecretCategory.fromId("not-real"));
+        assertEquals(DungeonSecretCategory.DEFAULT, DungeonSecretCategory.fromId(""));
+        assertEquals(DungeonSecretCategory.DEFAULT, DungeonSecretCategory.fromId(null));
+    }
+
+    @Test
+    void roomTypeLookupReturnsNullForUnknownMapColors() {
+        assertEquals(DungeonRoomType.ENTRANCE,
+                DungeonRoomType.fromMapColor(DungeonRoomType.ENTRANCE.packedColor));
+        assertEquals(DungeonRoomType.BLOOD,
+                DungeonRoomType.fromMapColor(DungeonRoomType.BLOOD.packedColor));
+        assertNull(DungeonRoomType.fromMapColor((byte) 0));
+    }
+}

--- a/src/test/java/dev/ethan/waypointer/dungeon/DungeonMapMathTest.java
+++ b/src/test/java/dev/ethan/waypointer/dungeon/DungeonMapMathTest.java
@@ -1,0 +1,115 @@
+package dev.ethan.waypointer.dungeon;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DungeonMapMathTest {
+
+    @Test
+    void physicalSegmentCorner_snapsToHypixelGridOffset() {
+        assertArrayEquals(new int[] { -8, -8 }, DungeonMapMath.physicalSegmentCorner(0.0, 0.0));
+        assertArrayEquals(new int[] { -8, -8 }, DungeonMapMath.physicalSegmentCorner(23.49, 23.49));
+        assertArrayEquals(new int[] { 24, 24 }, DungeonMapMath.physicalSegmentCorner(23.5, 23.5));
+        assertArrayEquals(new int[] { -40, -40 }, DungeonMapMath.physicalSegmentCorner(-24.0, -24.0));
+    }
+
+    @Test
+    void physicalAndMapCoordinatesRoundTripFromEntranceAnchor() {
+        int physEntranceX = -8;
+        int physEntranceZ = -8;
+        int mapEntranceX = 22;
+        int mapEntranceZ = 14;
+        int mapRoomSize = 18;
+
+        int[] map = DungeonMapMath.physicalToMap(
+                physEntranceX, physEntranceZ,
+                mapEntranceX, mapEntranceZ,
+                mapRoomSize,
+                56, 24);
+        assertArrayEquals(new int[] { 66, 36 }, map);
+
+        int[] physical = DungeonMapMath.mapToPhysical(
+                mapEntranceX, mapEntranceZ,
+                mapRoomSize,
+                physEntranceX, physEntranceZ,
+                map[0], map[1]);
+        assertArrayEquals(new int[] { 56, 24 }, physical);
+    }
+
+    @Test
+    void physicalCorner_usesInnerFarCornerForRotatedRooms() {
+        int minX = -8;
+        int minZ = 24;
+        int maxX = 56;
+        int maxZ = 88;
+
+        assertArrayEquals(new int[] { -8, 24 },
+                DungeonMapMath.physicalCorner(Direction.NW, minX, minZ, maxX, maxZ));
+        assertArrayEquals(new int[] { 86, 24 },
+                DungeonMapMath.physicalCorner(Direction.NE, minX, minZ, maxX, maxZ));
+        assertArrayEquals(new int[] { -8, 118 },
+                DungeonMapMath.physicalCorner(Direction.SW, minX, minZ, maxX, maxZ));
+        assertArrayEquals(new int[] { 86, 118 },
+                DungeonMapMath.physicalCorner(Direction.SE, minX, minZ, maxX, maxZ));
+    }
+
+    @Test
+    void relativeToActual_appliesExpectedRotationForEachDirection() {
+        int cornerX = 100;
+        int cornerZ = 200;
+        int rx = 3;
+        int ry = 70;
+        int rz = 5;
+
+        assertArrayEquals(new int[] { 103, 70, 205 },
+                DungeonMapMath.relativeToActual(Direction.NW, cornerX, cornerZ, rx, ry, rz));
+        assertArrayEquals(new int[] { 95, 70, 203 },
+                DungeonMapMath.relativeToActual(Direction.NE, cornerX, cornerZ, rx, ry, rz));
+        assertArrayEquals(new int[] { 105, 70, 197 },
+                DungeonMapMath.relativeToActual(Direction.SW, cornerX, cornerZ, rx, ry, rz));
+        assertArrayEquals(new int[] { 97, 70, 195 },
+                DungeonMapMath.relativeToActual(Direction.SE, cornerX, cornerZ, rx, ry, rz));
+    }
+
+    @Test
+    void relativeAndActualCoordinatesAreInversesForAllDirections() {
+        int cornerX = -40;
+        int cornerZ = 88;
+        int[][] samples = {
+                { 0, 68, 0 },
+                { 12, 70, 29 },
+                { -3, 65, 31 },
+                { 30, 91, -4 }
+        };
+
+        for (Direction direction : Direction.values()) {
+            for (int[] relative : samples) {
+                int[] actual = DungeonMapMath.relativeToActual(
+                        direction,
+                        cornerX,
+                        cornerZ,
+                        relative[0],
+                        relative[1],
+                        relative[2]);
+
+                assertArrayEquals(relative,
+                        DungeonMapMath.actualToRelative(
+                                direction,
+                                cornerX,
+                                cornerZ,
+                                actual[0],
+                                actual[1],
+                                actual[2]),
+                        "round trip failed for " + direction);
+            }
+        }
+    }
+
+    @Test
+    void label_returnsLowerCaseDirectionName() {
+        assertEquals("nw", DungeonMapMath.label(Direction.NW));
+        assertEquals("se", DungeonMapMath.label(Direction.SE));
+    }
+}

--- a/src/test/java/dev/ethan/waypointer/dungeon/DungeonRoomShapeTest.java
+++ b/src/test/java/dev/ethan/waypointer/dungeon/DungeonRoomShapeTest.java
@@ -1,0 +1,41 @@
+package dev.ethan.waypointer.dungeon;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DungeonRoomShapeTest {
+
+    @Test
+    void classify_treatsEmptyAndSingleSegmentAsOneByOne() {
+        assertEquals(DungeonRoomShape.ONE_BY_ONE, DungeonRoomShape.classify(0, 0, 0));
+        assertEquals(DungeonRoomShape.ONE_BY_ONE, DungeonRoomShape.classify(1, 1, 1));
+    }
+
+    @Test
+    void classify_twoSegmentsAsOneByTwoRegardlessOfAxis() {
+        assertEquals(DungeonRoomShape.ONE_BY_TWO, DungeonRoomShape.classify(2, 1, 2));
+        assertEquals(DungeonRoomShape.ONE_BY_TWO, DungeonRoomShape.classify(2, 2, 1));
+    }
+
+    @Test
+    void classify_threeSegmentsDistinguishesLineFromElbow() {
+        assertEquals(DungeonRoomShape.ONE_BY_THREE, DungeonRoomShape.classify(3, 1, 3));
+        assertEquals(DungeonRoomShape.ONE_BY_THREE, DungeonRoomShape.classify(3, 3, 1));
+        assertEquals(DungeonRoomShape.L_SHAPE, DungeonRoomShape.classify(3, 2, 2));
+    }
+
+    @Test
+    void classify_fourSegmentsDistinguishesLineSquareAndElbow() {
+        assertEquals(DungeonRoomShape.ONE_BY_FOUR, DungeonRoomShape.classify(4, 1, 4));
+        assertEquals(DungeonRoomShape.ONE_BY_FOUR, DungeonRoomShape.classify(4, 4, 1));
+        assertEquals(DungeonRoomShape.TWO_BY_TWO, DungeonRoomShape.classify(4, 2, 2));
+        assertEquals(DungeonRoomShape.L_SHAPE, DungeonRoomShape.classify(4, 2, 3));
+    }
+
+    @Test
+    void classify_unknownForLargerOrImpossibleFootprints() {
+        assertEquals(DungeonRoomShape.UNKNOWN, DungeonRoomShape.classify(5, 2, 3));
+        assertEquals(DungeonRoomShape.UNKNOWN, DungeonRoomShape.classify(9, 3, 3));
+    }
+}

--- a/src/test/java/dev/ethan/waypointer/dungeon/DungeonRouteSessionTest.java
+++ b/src/test/java/dev/ethan/waypointer/dungeon/DungeonRouteSessionTest.java
@@ -1,0 +1,79 @@
+package dev.ethan.waypointer.dungeon;
+
+import dev.ethan.waypointer.dungeon.data.DungeonRoomData;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DungeonRouteSessionTest {
+
+    @BeforeEach
+    @AfterEach
+    void clearCustomRooms() {
+        DungeonRoomData.clearAllCustom();
+    }
+
+    @Test
+    void routeStartsAtLowestSecretIndexAndAdvancesPastFoundSecrets() {
+        DungeonRoom base = room();
+        var definition = DungeonRoomData.defineRoom("route-room", "Route Room", base);
+        DungeonRoomData.addWaypoint(definition.id(), waypoint("second", 2));
+        DungeonRoomData.addWaypoint(definition.id(), waypoint("first", 1));
+        DungeonRoom room = base.withDefinition(definition.id(), definition.displayName());
+
+        DungeonRouteSession session = new DungeonRouteSession();
+
+        assertEquals(1, session.currentSecretIndex(room));
+        assertEquals(DungeonRouteSession.Status.CURRENT,
+                session.status(room, DungeonRoomData.waypointsFor(room).get(1)));
+
+        session.markFound(room, 1);
+
+        assertEquals(2, session.currentSecretIndex(room));
+        assertEquals(DungeonRouteSession.Status.FOUND,
+                session.status(room, DungeonRoomData.waypointsFor(room).get(1)));
+        assertEquals(DungeonRouteSession.Status.CURRENT,
+                session.status(room, DungeonRoomData.waypointsFor(room).get(0)));
+    }
+
+    @Test
+    void resetRoomClearsFoundState() {
+        DungeonRoom base = room();
+        var definition = DungeonRoomData.defineRoom("reset-room", "Reset Room", base);
+        DungeonRoomData.addWaypoint(definition.id(), waypoint("first", 1));
+        DungeonRoom room = base.withDefinition(definition.id(), definition.displayName());
+
+        DungeonRouteSession session = new DungeonRouteSession();
+        session.markFound(room, 1);
+        session.resetRoom(room);
+
+        assertEquals(DungeonRouteSession.Status.CURRENT,
+                session.status(room, DungeonRoomData.waypointsFor(room).get(0)));
+    }
+
+    private static DungeonRoom room() {
+        return new DungeonRoom(
+                DungeonRoomType.ROOM,
+                DungeonRoomShape.ONE_BY_ONE,
+                Direction.NW,
+                -8,
+                24,
+                List.of(DungeonRoom.packSegment(-8, 24)));
+    }
+
+    private static DungeonWaypoint waypoint(String id, int secretIndex) {
+        return new DungeonWaypoint(
+                id,
+                secretIndex,
+                DungeonSecretCategory.CHEST,
+                16,
+                70,
+                16,
+                id,
+                List.of());
+    }
+}

--- a/src/test/java/dev/ethan/waypointer/dungeon/config/DungeonConfigTest.java
+++ b/src/test/java/dev/ethan/waypointer/dungeon/config/DungeonConfigTest.java
@@ -1,0 +1,71 @@
+package dev.ethan.waypointer.dungeon.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DungeonConfigTest {
+
+    @Test
+    void defaultsEnableMvpRenderingWithoutDebugNoise() {
+        DungeonConfig config = new DungeonConfig();
+
+        assertTrue(config.enabled());
+        assertTrue(config.showSecretWaypoints());
+        assertTrue(config.showHighlights());
+        assertFalse(config.debugLogRoomChanges());
+        assertFalse(config.drawRoomBounds());
+        assertTrue(config.showFoundSecrets());
+        assertEquals("ALL", config.routeRenderMode());
+        assertEquals("NW", config.defaultDirection());
+    }
+
+    @Test
+    void booleanSettersUpdateIndependentFeatureGates() {
+        DungeonConfig config = new DungeonConfig();
+
+        config.setEnabled(false);
+        config.setShowSecretWaypoints(false);
+        config.setShowHighlights(false);
+        config.setDebugLogRoomChanges(true);
+        config.setDrawRoomBounds(true);
+        config.setShowFoundSecrets(false);
+
+        assertFalse(config.enabled());
+        assertFalse(config.showSecretWaypoints());
+        assertFalse(config.showHighlights());
+        assertTrue(config.debugLogRoomChanges());
+        assertTrue(config.drawRoomBounds());
+        assertFalse(config.showFoundSecrets());
+    }
+
+    @Test
+    void defaultDirectionAcceptsOnlyCardinalDungeonRotations() {
+        DungeonConfig config = new DungeonConfig();
+
+        config.setDefaultDirection(" se ");
+        assertEquals("SE", config.defaultDirection());
+
+        config.setDefaultDirection("north");
+        assertEquals("SE", config.defaultDirection());
+
+        config.setDefaultDirection(null);
+        assertEquals("SE", config.defaultDirection());
+    }
+
+    @Test
+    void routeRenderModeAcceptsOnlySupportedModes() {
+        DungeonConfig config = new DungeonConfig();
+
+        config.setRouteRenderMode("active");
+        assertEquals("ACTIVE", config.routeRenderMode());
+
+        config.setRouteRenderMode("everything");
+        assertEquals("ACTIVE", config.routeRenderMode());
+
+        config.setRouteRenderMode("all");
+        assertEquals("ALL", config.routeRenderMode());
+    }
+}

--- a/src/test/java/dev/ethan/waypointer/dungeon/data/DungeonRoomDataTest.java
+++ b/src/test/java/dev/ethan/waypointer/dungeon/data/DungeonRoomDataTest.java
@@ -1,0 +1,265 @@
+package dev.ethan.waypointer.dungeon.data;
+
+import dev.ethan.waypointer.dungeon.Direction;
+import dev.ethan.waypointer.dungeon.DungeonHighlight;
+import dev.ethan.waypointer.dungeon.DungeonRoom;
+import dev.ethan.waypointer.dungeon.DungeonRoomShape;
+import dev.ethan.waypointer.dungeon.DungeonRoomType;
+import dev.ethan.waypointer.dungeon.DungeonSecretCategory;
+import dev.ethan.waypointer.dungeon.DungeonWaypoint;
+import dev.ethan.waypointer.dungeon.DungeonWaypointTrigger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DungeonRoomDataTest {
+
+    @BeforeEach
+    @AfterEach
+    void clearRuntimeData() {
+        DungeonRoomData.clearAllCustom();
+    }
+
+    @Test
+    void demoWaypointsCoverEveryRoomShapeWithParentAndChildren() {
+        Map<DungeonRoomShape, List<DungeonWaypoint>> demos = DungeonRoomData.demoWaypoints();
+
+        assertEquals(DungeonRoomShape.values().length, demos.size());
+        for (DungeonRoomShape shape : DungeonRoomShape.values()) {
+            List<DungeonWaypoint> waypoints = demos.get(shape);
+
+            assertEquals(1, waypoints.size(), "one demo waypoint for " + shape);
+            DungeonWaypoint waypoint = waypoints.get(0);
+            assertEquals("demo:" + shape.name(), waypoint.id());
+            assertEquals(DungeonSecretCategory.CHEST, waypoint.category());
+            assertEquals(2, waypoint.highlights().size());
+            assertTrue(waypoint.hasHighlights());
+        }
+    }
+
+    @Test
+    void demoCollectionsAreImmutable() {
+        Map<DungeonRoomShape, List<DungeonWaypoint>> demos = DungeonRoomData.demoWaypoints();
+        List<DungeonWaypoint> oneByOne = demos.get(DungeonRoomShape.ONE_BY_ONE);
+
+        assertThrows(UnsupportedOperationException.class, demos::clear);
+        assertThrows(UnsupportedOperationException.class, oneByOne::clear);
+    }
+
+    @Test
+    void waypointsForNullOrUnknownRoomIsEmpty() {
+        assertTrue(DungeonRoomData.waypointsFor(null).isEmpty());
+        assertTrue(DungeonRoomData.waypointsFor(twoByTwoRoomAt(-8, 24)).isEmpty());
+    }
+
+    @Test
+    void addCustomStoresWaypointsByRoomIdentityKeyInOrder() {
+        DungeonRoom room = roomAt(-8, 24);
+        DungeonWaypoint first = waypoint("first");
+        DungeonWaypoint second = waypoint("second");
+
+        DungeonRoomData.addCustom(room.identityKey(), first);
+        DungeonRoomData.addCustom(room.identityKey(), second);
+
+        assertEquals(List.of(first, second), DungeonRoomData.waypointsFor(room));
+    }
+
+    @Test
+    void customBucketsAreIndependentPerRoom() {
+        DungeonRoom firstRoom = roomAt(-8, 24);
+        DungeonRoom secondRoom = twoByTwoRoomAt(24, 24);
+        DungeonWaypoint first = waypoint("first");
+        DungeonWaypoint second = waypoint("second");
+
+        DungeonRoomDefinition firstDefinition = DungeonRoomData.defineRoom("first-room", "First", firstRoom);
+        DungeonRoomDefinition secondDefinition = DungeonRoomData.defineRoom("second-room", "Second", secondRoom);
+        DungeonRoomData.addWaypoint(firstDefinition.id(), first);
+        DungeonRoomData.addWaypoint(secondDefinition.id(), second);
+
+        assertEquals(List.of(first), DungeonRoomData.waypointsFor(
+                firstRoom.withDefinition(firstDefinition.id(), firstDefinition.displayName())));
+        assertEquals(List.of(second), DungeonRoomData.waypointsFor(
+                secondRoom.withDefinition(secondDefinition.id(), secondDefinition.displayName())));
+    }
+
+    @Test
+    void customWaypointListsReturnedToCallersAreImmutable() {
+        DungeonRoom room = roomAt(-8, 24);
+        DungeonRoomData.addCustom(room.identityKey(), waypoint("first"));
+
+        List<DungeonWaypoint> waypoints = DungeonRoomData.waypointsFor(room);
+
+        assertThrows(UnsupportedOperationException.class, waypoints::clear);
+    }
+
+    @Test
+    void clearCustomRemovesOnlyOneRoomBucket() {
+        DungeonRoom keep = roomAt(-8, 24);
+        DungeonRoom clear = twoByTwoRoomAt(24, 24);
+        DungeonWaypoint keepWaypoint = waypoint("keep");
+
+        DungeonRoomDefinition keepDefinition = DungeonRoomData.defineRoom("keep-room", "Keep", keep);
+        DungeonRoomDefinition clearDefinition = DungeonRoomData.defineRoom("clear-room", "Clear", clear);
+        DungeonRoomData.addWaypoint(keepDefinition.id(), keepWaypoint);
+        DungeonRoomData.addWaypoint(clearDefinition.id(), waypoint("clear"));
+        DungeonRoomData.clearCustom(clearDefinition.id());
+
+        assertEquals(List.of(keepWaypoint), DungeonRoomData.waypointsFor(
+                keep.withDefinition(keepDefinition.id(), keepDefinition.displayName())));
+        assertTrue(DungeonRoomData.waypointsFor(
+                clear.withDefinition(clearDefinition.id(), clearDefinition.displayName())).isEmpty());
+    }
+
+    @Test
+    void clearAllCustomRemovesEveryRuntimeWaypoint() {
+        DungeonRoom room = roomAt(-8, 24);
+        DungeonRoomDefinition definition = DungeonRoomData.defineRoom("clear-all", "Clear All", room);
+        DungeonRoomData.addWaypoint(definition.id(), waypoint("first"));
+        DungeonRoom matched = room.withDefinition(definition.id(), definition.displayName());
+
+        assertFalse(DungeonRoomData.waypointsFor(matched).isEmpty());
+        DungeonRoomData.clearAllCustom();
+
+        assertTrue(DungeonRoomData.waypointsFor(matched).isEmpty());
+    }
+
+    @Test
+    void defineRoomCreatesStableCustomMatchAcrossPhysicalInstances() {
+        DungeonRoom firstRun = roomAt(-8, 24);
+        DungeonRoom secondRun = roomAt(56, 88);
+
+        DungeonRoomDefinition definition = DungeonRoomData.defineRoom("crypt-a", "Crypt A", firstRun);
+        DungeonRoomData.addWaypoint(definition.id(), waypoint("first"));
+
+        DungeonRoom matched = DungeonRoomData.withMatchedDefinition(secondRun, null);
+
+        assertEquals("crypt-a", matched.roomId());
+        assertEquals("Crypt A", matched.displayName());
+        assertEquals(List.of(waypoint("first")), DungeonRoomData.waypointsFor(matched));
+    }
+
+    @Test
+    void fingerprintMatchWinsWhenShapeHasMultipleCandidates() {
+        DungeonRoom room = roomAt(-8, 24);
+        DungeonRoomDefinition first = DungeonRoomData.defineRoom("first-room", "First", room);
+        DungeonRoomDefinition second = DungeonRoomData.defineRoom("second-room", "Second", room);
+
+        DungeonRoomData.addFingerprint(first.id(),
+                new DungeonRoomFingerprint(1, 70, 1, "minecraft:stone"));
+        DungeonRoomData.addFingerprint(second.id(),
+                new DungeonRoomFingerprint(1, 70, 1, "minecraft:gold_block"));
+
+        DungeonRoom matched = DungeonRoomData.withMatchedDefinition(room,
+                (x, y, z) -> x == -7 && y == 70 && z == 25
+                        ? "minecraft:gold_block"
+                        : "minecraft:air");
+
+        assertEquals("second-room", matched.roomId());
+    }
+
+    @Test
+    void ambiguousUnfingerprintedRoomsDoNotMatchArbitrarily() {
+        DungeonRoom room = roomAt(-8, 24);
+
+        DungeonRoomData.defineRoom("first-room", "First", room);
+        DungeonRoomData.defineRoom("second-room", "Second", room);
+
+        assertNull(DungeonRoomData.match(room, null));
+    }
+
+    @Test
+    void jsonRoundTripsDefinitionsWaypointsAndHighlights() {
+        DungeonRoomDefinition definition = new DungeonRoomDefinition(
+                "round-trip",
+                "Round Trip",
+                DungeonRoomType.ROOM,
+                DungeonRoomShape.ONE_BY_ONE,
+                List.of(new DungeonRoomFingerprint(1, 70, 2, "stone")),
+                List.of(waypoint("first")));
+
+        Map<String, DungeonRoomDefinition> parsed =
+                DungeonRoomData.parseDefinitions(DungeonRoomData.toJson(List.of(definition)));
+
+        assertEquals(definition, parsed.get("round-trip"));
+    }
+
+    @Test
+    void waypointTriggerCanBeUpdatedAndPersistsThroughJson() {
+        DungeonRoom room = roomAt(-8, 24);
+        DungeonRoomDefinition definition = DungeonRoomData.defineRoom("trigger-room", "Trigger Room", room);
+        DungeonRoomData.addWaypoint(definition.id(), waypoint("first"));
+
+        DungeonRoomData.setWaypointTrigger(definition.id(), 0, DungeonWaypointTrigger.DUNGEONBREAKER);
+        String json = DungeonRoomData.toJson(DungeonRoomData.customDefinitions());
+        Map<String, DungeonRoomDefinition> parsed = DungeonRoomData.parseDefinitions(json);
+
+        assertEquals(DungeonWaypointTrigger.DUNGEONBREAKER,
+                parsed.get(definition.id()).waypoints().get(0).trigger());
+    }
+
+    @Test
+    void customStorePersistsDefinitions(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("dungeon_rooms.json");
+        DungeonRoomData.loadCustomStore(file);
+
+        DungeonRoomDefinition definition = DungeonRoomData.defineRoom("persisted", "Persisted", roomAt(-8, 24));
+        DungeonRoomData.addWaypoint(definition.id(), waypoint("first"));
+        DungeonRoomData.flush();
+        DungeonRoomData.clearAllCustom();
+
+        DungeonRoomData.loadCustomStore(file);
+
+        assertTrue(Files.exists(file));
+        assertNotNull(DungeonRoomData.definition("persisted"));
+        assertEquals(1, DungeonRoomData.definition("persisted").waypoints().size());
+    }
+
+    private static DungeonRoom roomAt(int x, int z) {
+        return new DungeonRoom(
+                DungeonRoomType.ROOM,
+                DungeonRoomShape.ONE_BY_ONE,
+                Direction.NW,
+                x,
+                z,
+                List.of(DungeonRoom.packSegment(x, z)));
+    }
+
+    private static DungeonRoom twoByTwoRoomAt(int x, int z) {
+        return new DungeonRoom(
+                DungeonRoomType.ROOM,
+                DungeonRoomShape.TWO_BY_TWO,
+                Direction.NW,
+                x,
+                z,
+                List.of(
+                        DungeonRoom.packSegment(x, z),
+                        DungeonRoom.packSegment(x + 32, z),
+                        DungeonRoom.packSegment(x, z + 32),
+                        DungeonRoom.packSegment(x + 32, z + 32)));
+    }
+
+    private static DungeonWaypoint waypoint(String id) {
+        return new DungeonWaypoint(
+                id,
+                1,
+                DungeonSecretCategory.CHEST,
+                16,
+                70,
+                16,
+                id,
+                List.of(DungeonHighlight.outline(15, 70, 15)));
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes #4
- Fixes #7
- #9 remains beta work

## Done
- [x] Label height offset setting
- [x] Label offset config tests
- [x] Labeled chat coord parsing
- [x] Chat coords create temps
- [x] Auto add toggle
- [x] Minecraft 26.x packaging
- [x] Dungeon room detection scaffold
- [x] Dungeon waypoint data model
- [x] Child highlight block boxes
- [x] Persistent custom room store
- [x] Room fingerprint matching
- [x] Dungeon route progress state
- [x] Secret trigger types
- [x] Chest and lever triggers
- [x] Superboom and break triggers
- [x] Item and bat triggers
- [x] Command autocomplete coverage
- [x] Focused dungeon tests
- [x] Full Gradle build

## Needs
- [ ] Live dungeon trigger testing
- [ ] Real room data entry
- [ ] More room fingerprints
- [ ] GUI room editor
- [ ] Trigger accuracy tuning
- [ ] Dungeonbreaker block tuning
- [ ] Secret dataset completion
- [ ] Beta user feedback

## Add A Room
- [ ] Stand in target room
- [ ] Create named room entry
- [ ] Add stable fingerprints
- [ ] Add secret waypoints
- [ ] Add target block boxes
- [ ] Set waypoint triggers
- [ ] Run room once
- [ ] Tune bad placements

## Test Plan
- [x] Full Gradle test
- [x] Full Gradle build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new dungeon data persistence, matching, and trigger detection paths plus rendering behavior changes, which can affect in-game overlays and saved custom data. Also introduces a reflection-based render-event compatibility layer and a new multi-jar build, increasing runtime/version compatibility risk.
> 
> **Overview**
> Expands the dungeon secrets feature into a *beta authoring + progress-tracking system*: room definitions can be created/renamed, fingerprinted, and populated with waypoints/highlights and per-waypoint `DungeonWaypointTrigger`s, persisted to `config/waypointer/dungeon_rooms.json` and seeded by a bundled `rooms.json`.
> 
> Adds per-run route progress via `DungeonRouteSession` and a new `DungeonTriggerDetector` that marks secrets found from client-observable actions (block use/attack, chat messages, break-state scans, item pickup and bat kill disappearance), with rendering updated to support *ACTIVE vs ALL* modes and optional hiding/dimming of found secrets.
> 
> Improves UX and compatibility: chat coordinate detection can now auto-create temp waypoints behind a new config toggle, command tab-completion is expanded (player coords, imports, group names, dungeon authoring indices), label height offset is now unclamped (finite-only), zone resolution handles generic “Dungeon” payloads, and the build now produces both `-1.21.11` and `-26.x` jars using an access-widener namespace rewrite plus a reflection-based `RenderEventCompat` bridge for Fabric render event API changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70133ac84f7df57844388b09799ad1a457b0167b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->