### PR TITLE
Beta

### DIFF
--- a/CODEC.md
+++ b/CODEC.md
@@ -8,13 +8,15 @@ WP:4BdPN0BU%k[nFq#[FH-++?AX6bO}NHVtY(cx5KE...
 
 Paste it in chat, get back a group of waypoints. This document explains how that string is built.
 
-**Current wire version: 2.**
+**Current wire version: 3.**
 
 Reference implementation in `src/main/java/dev/ethan/waypointer/codec/`:
 
 - `WaypointCodec.java` body format, coord modes, encode/decode
-- `AsciiPackCodec.java` text alphabet (base-85, ASCII)
+- `AsciiStreamCodec.java` text alphabet (base-93 streaming, ASCII)
+- `AsciiPackCodec.java` retired v2 base-85 packer, kept for tests/history
 - `CodecDictionary.java` preset DEFLATE dictionary
+- `CodecZoneDictionary.java` compact known-zone refs, seeded from Skyblocker
 
 ---
 
@@ -34,7 +36,7 @@ Five steps. The top half runs on the sender, the bottom half runs on the receive
   [2] DEFLATE + dict    ──── entropy compression ──    [2] Inflate + dict
        │                                                ▲
        ▼                                                │
-  [3] base-85 text      ──── chat-safe alphabet ───    [3] base-85 decode
+  [3] base-93 text      ──── chat-safe alphabet ───    [3] base-93 decode
        │                                                ▲
        ▼                                                │
   [4] "WP:" prefix      ──── scanner anchor ───────    [4] Strip "WP:"
@@ -45,12 +47,14 @@ Five steps. The top half runs on the sender, the bottom half runs on the receive
 
 Each stage has one job:
 
-| Stage | Job |
-| --- | --- |
-| Binary body | Squeeze varints and bit-packed fields. Route-level smarts live here. |
-| DEFLATE + dict | Byte-level compression with a preset dictionary. |
-| base-85 | Turn bytes into chat-safe ASCII at 1 byte per character. |
-| `WP:` prefix | Lets the chat scanner find the string without parsing it. |
+
+| Stage          | Job                                                                  |
+| -------------- | -------------------------------------------------------------------- |
+| Binary body    | Squeeze varints and bit-packed fields. Route-level smarts live here. |
+| DEFLATE + dict | Byte-level compression with a preset dictionary.                     |
+| base-93        | Turn bytes into chat-safe ASCII at 1 byte per character.             |
+| `WP:` prefix   | Lets the chat scanner find the string without parsing it.            |
+
 
 ---
 
@@ -65,12 +69,12 @@ The format is built around that number:
 ```
   Total budget: 256 wire bytes per /command
   ┌──────────────────────────────────────────────────────────────┐
-  │  /pc  │  WP:  │  ............  base-85 body  ............   │
+  │  /pc  │  WP:  │  ............  base-93 body  ............   │
   └───────┴───────┴──────────────────────────────────────────────┘
-    4 B     3 B                    up to ~249 B
+    3 B     3 B                    up to ~250 B
 ```
 
-Everything in the codec is in service of cramming the most route info into those ~249 body bytes.
+Everything in the codec is in service of cramming the most route info into those ~250 body bytes.
 
 Other constraints shaping the design:
 
@@ -86,24 +90,27 @@ Other constraints shaping the design:
 
 ```
 payload    := "WP:" body
-body       := 1*alphabet-char + trailer   ; each char is 1 UTF-8 byte
+body       := *alphabet-char   ; each char is 1 UTF-8 byte
 ```
 
 The body decodes to bytes, which are raw DEFLATE, which inflates to the binary body in §6.
 
 ---
 
-## 4. Text Alphabet (base-85)
+## 4. Text Alphabet (base-93)
 
 ### 4.1 Characters
 
-85 printable ASCII characters. Z85's alphabet with `.` swapped for `;`:
+93 printable ASCII characters. Every printable ASCII character except space and `.`:
 
 ```
+  ! " # $ % & ' ( ) * + , - /
   0 1 2 3 4 5 6 7 8 9
-  a b c d e f g h i j k l m n o p q r s t u v w x y z
+  : ; < = > ? @
   A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
-  ; - : + = ^ ! / * ? & < > ( ) [ ] { } @ % $ #
+  [ \ ] ^ _ `
+  a b c d e f g h i j k l m n o p q r s t u v w x y z
+  { | } ~
 ```
 
 Every character:
@@ -112,62 +119,49 @@ Every character:
 - is not `.`, so sequences can't look like `host.tld` to Hypixel's ad filter
 - is not whitespace, so paste can't collapse runs
 - is not `§`, so chat validation never treats a body character as a color code
-- is printable ASCII, verified live on Hypixel by typing every character in `/pc` and `/msg`
+- is printable ASCII
 
 ### 4.2 Packing
 
-Four input bytes become five output characters:
+The v3 text layer is the basE91 streaming scheme generalized to a 93-symbol
+alphabet. It accumulates source bits and emits 13 or 14 bits per two output
+characters depending on whether the current 14-bit value fits in `93²`.
 
 ```
-  4 input bytes  (32 bits)
-  ┌──────┬──────┬──────┬──────┐
-  │  B0  │  B1  │  B2  │  B3  │
-  └──────┴──────┴──────┴──────┘
-             │
-             ▼  interpret as one big-endian uint32
-             │
-             ▼  split into 5 base-85 digits (MSB first)
-             │
-  ┌────┬────┬────┬────┬────┐
-  │ d0 │ d1 │ d2 │ d3 │ d4 │   each digit 0..84 → one alphabet char
-  └────┴────┴────┴────┴────┘
+  93² = 8649
+  2¹³ = 8192
+
+  Most pairs carry 13 bits.
+  457 low-value pairs carry 14 bits because they still fit below 8649.
 ```
 
-If the input length isn't a multiple of 4, pad with zero bytes and remember how many. One trailer character (digit value `0..3`) records the pad count:
+There is no pad trailer. The final partial bit buffer is emitted as one or two
+characters, and decode reconstructs the exact original byte length.
 
-```
-  ... 5 chars per group ...  [trailer]
-                                  └── digit 0..3 = how many trailing
-                                      bytes to discard on decode
-```
+Output length is data-dependent, typically about `ceil(n * 1.22)` characters
+for `n` compressed bytes.
 
-Output length is `ceil(n / 4) * 5 + 1` characters for `n` input bytes.
+### 4.3 Why base-93 and not CJK / base64 / base-85?
 
-### 4.3 Why base-85 and not base-84 / CJK / base64?
+The real budget is UTF-8 bytes, not visible glyph count:
 
-The packing math forces our hand. Four input bytes need to fit in five output digits, which requires `base⁵ ≥ 2³²`:
 
-| Alphabet | base⁵ | ≥ 2³²? | Bits/char | UTF-8 bytes/char | **Bits per wire byte** |
-| --- | ---: | :---: | ---: | ---: | ---: |
-| base64 | 1,073,741,824 | no (uses 4-char groups instead) | 6.00 | 1 | 6.00 |
-| base-84 | 4,182,119,424 | **no** | 6.39 | 1 | — |
-| **base-85 (ours)** | 4,437,053,125 | yes | 6.41 | 1 | **6.41** |
-| CJK base-16384 | — | — | 14.00 | 3 | 4.67 |
+| Alphabet              | Bits/char | UTF-8 bytes/char | **Bits per wire byte** | Notes                                  |
+| --------------------- | --------- | ---------------- | ---------------------- | -------------------------------------- |
+| base64                | 6.00      | 1                | 6.00                   | safe but wastes capacity               |
+| v2 base-85            | 6.41      | 1                | 6.41                   | fixed 4-byte/5-char groups + 1 trailer |
+| **v3 base-93 stream** | ~6.53     | 1                | ~6.53                  | no trailer, variable 13/14-bit pairs   |
+| CJK base-16384        | 14.00     | 3                | 4.67                   | visually short, byte-expensive         |
 
-Base-84 *almost* works but `84⁵` falls short of `2³²` by ~113M, so some 4-byte inputs cannot be represented in 5 base-84 digits. We need at least 85 symbols.
 
-Straight Z85 hits 85 symbols by including `.`, which is also the single most URL-shaped character on the keyboard. Hypixel's ad filter disconnected senders whenever a random digit sequence happened to land as `H.vD` or similar. Swapping `.` for `;` keeps the 85-symbol alphabet (so the packing math works) while making any URL shape impossible — semicolons don't appear in URLs.
-
-CJK looks like it wins on raw density (14 bits per character), but each character costs 3 UTF-8 bytes on the wire, so it's actually the worst per-byte. v1 used it because we were optimising for the chat textbox, not the server byte cap. v2 fixed that.
+CJK looks like it wins on raw density (14 bits per character), but each character costs 3 UTF-8 bytes on the wire, so it's actually the worst per-byte. v1 used it because we were optimising for the chat textbox, not the server byte cap. v2 fixed that with base-85; v3 removes the base-85 pad trailer and uses the remaining printable ASCII capacity.
 
 ### 4.4 Decode safety
 
 `decode()` checks:
 
-- body length (excluding trailer) is a multiple of 5
 - every character is in the alphabet
-- the trailer digit is in `[0, 3]`
-- each 5-digit group's integer value fits in 32 bits (since `85⁵ > 2³²`, a digit sequence like `#####` would otherwise silently wrap)
+- every two-character value fits the streaming base math
 
 A single bad character fails loudly instead of producing silent errors.
 
@@ -283,12 +277,12 @@ Decode-only safety caps against memory amplification:
 
 ```
 group := varint nameIdx         ; pool index (0 = unnamed)
-         varint zoneIdIdx       ; pool index
+         varint zoneRef         ; known-zone ref or pool index
          u8     groupFlags      ; see below
          [ varint radius_x10 ]  ; iff GROUP_FLAG_CUSTOM_RADIUS
          varint waypointCount
          coord-block            ; §6.7
-         waypoint-body{waypointCount}
+         waypoint-body{waypointCount} ; omitted iff GROUP_FLAG_BODYLESS_WAYPOINTS
 ```
 
 `groupFlags`:
@@ -296,10 +290,10 @@ group := varint nameIdx         ; pool index (0 = unnamed)
 ```
   bit   7   6   5   4   3   2   1   0
       ┌───┬───┬───────┬───┬───┬───┬───┐
-      │ r │ r │ coord │ R │ S │ G │ r │
+      │ r │ r │ coord │ R │ S │ G │ B │
       └───┴───┴───────┴───┴───┴───┴───┘
         │   │     │     │   │   │   │
-        │   │     │     │   │   │   └── reserved (formerly "enabled"; see §6.6)
+        │   │     │     │   │   │   └── GROUP_FLAG_BODYLESS_WAYPOINTS
         │   │     │     │   │   └────── GROUP_FLAG_GRAD_AUTO  (1=AUTO, 0=MANUAL)
         │   │     │     │   └────────── GROUP_FLAG_LOAD_SEQUENCE (1=SEQUENCE, 0=STATIC)
         │   │     │     └────────────── GROUP_FLAG_CUSTOM_RADIUS (1=radius_x10 follows)
@@ -307,6 +301,18 @@ group := varint nameIdx         ; pool index (0 = unnamed)
         │   └────────────────────────── reserved
         └────────────────────────────── reserved
 ```
+
+`zoneRef` is a tagged varint:
+
+```
+known zone: (zoneDictionaryIndex << 1) | 1
+custom zone: poolIndex << 1
+```
+
+The built-in zone dictionary is seeded from Skyblocker's `Location` enum
+(Hypixel location IDs + friendly names), then extended with Waypointer's
+canonical aliases and dungeon/mineshaft refinements. Unknown or user-created
+zone IDs still round-trip through the string pool.
 
 When `CUSTOM_RADIUS` is set, `radius_x10` is the radius in tenths (`3.5m = 35`). Radii step in 0.1 units, so a float would waste 3 bytes per group for no added precision.
 
@@ -317,7 +323,10 @@ Exports describe a route to share, not a sender's session. Deliberately absent f
 - Group `enabled` state, imported groups always land enabled
 - Group `currentIndex` (progress), imported groups always start at index 0
 
-The old bit slot for `enabled` is now reserved (bit 0 of `groupFlags`), encoder writes 0, decoder masks it off. Future reuse doesn't need a version bump.
+The old bit slot for `enabled` is now reused as `GROUP_FLAG_BODYLESS_WAYPOINTS`.
+When set, the coord block is followed by no per-waypoint body bytes; every
+waypoint uses the default body (`wpFlags = 0`). This saves one raw zero byte per
+waypoint before DEFLATE on clean geometry-only exports.
 
 ### 6.7 Coordinate block
 
@@ -379,20 +388,27 @@ Origins are the per-axis `min` across the group, so every delta is ≥ 0 and no 
 
 #### Picking a mode
 
-The encoder tries every eligible mode, runs each candidate through DEFLATE (with the preset dictionary), and picks the one whose *compressed* bytes are smallest. Comparing raw bytes isn't enough — a repetitive VECTOR delta stream can look large but compress to almost nothing, while an already-dense FIT_COMPACT bitstream compresses poorly.
+The encoder tries every eligible mode, runs each candidate through DEFLATE plus
+the base-93 text layer, and picks the one whose final text length is smallest.
+Comparing raw bytes isn't enough — a repetitive VECTOR delta stream can look
+large but compress to almost nothing, while an already-dense FIT_COMPACT
+bitstream compresses poorly.
 
 *Worst case*: AUTO matches the best forced mode. *Best case*: it saves real characters. The decoder pays nothing, it just reads whichever mode the group header names.
 
-All four modes lay out as `[ coord-stream | waypoint-bodies ]`, so the decoder reads `waypointCount` coords in whichever mode, then `waypointCount` waypoint bodies.
+All four modes lay out as `[ coord-stream | waypoint-bodies ]`, so the decoder reads `waypointCount` coords in whichever mode, then `waypointCount` waypoint bodies unless the group is bodyless.
 
 ### 6.8 Waypoint body
 
 ```
 waypoint-body := u8 wpFlags
-                 [ varint nameIdx ]     ; iff WP_FLAG_HAS_NAME
+                 [ name-ref ]           ; iff WP_FLAG_HAS_NAME
                  [ byte[3] rgb ]        ; iff WP_FLAG_HAS_COLOR  (MSB-first R,G,B)
                  [ varint radius_x10 ]  ; iff WP_FLAG_HAS_RADIUS
                  [ varint flags ]       ; iff WP_FLAG_EXTENDED  (user flag byte, &0xFF)
+
+name-ref      := varint nameIdx         ; pooled name, iff WP_FLAG_NAME_INLINE unset
+              | varint byteLen; bytes   ; inline UTF-8, iff WP_FLAG_NAME_INLINE set
 ```
 
 `wpFlags`:
@@ -400,14 +416,20 @@ waypoint-body := u8 wpFlags
 ```
   bit   7   6   5   4   3   2   1   0
       ┌───┬───┬───┬───┬───┬───┬───┬───┐
-      │ r │ r │ r │ r │ X │ R │ C │ N │
+      │ r │ r │ r │ I │ X │ R │ C │ N │
       └───┴───┴───┴───┴───┴───┴───┴───┘
-                        │   │   │   │
-                        │   │   │   └── WP_FLAG_HAS_NAME   (else unnamed)
-                        │   │   └────── WP_FLAG_HAS_COLOR  (else DEFAULT_COLOR)
-                        │   └────────── WP_FLAG_HAS_RADIUS (else inherit group)
-                        └────────────── WP_FLAG_EXTENDED   (else no user flags)
+                            │   │   │   │
+                            │   │   │   └── WP_FLAG_HAS_NAME   (else unnamed)
+                            │   │   └────── WP_FLAG_HAS_COLOR  (else DEFAULT_COLOR)
+                            │   └────────── WP_FLAG_HAS_RADIUS (else inherit group)
+                            └────────────── WP_FLAG_EXTENDED   (else no user flags)
+                        └────────────── WP_FLAG_NAME_INLINE (name-ref is inline UTF-8)
 ```
+
+Unique waypoint names are inlined instead of inserted into the string pool,
+because pooling a one-use name costs the string bytes plus a separate index.
+Repeated waypoint names still pool, so common labels like `Terminal` or `Lever`
+are stored once and referenced by index.
 
 #### Opt-out semantics
 
@@ -467,11 +489,11 @@ Signed values are "zigzagged" first so small negatives stay one byte:
        ▼
   write binary body   ──┐
        │                │ for each group, run every eligible
-       ▼                ├─ coord mode through a trial DEFLATE
-  DEFLATE + preset dict ┘ and pick the smallest
+       ▼                ├─ coord mode through trial DEFLATE + base-93
+  DEFLATE + preset dict ┘ and pick the shortest text
        │
        ▼
-  base-85 encode
+  base-93 encode
        │
        ▼
   prepend "WP:"
@@ -489,7 +511,7 @@ Signed values are "zigzagged" first so small negatives stay one byte:
   verify "WP:" prefix
        │
        ▼
-  base-85 decode
+  base-93 decode
        │
        ▼
   Inflate + preset dict
@@ -507,7 +529,7 @@ Signed values are "zigzagged" first so small negatives stay one byte:
   for each group:
     read group header
     read coord stream per coord-mode
-    read waypoint bodies
+    read waypoint bodies (unless bodyless)
        │
        ▼
   return groups (+ label for decodeFull)
@@ -515,13 +537,22 @@ Signed values are "zigzagged" first so small negatives stay one byte:
 
 Unknown-version payloads fail fast with `unsupported wire version N` instead of limping through a misinterpreted body.
 
+Current decoders accept both v3 and legacy v2 exports:
+
+- v3: `AsciiStreamCodec` base-93 text layer + v3 body (`zoneRef`, inline names,
+bodyless groups).
+- v2: `AsciiPackCodec` base-85 text layer + v2 body (zone IDs are string-pool
+indexes, waypoint names are always pool refs, bit 0 of group flags is ignored).
+
+The encoder only writes v3.
+
 ### 8.3 peekLabel
 
 Chat-hover tooltip path:
 
 ```
   peekLabel(text):
-    same prefix / base-85 / inflate path as decode
+    same prefix / base-93 / inflate path as decode
     read header byte
     if version mismatch or HEADER_FLAG_LABEL unset → Optional.empty()
     read label, sanitize, return
@@ -538,21 +569,25 @@ This is why the label lives before the string pool — partial decoders never wa
 
 ## 9. Versioning
 
-Three separate version surfaces:
+Four separate version surfaces:
 
-| Surface | Where it lives | Cost of changing |
-| --- | --- | --- |
-| `MAGIC` (`"WP:"`) | Constant in `WaypointCodec` | Breaks the chat scanner for all payloads. |
-| `WIRE_VERSION` | Low nibble of the header byte | Breaks decode only. Scanner still fires. |
-| Dictionary bytes | `CodecDictionary.RAW` | Breaks decode at the stream level, `Inflater` throws on Adler-32 mismatch. Always bump `WIRE_VERSION` alongside. |
+
+| Surface           | Where it lives                | Cost of changing                                                                                                 |
+| ----------------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `MAGIC` (`"WP:"`) | Constant in `WaypointCodec`   | Breaks the chat scanner for all payloads.                                                                        |
+| `WIRE_VERSION`    | Low nibble of the header byte | Breaks decode for older builds. Scanner still fires.                                                             |
+| Dictionary bytes  | `CodecDictionary.RAW`         | Breaks decode at the stream level, `Inflater` throws on Adler-32 mismatch. Always bump `WIRE_VERSION` alongside. |
+| Zone dictionary   | `CodecZoneDictionary.IDS`     | Breaks known-zone refs. Always bump `WIRE_VERSION` when entries change.                                          |
+
 
 Rules:
 
 1. Changing the header's high-nibble flag meanings → version bump.
 2. Changing any field order in the body → version bump.
 3. Editing `CodecDictionary.RAW` → version bump.
-4. Adding a new bit in a reserved slot is *not* a bump, as long as older decoders can ignore it safely. Decoder masks reserved bits, encoder writes 0. That's how bit 0 of `groupFlags` went from `enabled` to reserved without bumping.
-5. The coord-mode field is 2 bits. v2 uses all four values (0..3). A fifth coord mode requires a version bump.
+4. Editing `CodecZoneDictionary.IDS` → version bump.
+5. Adding a new bit in a reserved slot is *not* a bump, as long as older decoders can ignore it safely. If older decoders would read a different byte stream, bump the wire version.
+6. The coord-mode field is 2 bits. v3 uses all four values (0..3). A fifth coord mode requires a version bump.
 
 ---
 
@@ -563,25 +598,26 @@ A single group named `Dungeon`, zone `dungeon_f7`, three waypoints at `(10, 70, 
 Binary body (pre-DEFLATE, whitespace for readability):
 
 ```
-02               header: version=2, no flags, no label
-03               string pool: 3 entries
+13               header: version=3, names flag, no label
+02               string pool: 2 entries
   00                       ""          (reserved at index 0)
   07  44 75 6E 67 65 6F 6E              "Dungeon"
-  0A  64 75 6E 67 65 6F 6E 5F 66 37     "dungeon_f7"
 01               groupCount = 1
   01             nameIdx   = 1   ("Dungeon")
-  02             zoneIdIdx = 2   ("dungeon_f7")
-  02             groupFlags = 0b00000010  (GRAD_AUTO, VECTOR)
+  35             zoneRef   = (26 << 1) | 1   ("dungeon_f7")
+  03             groupFlags = 0b00000011  (BODYLESS, GRAD_AUTO, VECTOR)
   03             waypointCount = 3
   -- VECTOR coord stream --
   14  8C 01  14    (10, 70, 10)  as zigzag varints
   04  00  00       delta (+2, 0, 0)
   00  00  0A       delta (0, 0, +5)
-  -- waypoint bodies --
-  00 00 00         all three: no optional fields
+  -- waypoint bodies omitted: group is BODYLESS --
 ```
 
-`dungeon_f7` is already in the preset dictionary, so its 10 bytes compress to a ~3-byte back-reference. The whole body compresses to roughly half its raw size. The final string lands around 40–50 characters (= 40–50 wire bytes), well inside a single chat command.
+`dungeon_f7` is already in the known-zone dictionary, so the group stores it as
+one varint instead of writing the string. The whole body compresses to roughly
+half its raw size. The final string lands around 35–45 characters (= 35–45 wire
+bytes), well inside a single chat command.
 
 ---
 
@@ -597,7 +633,7 @@ Binary body (pre-DEFLATE, whitespace for readability):
 ## 12. Non-Goals
 
 - Random Access Format is sequential, no index, no length-prefixed group, no "seek to group 3."
-- Human readability, base-85 text looks like line noise. Use `debugDecode` or hex-dump the raw body.
+- Human readability, base-93 text looks like line noise. Use `debugDecode` or hex-dump the raw body.
 - Interchange with other mods, `WP:` is native. `WaypointImporter` handles Skyblocker, Skytils, Soopy, and Coleweight payloads separately; they don't share bytes with this codec.
 - Cross-version forward compat, an older build that sees a newer `WIRE_VERSION` refuses to decode. Guessing at a newer layout risks silent misreads.
 
@@ -605,11 +641,16 @@ Binary body (pre-DEFLATE, whitespace for readability):
 
 ## 13. File Map
 
-| Path | Responsibility |
-| --- | --- |
-| `codec/WaypointCodec.java` | Body format, coord modes, options, encode/decode. |
-| `codec/AsciiPackCodec.java` | base-85 text alphabet, pack/unpack, validation. |
-| `codec/CodecDictionary.java` | Preset DEFLATE dictionary. |
-| `codec/DecodeDebug.java` | Immutable debug snapshot returned by `debugDecode`. |
-| `codec/WaypointImporter.java` | Multi-format import (Waypointer, Skyblocker, Skytils, Soopy, Coleweight). |
-| `chat/CodecScanner.java`, `chat/ChatImportDetector.java` | Detect `WP:` substrings in chat lines. |
+
+| Path                                                     | Responsibility                                                            |
+| -------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `codec/WaypointCodec.java`                               | Body format, coord modes, options, encode/decode.                         |
+| `codec/AsciiStreamCodec.java`                            | base-93 text alphabet, streaming pack/unpack, validation.                 |
+| `codec/AsciiPackCodec.java`                              | Retired v2 base-85 packer, kept for regression tests/history.             |
+| `codec/CodecDictionary.java`                             | Preset DEFLATE dictionary.                                                |
+| `codec/CodecZoneDictionary.java`                         | Skyblocker-seeded known-zone dictionary.                                  |
+| `codec/DecodeDebug.java`                                 | Immutable debug snapshot returned by `debugDecode`.                       |
+| `codec/WaypointImporter.java`                            | Multi-format import (Waypointer, Skyblocker, Skytils, Soopy, Coleweight). |
+| `chat/CodecScanner.java`, `chat/ChatImportDetector.java` | Detect `WP:` substrings in chat lines.                                    |
+
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ loader_version=0.18.2
 loom_version=1.15-SNAPSHOT
 
 # Mod Properties
-mod_version=1.4.0
+mod_version=1.4.1
 maven_group=dev.ethan.waypointer
 archives_base_name=waypointer
 

--- a/src/client/java/dev/ethan/waypointer/commands/WaypointerCommandSuggestionOverride.java
+++ b/src/client/java/dev/ethan/waypointer/commands/WaypointerCommandSuggestionOverride.java
@@ -1,0 +1,138 @@
+package dev.ethan.waypointer.commands;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.builder.ArgumentBuilder;
+import com.mojang.brigadier.tree.CommandNode;
+import dev.ethan.waypointer.Waypointer;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.impl.command.client.ClientCommandInternals;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientPacketListener;
+import net.minecraft.client.multiplayer.ClientSuggestionProvider;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+/**
+ * Keeps the short {@code /wp} alias useful on servers that also advertise a
+ * server-side {@code /wp} command.
+ *
+ * Fabric currently executes same-name client commands first, but the chat box
+ * can still read suggestions from the server's command node. Replacing only the
+ * vanilla suggestion node for {@code /wp} preserves Waypointer's short alias
+ * without touching unrelated server commands.
+ */
+public final class WaypointerCommandSuggestionOverride {
+
+    private static final String ROOT = "wp";
+
+    private static final Field CHILDREN_FIELD = findCommandNodeMap("children");
+    private static final Field LITERALS_FIELD = findCommandNodeMap("literals");
+    private static final Field ARGUMENTS_FIELD = findCommandNodeMap("arguments");
+
+    private boolean warnedReflectionFailure;
+
+    public void install() {
+        ClientTickEvents.END_CLIENT_TICK.register(this::onTick);
+    }
+
+    private void onTick(Minecraft mc) {
+        ClientPacketListener connection = mc.getConnection();
+        if (connection == null) return;
+
+        CommandDispatcher<ClientSuggestionProvider> target = connection.getCommands();
+        CommandNode<ClientSuggestionProvider> targetRoot = target.getRoot().getChild(ROOT);
+        if (isWaypointerRoot(targetRoot)) return;
+
+        CommandNode<FabricClientCommandSource> clientRoot = clientRoot();
+        if (clientRoot == null) return;
+
+        replaceWpRoot(target.getRoot(), clientRoot);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static CommandNode<FabricClientCommandSource> clientRoot() {
+        CommandDispatcher<FabricClientCommandSource> dispatcher =
+                (CommandDispatcher<FabricClientCommandSource>) ClientCommandInternals.getActiveDispatcher();
+        if (dispatcher == null) return null;
+        return dispatcher.getRoot().getChild(ROOT);
+    }
+
+    private static boolean isWaypointerRoot(CommandNode<?> node) {
+        return node != null
+                && node.getChild("add") != null
+                && node.getChild("group") != null
+                && node.getChild("import") != null;
+    }
+
+    private void replaceWpRoot(CommandNode<ClientSuggestionProvider> targetRoot,
+                               CommandNode<FabricClientCommandSource> clientRoot) {
+        if (!canEditCommandNodeMaps()) return;
+
+        try {
+            removeChild(targetRoot, ROOT);
+            targetRoot.addChild(copyAsSuggestionNode(clientRoot));
+        } catch (ReflectiveOperationException | RuntimeException e) {
+            warnReflectionFailure(e);
+        }
+    }
+
+    private boolean canEditCommandNodeMaps() {
+        boolean ready = CHILDREN_FIELD != null
+                && LITERALS_FIELD != null
+                && ARGUMENTS_FIELD != null;
+        if (!ready) warnReflectionFailure(null);
+        return ready;
+    }
+
+    private void warnReflectionFailure(Exception e) {
+        if (warnedReflectionFailure) return;
+        warnedReflectionFailure = true;
+
+        if (e == null) {
+            Waypointer.LOGGER.warn(
+                    "Unable to override /wp suggestions: Brigadier node maps were unavailable");
+        } else {
+            Waypointer.LOGGER.warn("Unable to override /wp suggestions", e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, CommandNode<?>> commandNodeMap(CommandNode<?> node, Field field)
+            throws IllegalAccessException {
+        return (Map<String, CommandNode<?>>) field.get(node);
+    }
+
+    private static void removeChild(CommandNode<?> parent, String name) throws IllegalAccessException {
+        commandNodeMap(parent, CHILDREN_FIELD).remove(name);
+        commandNodeMap(parent, LITERALS_FIELD).remove(name);
+        commandNodeMap(parent, ARGUMENTS_FIELD).remove(name);
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static CommandNode<ClientSuggestionProvider> copyAsSuggestionNode(CommandNode<?> origin) {
+        ArgumentBuilder builder = origin.createBuilder();
+        builder.requires(source -> true);
+        if (builder.getCommand() != null) {
+            builder.executes(ctx -> 0);
+        }
+
+        CommandNode copy = builder.build();
+        for (CommandNode child : origin.getChildren()) {
+            copy.addChild(copyAsSuggestionNode(child));
+        }
+        return copy;
+    }
+
+    private static Field findCommandNodeMap(String name) {
+        try {
+            Field field = CommandNode.class.getDeclaredField(name);
+            field.setAccessible(true);
+            return field;
+        } catch (ReflectiveOperationException | RuntimeException e) {
+            Waypointer.LOGGER.warn("Unable to access Brigadier CommandNode.{}", name, e);
+            return null;
+        }
+    }
+}

--- a/src/client/java/dev/ethan/waypointer/commands/WaypointerCommands.java
+++ b/src/client/java/dev/ethan/waypointer/commands/WaypointerCommands.java
@@ -82,6 +82,7 @@ public final class WaypointerCommands {
             register(dispatcher, "wptr");
             register(dispatcher, "wp");
         });
+        new WaypointerCommandSuggestionOverride().install();
     }
 
     private void register(CommandDispatcher<FabricClientCommandSource> d, String root) {

--- a/src/client/java/dev/ethan/waypointer/progression/ProximityTracker.java
+++ b/src/client/java/dev/ethan/waypointer/progression/ProximityTracker.java
@@ -47,12 +47,17 @@ public final class ProximityTracker {
         // player's preferred feel is baked in from day one.
         boolean loop = config.restartRouteWhenComplete();
         boolean globalSkipAhead = config.skipAheadMechanicEnabled();
+        boolean hideReachedStatic = config.hideReachedStaticWaypointsUntilCycleComplete();
         for (WaypointGroup group : manager.activeGroups()) {
             // Temp-only bucket groups don't participate in progression -- they hold
             // ad-hoc markers whose own expiry modes handle cleanup. Running proximity
             // on them would re-enter the "advance past waypoint" logic on a container
             // whose order is meaningless.
             if (group.temp()) continue;
+            if (hideReachedStatic && group.loadMode() == WaypointGroup.LoadMode.STATIC) {
+                markReachedStaticWaypoints(group, px, py, pz);
+                continue;
+            }
             // Group-level skip-ahead gate. When a waypoint was just added the
             // group's flag is flipped off (see the feature wiring in
             // WaypointerConfig#disableGroupSkipAheadOnWaypointAdd); we respect
@@ -61,6 +66,30 @@ public final class ProximityTracker {
             boolean allowSkip = globalSkipAhead && group.skipAheadEnabled();
             advanceIfReached(group, px, py, pz, loop, allowSkip);
         }
+    }
+
+    /**
+     * Static groups are unordered map overlays, so reach tracking scans every
+     * waypoint instead of advancing a single route index. Reaching the final
+     * hidden marker resets the group immediately (handled by WaypointGroup),
+     * making the next cycle visible without requiring a reconnect or command.
+     */
+    public static boolean markReachedStaticWaypoints(WaypointGroup group,
+                                                     double px, double py, double pz) {
+        boolean changed = false;
+        for (int i = 0; i < group.size(); i++) {
+            if (group.isStaticWaypointReached(i)) continue;
+
+            Waypoint w = group.get(i);
+            double r = group.effectiveRadius(w);
+            double dx = (w.x() + 0.5) - px;
+            double dy = (w.y() + 0.5) - py;
+            double dz = (w.z() + 0.5) - pz;
+            if (dx * dx + dy * dy + dz * dz <= r * r) {
+                changed |= group.markStaticWaypointReached(i);
+            }
+        }
+        return changed;
     }
 
     /**

--- a/src/client/java/dev/ethan/waypointer/progression/ProximityTracker.java
+++ b/src/client/java/dev/ethan/waypointer/progression/ProximityTracker.java
@@ -86,7 +86,12 @@ public final class ProximityTracker {
             double dy = (w.y() + 0.5) - py;
             double dz = (w.z() + 0.5) - pz;
             if (dx * dx + dy * dy + dz * dz <= r * r) {
-                changed |= group.markStaticWaypointReached(i);
+                if (group.markStaticWaypointReached(i)) {
+                    changed = true;
+                    if (group.consumeStaticCycleJustCompleted()) {
+                        break;
+                    }
+                }
             }
         }
         return changed;

--- a/src/client/java/dev/ethan/waypointer/render/WaypointRenderer.java
+++ b/src/client/java/dev/ethan/waypointer/render/WaypointRenderer.java
@@ -28,10 +28,14 @@ import org.joml.Vector3fc;
  * Draws every active waypoint as an outlined cube (world-space) plus a 2D label
  * anchored over it (screen-space).
  *
- * State-driven coloring:
+ * State-driven coloring in SEQUENCE mode:
  *   - Completed (i < currentIndex): dim alpha, hidden if its FLAG_HIDE_BEACON is set.
  *   - Current   (i == currentIndex): full alpha, label always visible.
  *   - Upcoming  (i >  currentIndex): mid alpha.
+ *
+ * STATIC groups intentionally draw every waypoint as current/full-alpha. Their
+ * purpose is to act as a persistent map overlay, so proximity progress should
+ * not make markers fade just because the player walked near them.
  *
  * <p><b>Why two render paths?</b> Minecraft 1.21.9 reworked world-space text to go
  * through an {@code OrderedSubmitNodeCollector} queue, and neither the old
@@ -193,8 +197,10 @@ public final class WaypointRenderer implements HudElement {
         float beaconOpacity = (float) config.beaconOpacity();
 
         g.forEachVisibleIndex(i -> {
+            if (shouldHideStaticReached(g, i)) return;
+
             Waypoint w = g.get(i);
-            State state = stateFor(i, currentIdx);
+            State state = stateFor(g, i, currentIdx);
             if (state == State.COMPLETED && (!showCompleted || w.hasFlag(Waypoint.FLAG_HIDE_BEACON))) return;
 
             float alpha = alphaFor(g, state) * beaconOpacity;
@@ -244,8 +250,10 @@ public final class WaypointRenderer implements HudElement {
         boolean colorizeNames = config.matchWaypointTextToWaypointColor();
 
         group.forEachVisibleIndex(i -> {
+            if (shouldHideStaticReached(group, i)) return;
+
             Waypoint w = group.get(i);
-            State state = stateFor(i, currentIdx);
+            State state = stateFor(group, i, currentIdx);
             if (state == State.COMPLETED && (!showCompleted || w.hasFlag(Waypoint.FLAG_HIDE_BEACON))) return;
             if (w.hasFlag(Waypoint.FLAG_HIDE_NAME)) return;
 
@@ -327,10 +335,17 @@ public final class WaypointRenderer implements HudElement {
                 : "#" + (i + 1);
     }
 
-    private static State stateFor(int i, int currentIdx) {
+    private static State stateFor(WaypointGroup group, int i, int currentIdx) {
+        if (group.loadMode() == WaypointGroup.LoadMode.STATIC) return State.CURRENT;
         if (i < currentIdx) return State.COMPLETED;
         if (i == currentIdx) return State.CURRENT;
         return State.UPCOMING;
+    }
+
+    private boolean shouldHideStaticReached(WaypointGroup group, int index) {
+        return config.hideReachedStaticWaypointsUntilCycleComplete()
+                && group.loadMode() == WaypointGroup.LoadMode.STATIC
+                && group.isStaticWaypointReached(index);
     }
 
     private float alphaFor(WaypointGroup group, State state) {

--- a/src/client/java/dev/ethan/waypointer/screen/ConfigScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/ConfigScreen.java
@@ -118,6 +118,12 @@ public final class ConfigScreen extends Screen {
                 "When on, waypoints you have already reached still draw (usually faded).\n"
               + "When off, completed stops disappear from the world HUD.");
         y2 += rowH;
+        addBoolRow(col2, y2, "Hide reached static waypoints",
+                config.hideReachedStaticWaypointsUntilCycleComplete(),
+                config::setHideReachedStaticWaypointsUntilCycleComplete,
+                "For STATIC groups, hide each waypoint when you enter its reach radius.\n"
+              + "After every waypoint in the group has been reached, all of them show again.");
+        y2 += rowH;
         addBoolRow(col2, y2, "Chat coord detection", config.chatCoordDetection(), config::setChatCoordDetection,
                 "Scans incoming chat for coordinates and can offer quick-add flows for\n"
               + "temporary or permanent waypoints (no effect when chat has no coords).");

--- a/src/client/java/dev/ethan/waypointer/screen/DebugInspectScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/DebugInspectScreen.java
@@ -471,7 +471,7 @@ public final class DebugInspectScreen extends Screen {
         rows.add(new Row.KV("Input",       d.inputChars() + " chars"));
         rows.add(new Row.KVDim("Prefix",   d.magic()));
         rows.add(new Row.KV("Payload",     d.payloadChars() + " chars"));
-        rows.add(new Row.KVDim("Encoding", "ASCII base-85"));
+        rows.add(new Row.KVDim("Encoding", d.textEncoding()));
         rows.add(new Row.KV("Compressed",  d.compressedBytes() + " bytes"));
         rows.add(new Row.KV("Raw body",    d.rawBodyBytes() + " bytes"));
         rows.add(new Row.KV("Density",     String.format(Locale.ROOT, "%.2f chars / raw byte", d.charsPerRawByte())));
@@ -504,7 +504,8 @@ public final class DebugInspectScreen extends Screen {
 
             rows.add(new Row.KV("Zone",          gd.zoneId().isEmpty() ? "(none)" : gd.zoneId()));
             rows.add(new Row.KV("Group flags",   formatByteFull(gd.groupFlagsByte())));
-            rows.add(new Row.Bit(0, "enabled",      gd.enabled()));
+            rows.add(new Row.Bit(0, d.version() == 2 ? "enabled" : "bodyless",
+                    d.version() == 2 ? gd.enabled() : (gd.groupFlagsByte() & 1) != 0));
             rows.add(new Row.Bit(1, "gradientAuto", gd.gradientAuto()));
             rows.add(new Row.Bit(2, "loadSequence", gd.loadSequence()));
             rows.add(new Row.Bit(3, "customRadius", gd.customRadius()));

--- a/src/client/java/dev/ethan/waypointer/screen/ExportScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/ExportScreen.java
@@ -65,8 +65,8 @@ public final class ExportScreen extends Screen {
      * /msg}, and friends silently fail when the export is too large.
      *
      * Chat INPUT is measured in characters (256 chars fit in the textbox),
-     * but the command wire packet is measured in bytes. v2 uses a base-85
-     * ASCII alphabet (1 UTF-8 byte per char), so the char-count and
+     * but the command wire packet is measured in bytes. The native codec uses
+     * a printable ASCII alphabet (1 UTF-8 byte per char), so the char-count and
      * wire-byte-count lines now report the same number for the body -- the
      * gap between them is just {@code WP:} plus any chat-framing. Keeping
      * both lines in the UI still makes sense: the chat-textbox cap is a
@@ -358,7 +358,7 @@ public final class ExportScreen extends Screen {
      * Line 2 answers "can I paste this into chat?" -- the chat textbox
      * caps at 256 characters regardless of bytes.
      *
-     * With the v2 base-85 alphabet (1 byte/char) the two caps coincide on
+     * With the ASCII text codec (1 byte/char) the two caps coincide on
      * the body itself, but command framing ({@code "/pc "} etc.) still
      * puts the command cap first. When a command won't fit but chat will,
      * we point that out inline so the user doesn't have to cross-reference

--- a/src/main/java/dev/ethan/waypointer/chat/CodecScanner.java
+++ b/src/main/java/dev/ethan/waypointer/chat/CodecScanner.java
@@ -1,6 +1,6 @@
 package dev.ethan.waypointer.chat;
 
-import dev.ethan.waypointer.codec.AsciiPackCodec;
+import dev.ethan.waypointer.codec.AsciiStreamCodec;
 import dev.ethan.waypointer.codec.WaypointCodec;
 
 import java.util.ArrayList;
@@ -17,12 +17,12 @@ import java.util.List;
  *
  *   - A match must start with {@link WaypointCodec#MAGIC}.
  *   - The character immediately before the magic (if any) must be outside the
- *     base-85 alphabet. The alphabet is printable ASCII, so without this
+ *     codec alphabet. The alphabet is printable ASCII, so without this
  *     boundary rule a chat line like {@code "helloWP:stuff"} would fire a
  *     false [Invalid Waypointer Code] pill on every mid-word substring. The
  *     old CJK layer implicitly had this property because its alphabet sat
  *     outside the ordinary ASCII range.
- *   - Body characters are extended greedily while they fall in the base-85
+ *   - Body characters are extended greedily while they fall in the codec
  *     alphabet.
  *   - The body must be at least {@value #MIN_BODY} characters so a bare magic
  *     prefix surrounded by ordinary text isn't flagged as a codec.
@@ -30,7 +30,7 @@ import java.util.List;
  * Intentional non-goal: we don't validate the payload here. A malformed codec
  * still gets flagged; the actual decode happens when the user clicks the import
  * chip and {@link WaypointCodec#decode} surfaces any errors. Validating at scan
- * time would run deflate + base-85 decode on every chat line, which is wasteful.
+ * time would run text decode + deflate on every chat line, which is wasteful.
  */
 public final class CodecScanner {
 
@@ -56,7 +56,7 @@ public final class CodecScanner {
 
             int bodyStart = i + WaypointCodec.MAGIC.length();
             int bodyEnd = bodyStart;
-            while (bodyEnd < message.length() && AsciiPackCodec.isAlphabetChar(message.charAt(bodyEnd))) {
+            while (bodyEnd < message.length() && AsciiStreamCodec.isAlphabetChar(message.charAt(bodyEnd))) {
                 bodyEnd++;
             }
             int bodyLen = bodyEnd - bodyStart;
@@ -77,7 +77,7 @@ public final class CodecScanner {
 
     /**
      * True iff position {@code i} is at the start of the string or the
-     * preceding character is not part of the base-85 alphabet. Rejects
+     * preceding character is not part of the codec alphabet. Rejects
      * mid-word and URL-embedded false positives without a heavy regex.
      *
      * The rule is intentionally stricter than "is not alphanumeric" because
@@ -88,6 +88,6 @@ public final class CodecScanner {
      */
     private static boolean isAtWordBoundary(String s, int i) {
         if (i == 0) return true;
-        return !AsciiPackCodec.isAlphabetChar(s.charAt(i - 1));
+        return !AsciiStreamCodec.isAlphabetChar(s.charAt(i - 1));
     }
 }

--- a/src/main/java/dev/ethan/waypointer/codec/AsciiStreamCodec.java
+++ b/src/main/java/dev/ethan/waypointer/codec/AsciiStreamCodec.java
@@ -1,0 +1,138 @@
+package dev.ethan.waypointer.codec;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+
+/**
+ * Trailer-free binary-to-text codec for Waypointer chat payloads.
+ *
+ * <p>The alphabet is every printable one-byte ASCII character except space and
+ * {@code '.'}. Space would split/collapse during chat paste, and the period has
+ * repeatedly tripped Hypixel's URL-shaped advertising filter. Keeping the
+ * alphabet entirely below {@code 0x80} preserves the important invariant that
+ * one visible character is one UTF-8 wire byte.
+ *
+ * <p>The bit-packing is the basE91 streaming scheme generalized to a 93-symbol
+ * alphabet. It emits 13 or 14 source bits per two output characters depending
+ * on whether the current 14-bit value fits in {@code 93^2}. Unlike the old
+ * 4-byte/5-char base-85 packer, this has no pad trailer and round-trips arbitrary
+ * byte arrays exactly.
+ */
+public final class AsciiStreamCodec {
+
+    private static final char[] ALPHABET = (
+            "!\"#$%&'()*+,-/0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+          + "[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+    ).toCharArray();
+
+    private static final int BASE = ALPHABET.length;
+    private static final int TWO_CHAR_VALUES = BASE * BASE;
+    private static final int THIRTEEN_BITS = 1 << 13;
+    private static final int FOURTEEN_BIT_THRESHOLD = TWO_CHAR_VALUES - THIRTEEN_BITS - 1;
+
+    private static final int[] DECODE_TABLE = new int[128];
+
+    static {
+        Arrays.fill(DECODE_TABLE, -1);
+        for (int i = 0; i < ALPHABET.length; i++) {
+            DECODE_TABLE[ALPHABET[i]] = i;
+        }
+    }
+
+    private AsciiStreamCodec() {}
+
+    public static String encode(byte[] input) {
+        if (input == null) throw new IllegalArgumentException("null input");
+        if (input.length == 0) return "";
+
+        StringBuilder out = new StringBuilder((input.length * 123 + 99) / 100);
+        long bitBuffer = 0L;
+        int bitCount = 0;
+
+        for (byte value : input) {
+            bitBuffer |= (long) (value & 0xFF) << bitCount;
+            bitCount += 8;
+
+            if (bitCount > 13) {
+                int encoded = (int) (bitBuffer & (THIRTEEN_BITS - 1));
+                if (encoded > FOURTEEN_BIT_THRESHOLD) {
+                    bitBuffer >>>= 13;
+                    bitCount -= 13;
+                } else {
+                    encoded = (int) (bitBuffer & ((1 << 14) - 1));
+                    bitBuffer >>>= 14;
+                    bitCount -= 14;
+                }
+                out.append(ALPHABET[encoded % BASE]);
+                out.append(ALPHABET[encoded / BASE]);
+            }
+        }
+
+        if (bitCount > 0) {
+            out.append(ALPHABET[(int) (bitBuffer % BASE)]);
+            if (bitCount > 7 || bitBuffer >= BASE) {
+                out.append(ALPHABET[(int) (bitBuffer / BASE)]);
+            }
+        }
+        return out.toString();
+    }
+
+    public static byte[] decode(String input) {
+        if (input == null) throw new IllegalArgumentException("null input");
+        if (input.isEmpty()) return new byte[0];
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream(input.length());
+        long bitBuffer = 0L;
+        int bitCount = 0;
+        int pending = -1;
+
+        for (int i = 0; i < input.length(); i++) {
+            int digit = digitOf(input.charAt(i));
+            if (digit < 0) {
+                throw new IllegalArgumentException(
+                        "invalid character at " + i + ": '" + input.charAt(i) + "'");
+            }
+
+            if (pending < 0) {
+                pending = digit;
+                continue;
+            }
+
+            int encoded = pending + digit * BASE;
+            bitBuffer |= (long) encoded << bitCount;
+            bitCount += (encoded & (THIRTEEN_BITS - 1)) > FOURTEEN_BIT_THRESHOLD ? 13 : 14;
+
+            while (bitCount >= 8) {
+                out.write((int) (bitBuffer & 0xFF));
+                bitBuffer >>>= 8;
+                bitCount -= 8;
+            }
+            pending = -1;
+        }
+
+        if (pending >= 0) {
+            out.write((int) ((bitBuffer | ((long) pending << bitCount)) & 0xFF));
+        }
+        return out.toByteArray();
+    }
+
+    public static boolean isValidBody(String s) {
+        if (s == null || s.isEmpty()) return false;
+        for (int i = 0; i < s.length(); i++) {
+            if (!isAlphabetChar(s.charAt(i))) return false;
+        }
+        return true;
+    }
+
+    public static boolean isAlphabetChar(char c) {
+        return c < DECODE_TABLE.length && DECODE_TABLE[c] >= 0;
+    }
+
+    public static int alphabetSize() {
+        return BASE;
+    }
+
+    private static int digitOf(char c) {
+        return c < DECODE_TABLE.length ? DECODE_TABLE[c] : -1;
+    }
+}

--- a/src/main/java/dev/ethan/waypointer/codec/CodecZoneDictionary.java
+++ b/src/main/java/dev/ethan/waypointer/codec/CodecZoneDictionary.java
@@ -1,0 +1,142 @@
+package dev.ethan.waypointer.codec;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Tiny built-in dictionary for zone IDs that are common in shared waypoint routes.
+ *
+ * <p>The coarse island coverage is derived from Skyblocker's
+ * {@code de.hysky.skyblocker.utils.Location} enum, which mirrors Hypixel's
+ * location IDs and friendly names:
+ * https://github.com/SkyblockerMod/Skyblocker/blob/master/src/main/java/de/hysky/skyblocker/utils/Location.java
+ *
+ * <p>Waypointer stores a few friendlier canonical IDs (for example
+ * {@code the_park} instead of Skyblocker's raw {@code foraging_1}), so this
+ * dictionary includes those aliases plus Waypointer-only floor/sub-area IDs.
+ * Changing this table changes the wire format: bump {@link WaypointCodec}'s
+ * wire version if any entry is added, removed, or reordered.
+ */
+public final class CodecZoneDictionary {
+
+    private static final String[] IDS = {
+            "hub",
+            "private_island",
+            "dungeon_hub",
+            "the_park",
+            "the_farming_isles",
+            "spiders_den",
+            "the_end",
+            "crimson_isle",
+            "kuudra",
+            "gold_mine",
+            "deep_caverns",
+            "dwarven_mines",
+            "crystal_hollows",
+            "garden",
+            "rift",
+            "galatea",
+            "backwater_bayou",
+            "winter",
+            "dark_auction",
+            "dungeon",
+            "dungeon_f1",
+            "dungeon_f2",
+            "dungeon_f3",
+            "dungeon_f4",
+            "dungeon_f5",
+            "dungeon_f6",
+            "dungeon_f7",
+            "dungeon_m1",
+            "dungeon_m2",
+            "dungeon_m3",
+            "dungeon_m4",
+            "dungeon_m5",
+            "dungeon_m6",
+            "dungeon_m7",
+
+            // Raw Skyblocker/Hypixel location IDs whose Waypointer storage IDs differ.
+            "dynamic",
+            "farming_1",
+            "foraging_1",
+            "foraging_2",
+            "combat_1",
+            "combat_2",
+            "combat_3",
+            "mining_1",
+            "mining_2",
+            "mining_3",
+            "fishing_1",
+            "mineshaft",
+
+            // Waypointer refinements beyond Skyblocker's coarse Location enum.
+            "great_glacite_lake",
+            "glacite_tunnels",
+            "dwarven_base_camp",
+            "mineshaft_unknown",
+            "mineshaft_topaz_1",
+            "mineshaft_topaz_2",
+            "mineshaft_sapphire_1",
+            "mineshaft_sapphire_2",
+            "mineshaft_amethyst_1",
+            "mineshaft_amethyst_2",
+            "mineshaft_amber_1",
+            "mineshaft_amber_2",
+            "mineshaft_jade_1",
+            "mineshaft_jade_2",
+            "mineshaft_ruby_1",
+            "mineshaft_ruby_2",
+            "mineshaft_ruby_crystal",
+            "mineshaft_onyx_1",
+            "mineshaft_onyx_2",
+            "mineshaft_onyx_crystal",
+            "mineshaft_aquamarine_1",
+            "mineshaft_aquamarine_2",
+            "mineshaft_aquamarine_crystal",
+            "mineshaft_citrine_1",
+            "mineshaft_citrine_2",
+            "mineshaft_citrine_crystal",
+            "mineshaft_peridot_1",
+            "mineshaft_peridot_2",
+            "mineshaft_peridot_crystal",
+            "mineshaft_jasper",
+            "mineshaft_jasper_crystal",
+            "mineshaft_opal",
+            "mineshaft_opal_crystal",
+            "mineshaft_titanium",
+            "mineshaft_umber",
+            "mineshaft_tungsten",
+            "mineshaft_vanguard",
+            "mineshaft_littlefoots_den"
+    };
+
+    private static final Map<String, Integer> INDEX_BY_ID = new HashMap<>();
+
+    static {
+        for (int i = 0; i < IDS.length; i++) {
+            String previous = IDS[i] == null ? null : IDS[i].intern();
+            if (previous == null || previous.isEmpty()) {
+                throw new IllegalStateException("blank zone dictionary entry at " + i);
+            }
+            Integer old = INDEX_BY_ID.put(previous, i);
+            if (old != null) {
+                throw new IllegalStateException("duplicate zone dictionary entry: " + previous);
+            }
+            IDS[i] = previous;
+        }
+    }
+
+    private CodecZoneDictionary() {}
+
+    public static int indexOf(String id) {
+        Integer index = INDEX_BY_ID.get(id == null ? "" : id);
+        return index == null ? -1 : index;
+    }
+
+    public static String idAt(int index) {
+        if (index < 0 || index >= IDS.length) {
+            throw new IllegalArgumentException("zone dictionary OOB: " + index);
+        }
+        return IDS[index];
+    }
+}

--- a/src/main/java/dev/ethan/waypointer/codec/DecodeDebug.java
+++ b/src/main/java/dev/ethan/waypointer/codec/DecodeDebug.java
@@ -17,8 +17,9 @@ import java.util.List;
  * @param rawInput         Original input string, untrimmed.
  * @param inputChars       {@code rawInput.length()}.
  * @param magic            Magic prefix that matched (always {@link WaypointCodec#MAGIC}).
- * @param payloadChars     Chars after the magic prefix (the base-85-encoded body).
- * @param compressedBytes  Byte count after base-85 decoding, before inflate.
+ * @param payloadChars     Chars after the magic prefix.
+ * @param textEncoding     Text layer used before DEFLATE.
+ * @param compressedBytes  Byte count after text decoding, before inflate.
  * @param rawBodyBytes     Byte count after inflate -- size of the binary body.
  * @param charsPerRawByte  {@code inputChars / rawBodyBytes}; overall density ratio.
  * @param headerByte       First byte of the raw body: version in low nibble, flags in high nibble.
@@ -42,6 +43,7 @@ public record DecodeDebug(
         int inputChars,
         String magic,
         int payloadChars,
+        String textEncoding,
         int compressedBytes,
         int rawBodyBytes,
         double charsPerRawByte,

--- a/src/main/java/dev/ethan/waypointer/codec/WaypointCodec.java
+++ b/src/main/java/dev/ethan/waypointer/codec/WaypointCodec.java
@@ -11,9 +11,11 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.zip.DataFormatException;
 import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
@@ -24,7 +26,7 @@ import java.util.zip.Inflater;
  *
  * Wire format:
  *
- *     WP:<base-85 body of raw DEFLATE(bin)>
+ *     WP:<base-93 body of raw DEFLATE(bin)>
  *
  * The {@code WP:} prefix is just a scanner anchor; the schema version lives
  * in the low nibble of the first body byte (see below). Keeping the version
@@ -33,14 +35,15 @@ import java.util.zip.Inflater;
  *
  * The body is raw DEFLATE (no gzip header/trailer) compressed with a preset
  * dictionary of Hypixel zone ids and waypoint-name fragments, then encoded
- * with {@link AsciiPackCodec} (a Z85-derived base-85 alphabet with
- * {@code '.'} swapped for {@code ';'} to avoid Hypixel's advertising filter).
+ * with {@link AsciiStreamCodec} (a trailer-free printable-ASCII stream codec
+ * that excludes {@code '.'} to avoid Hypixel's advertising filter).
  * Each output character is a single UTF-8 byte of printable ASCII that
  * survives Minecraft chat validation, paste, and the ad-detection heuristic.
  * The earlier CJK base-16384 alphabet (v1) visually fit more characters into
  * the 256-CHAR chat textbox, but Minecraft's 256-BYTE command-packet cap is
- * the constraint that actually drops messages; base-85 carries ~37% more
- * compressed bytes through that envelope (6.41 bits/UTF-8-byte vs 4.67).
+ * the constraint that actually drops messages; printable ASCII carries more
+ * compressed bytes through that envelope because every character costs one
+ * UTF-8 byte.
  *
  * Binary body:
  *
@@ -59,9 +62,9 @@ import java.util.zip.Inflater;
  *     varint groupCount
  *     per group:
  *       varint    nameIdx          (always written; empty if omitted)
- *       varint    zoneIdIdx
+ *       varint    zoneRef          (known-zone dictionary ref or pool index)
  *       u8        groupFlags
- *                   bit 0 = reserved (enabled-state); encoder writes 0, decoder ignores
+ *                   bit 0 = bodyless waypoint records (no per-point flag bytes)
  *                   bit 1 = gradientAuto       (else MANUAL)
  *                   bit 2 = loadSequence       (else STATIC)
  *                   bit 3 = customDefaultRadius (else 3.0)
@@ -121,18 +124,20 @@ public final class WaypointCodec {
      * scanner. Version 0 is reserved as "invalid" so a corrupted header byte
      * can't accidentally decode as an older schema.
      *
-     * v2 (current): base-85 outer alphabet (Z85 with {@code '.'} swapped for
+     * v3 (current): base-93 streaming outer alphabet + adaptive waypoint-name
+     *               pooling + bodyless waypoint groups.
+     * v2 (retired): base-85 outer alphabet (Z85 with {@code '.'} swapped for
      *               {@code ';'} to dodge Hypixel's advertising filter) +
      *               FIT_COMPACT coord mode.
      * v1 (retired): CJK base-16384 alphabet; same binary body shape.
      *
-     * v1 payloads cannot decode here -- the base-85 body-decode step rejects
-     * the CJK characters first, and even a hand-crafted v1 binary body would
-     * hit the version-guard in readBody. We don't maintain a dual-decode path:
-     * users regenerate exports after upgrading, and the scanner still ignores
-     * non-alphabet-body matches so no stale chat lines go red.
+     * v2 payloads still decode through a legacy path so existing shared routes
+     * keep importing after the v3 density upgrade. v1 payloads remain retired:
+     * the current scanner/text codecs reject the CJK body before the binary
+     * version guard can run.
      */
-    static final int WIRE_VERSION = 2;
+    static final int WIRE_VERSION = 3;
+    private static final int LEGACY_V2_WIRE_VERSION = 2;
     private static final int HEADER_VERSION_MASK = 0x0F;
     /** Export flags occupy the high nibble so the version field can grow toward it if we ever need more than 4 bits. */
     private static final int HEADER_FLAG_NAMES = 1 << 4;
@@ -148,9 +153,11 @@ public final class WaypointCodec {
      */
     private static final int MAX_LABEL_BYTES = 256;
 
-    // Bit 0 (previously "enabled-state") is reserved: the encoder zeroes it,
-    // the decoder masks it off. Keeping the slot lets us evolve the group-flags
-    // byte later without bumping the version.
+    /**
+     * Bit 0: no per-waypoint body bytes follow the coord block. Used when every
+     * waypoint would otherwise write a zero flag byte.
+     */
+    private static final int GROUP_FLAG_BODYLESS_WAYPOINTS = 1;
     private static final int GROUP_FLAG_GRAD_AUTO     = 1 << 1;
     private static final int GROUP_FLAG_LOAD_SEQUENCE = 1 << 2;
     private static final int GROUP_FLAG_CUSTOM_RADIUS = 1 << 3;
@@ -180,6 +187,10 @@ public final class WaypointCodec {
     private static final int WP_FLAG_HAS_COLOR  = 1 << 1;
     private static final int WP_FLAG_HAS_RADIUS = 1 << 2;
     private static final int WP_FLAG_EXTENDED   = 1 << 3;
+    /** Set together with HAS_NAME when the UTF-8 name follows inline instead of a pool index. */
+    private static final int WP_FLAG_NAME_INLINE = 1 << 4;
+    private static final String TEXT_ENCODING_V3 = "ASCII base-93 stream";
+    private static final String TEXT_ENCODING_V2 = "ASCII base-85";
 
     private WaypointCodec() {}
 
@@ -353,7 +364,7 @@ public final class WaypointCodec {
         try {
             byte[] raw = writeBody(groups, opts, mode);
             byte[] compressed = deflate(raw);
-            return MAGIC + AsciiPackCodec.encode(compressed);
+            return MAGIC + AsciiStreamCodec.encode(compressed);
         } catch (IOException e) {
             throw new IllegalStateException("codec encode failed", e);
         }
@@ -379,13 +390,15 @@ public final class WaypointCodec {
         }
         String payload = trimmed.substring(MAGIC.length());
         try {
-            byte[] compressed = AsciiPackCodec.decode(payload);
-            byte[] raw = inflate(compressed);
-            DecodedHeader headerOut = new DecodedHeader();
-            List<WaypointGroup> groups = readBody(raw, null, headerOut);
-            return new Decoded(groups, headerOut.label);
+            return decodePayloadV3(payload);
         } catch (IOException | IllegalArgumentException e) {
-            throw new IllegalArgumentException("codec decode failed: " + e.getMessage(), e);
+            try {
+                return decodePayloadV2(payload);
+            } catch (IOException | IllegalArgumentException legacy) {
+                throw new IllegalArgumentException(
+                        "codec decode failed: v3=" + e.getMessage()
+                                + "; v2=" + legacy.getMessage(), legacy);
+            }
         }
     }
 
@@ -396,7 +409,7 @@ public final class WaypointCodec {
      *
      * <p>Implemented as "try to fully decode and discard" because every
      * corruption surface the wire format cares about lives in the decoder
-     * path: the CJK alphabet check, the DEFLATE bit-stream self-check (raw
+     * path: the ASCII alphabet check, the DEFLATE bit-stream self-check (raw
      * DEFLATE doesn't carry a CRC, but any corrupted token sequence surfaces
      * as a {@code DataFormatException} on inflate), the header-version guard,
      * and the per-field length sanity scattered through {@link #readBody}.
@@ -434,18 +447,8 @@ public final class WaypointCodec {
         String trimmed = text.trim();
         if (!trimmed.startsWith(MAGIC)) return Optional.empty();
         String payload = trimmed.substring(MAGIC.length());
-        try {
-            byte[] compressed = AsciiPackCodec.decode(payload);
-            byte[] raw = inflate(compressed);
-            DataInputStream in = new DataInputStream(new ByteArrayInputStream(raw));
-            int header = in.readUnsignedByte();
-            if ((header & HEADER_VERSION_MASK) != WIRE_VERSION) return Optional.empty();
-            if ((header & HEADER_FLAG_LABEL) == 0) return Optional.empty();
-            String label = readLabel(in);
-            return label.isEmpty() ? Optional.empty() : Optional.of(label);
-        } catch (Exception ignored) {
-            return Optional.empty();
-        }
+        Optional<String> v3 = peekLabel(payload, true);
+        return v3.isPresent() ? v3 : peekLabel(payload, false);
     }
 
     /** Result of {@link #decodeFull(String)}: the groups plus whatever label the sender stamped on. */
@@ -471,20 +474,70 @@ public final class WaypointCodec {
         }
         String payload = trimmed.substring(MAGIC.length());
         try {
-            byte[] compressed = AsciiPackCodec.decode(payload);
-            byte[] raw = inflate(compressed);
-            DebugCapture cap = new DebugCapture();
-            List<WaypointGroup> groups = readBody(raw, cap, null);
-            long elapsed = System.nanoTime() - t0;
-            return cap.build(text, payload, compressed, raw, groups, elapsed);
+            return debugDecodePayload(text, payload, t0, true);
         } catch (IOException | IllegalArgumentException e) {
-            throw new IllegalArgumentException("codec debug decode failed: " + e.getMessage(), e);
+            try {
+                return debugDecodePayload(text, payload, t0, false);
+            } catch (IOException | IllegalArgumentException legacy) {
+                throw new IllegalArgumentException(
+                        "codec debug decode failed: v3=" + e.getMessage()
+                                + "; v2=" + legacy.getMessage(), legacy);
+            }
         }
     }
 
     /** True iff {@code s} looks like a Waypointer export (prefix check only, does not validate payload). */
     public static boolean isCodecString(String s) {
         return s != null && s.trim().startsWith(MAGIC);
+    }
+
+    private static Decoded decodePayloadV3(String payload) throws IOException {
+        byte[] compressed = AsciiStreamCodec.decode(payload);
+        byte[] raw = inflate(compressed);
+        DecodedHeader headerOut = new DecodedHeader();
+        List<WaypointGroup> groups = readBody(raw, null, headerOut, WIRE_VERSION, false);
+        return new Decoded(groups, headerOut.label);
+    }
+
+    private static Decoded decodePayloadV2(String payload) throws IOException {
+        byte[] compressed = AsciiPackCodec.decode(payload);
+        byte[] raw = inflate(compressed);
+        DecodedHeader headerOut = new DecodedHeader();
+        List<WaypointGroup> groups = readBody(raw, null, headerOut, LEGACY_V2_WIRE_VERSION, true);
+        return new Decoded(groups, headerOut.label);
+    }
+
+    private static Optional<String> peekLabel(String payload, boolean currentVersion) {
+        try {
+            byte[] compressed = currentVersion
+                    ? AsciiStreamCodec.decode(payload)
+                    : AsciiPackCodec.decode(payload);
+            byte[] raw = inflate(compressed);
+            DataInputStream in = new DataInputStream(new ByteArrayInputStream(raw));
+            int header = in.readUnsignedByte();
+            int expectedVersion = currentVersion ? WIRE_VERSION : LEGACY_V2_WIRE_VERSION;
+            if ((header & HEADER_VERSION_MASK) != expectedVersion) return Optional.empty();
+            if ((header & HEADER_FLAG_LABEL) == 0) return Optional.empty();
+            String label = readLabel(in);
+            return label.isEmpty() ? Optional.empty() : Optional.of(label);
+        } catch (Exception ignored) {
+            return Optional.empty();
+        }
+    }
+
+    private static DecodeDebug debugDecodePayload(String input, String payload, long startNanos,
+                                                  boolean currentVersion)
+            throws IOException {
+        byte[] compressed = currentVersion
+                ? AsciiStreamCodec.decode(payload)
+                : AsciiPackCodec.decode(payload);
+        byte[] raw = inflate(compressed);
+        DebugCapture cap = new DebugCapture();
+        int expectedVersion = currentVersion ? WIRE_VERSION : LEGACY_V2_WIRE_VERSION;
+        List<WaypointGroup> groups = readBody(raw, cap, null, expectedVersion, !currentVersion);
+        long elapsed = System.nanoTime() - startNanos;
+        String encoding = currentVersion ? TEXT_ENCODING_V3 : TEXT_ENCODING_V2;
+        return cap.build(input, payload, encoding, compressed, raw, groups, elapsed);
     }
 
     // --- writer -------------------------------------------------------------------------------
@@ -500,7 +553,7 @@ public final class WaypointCodec {
         writeVarint(out, groups.size());
 
         for (WaypointGroup g : groups) {
-            writeGroup(out, g, pool, opts, mode);
+            writeGroup(buf, out, g, pool, opts, mode);
         }
         out.flush();
         return buf.toByteArray();
@@ -535,18 +588,79 @@ public final class WaypointCodec {
         return new String(bytes, StandardCharsets.UTF_8);
     }
 
+    private static void writeUtf8String(DataOutputStream out, String value) throws IOException {
+        byte[] bytes = (value == null ? "" : value).getBytes(StandardCharsets.UTF_8);
+        writeVarint(out, bytes.length);
+        out.write(bytes);
+    }
+
+    private static String readUtf8String(DataInputStream in) throws IOException {
+        int len = readVarint(in);
+        if (len < 0 || len > 1 << 20) throw new IOException("string too long: " + len);
+        byte[] bytes = in.readNBytes(len);
+        if (bytes.length != len) throw new IOException("truncated string");
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Zone refs are tagged varints: odd values point into the built-in
+     * Skyblocker-derived zone dictionary, even values point into the string pool.
+     * Unknown/custom zones therefore still round-trip exactly.
+     */
+    private static void writeZoneRef(DataOutputStream out, String zoneId, StringPool pool)
+            throws IOException {
+        int dictIndex = CodecZoneDictionary.indexOf(zoneId);
+        if (dictIndex >= 0) {
+            writeVarint(out, (dictIndex << 1) | 1);
+            return;
+        }
+        writeVarint(out, pool.index(zoneId) << 1);
+    }
+
+    private static String readZoneRef(DataInputStream in, List<String> pool) throws IOException {
+        int ref = readVarint(in);
+        if ((ref & 1) != 0) {
+            try {
+                return CodecZoneDictionary.idAt(ref >>> 1);
+            } catch (IllegalArgumentException e) {
+                throw new IOException(e.getMessage(), e);
+            }
+        }
+        return poolGet(pool, ref >>> 1);
+    }
+
     private static StringPool buildStringPool(List<WaypointGroup> groups, Options opts) {
         StringPool pool = new StringPool();
+        Map<String, Integer> waypointNameCounts = countWaypointNames(groups, opts);
+
         // Reserve index 0 for "" so group/waypoint records can omit names without a null check.
         pool.intern("");
         for (WaypointGroup g : groups) {
             pool.intern(g.name());
-            pool.intern(g.zoneId());
+            if (CodecZoneDictionary.indexOf(g.zoneId()) < 0) {
+                pool.intern(g.zoneId());
+            }
             if (opts.includeNames) {
-                for (Waypoint w : g.waypoints()) if (w.hasName()) pool.intern(w.name());
+                for (Waypoint w : g.waypoints()) {
+                    if (w.hasName() && waypointNameCounts.getOrDefault(w.name(), 0) > 1) {
+                        pool.internWaypointName(w.name());
+                    }
+                }
             }
         }
         return pool;
+    }
+
+    private static Map<String, Integer> countWaypointNames(List<WaypointGroup> groups, Options opts) {
+        Map<String, Integer> counts = new HashMap<>();
+        if (!opts.includeNames) return counts;
+
+        for (WaypointGroup g : groups) {
+            for (Waypoint w : g.waypoints()) {
+                if (w.hasName()) counts.merge(w.name(), 1, Integer::sum);
+            }
+        }
+        return counts;
     }
 
     /**
@@ -561,17 +675,13 @@ public final class WaypointCodec {
         return header;
     }
 
-    private static void writeGroup(DataOutputStream out, WaypointGroup g, StringPool pool,
+    private static void writeGroup(ByteArrayOutputStream bodySoFar, DataOutputStream out, WaypointGroup g, StringPool pool,
                                    Options opts, PackingMode mode) throws IOException {
-        writeVarint(out, pool.index(g.name()));
-        writeVarint(out, pool.index(g.zoneId()));
+        out.flush();
+        byte[] bodyPrefix = bodySoFar.toByteArray();
 
-        CoordPicked picked = pickCoordMode(g, pool, opts, mode);
+        boolean bodyless = hasEmptyWaypointBodies(g.waypoints(), pool, opts);
 
-        // Enabled-state bit (bit 0) is intentionally never set: exports describe a
-        // route to share, not the sender's toggle state. Same reason currentIndex
-        // is no longer written below.
-        //
         // When the sender opts out of group metadata, we want the recipient to
         // see the same defaults a freshly-created WaypointGroup would have:
         // AUTO gradient, STATIC load mode, default 3.0 radius. The wire bit
@@ -580,17 +690,25 @@ public final class WaypointCodec {
         // than the user's source if they had AUTO selected. The coord-mode
         // nibble is unaffected: it's a wire-level packing detail, not
         // user-visible state.
-        int groupFlags = 0;
+        int baseGroupFlags = 0;
+        if (bodyless) baseGroupFlags |= GROUP_FLAG_BODYLESS_WAYPOINTS;
         boolean customRadius = false;
         if (opts.includeGroupMeta) {
-            if (g.gradientMode() == WaypointGroup.GradientMode.AUTO) groupFlags |= GROUP_FLAG_GRAD_AUTO;
-            if (g.loadMode()     == WaypointGroup.LoadMode.SEQUENCE) groupFlags |= GROUP_FLAG_LOAD_SEQUENCE;
+            if (g.gradientMode() == WaypointGroup.GradientMode.AUTO) baseGroupFlags |= GROUP_FLAG_GRAD_AUTO;
+            if (g.loadMode()     == WaypointGroup.LoadMode.SEQUENCE) baseGroupFlags |= GROUP_FLAG_LOAD_SEQUENCE;
             customRadius = Math.abs(g.defaultRadius() - 3.0) > 0.001;
-            if (customRadius) groupFlags |= GROUP_FLAG_CUSTOM_RADIUS;
+            if (customRadius) baseGroupFlags |= GROUP_FLAG_CUSTOM_RADIUS;
         } else {
-            groupFlags |= GROUP_FLAG_GRAD_AUTO;
+            baseGroupFlags |= GROUP_FLAG_GRAD_AUTO;
         }
+
+        CoordPicked picked = pickCoordMode(g, pool, opts, mode, bodyless, baseGroupFlags,
+                customRadius, bodyPrefix);
+        int groupFlags = baseGroupFlags;
         groupFlags |= (picked.mode.wireValue << GROUP_FLAG_COORD_MODE_SHIFT) & GROUP_FLAG_COORD_MODE_MASK;
+
+        writeVarint(out, pool.index(g.name()));
+        writeZoneRef(out, g.zoneId(), pool);
         out.writeByte(groupFlags);
 
         if (customRadius) writeVarint(out, (int) Math.round(g.defaultRadius() * 10.0));
@@ -612,47 +730,53 @@ public final class WaypointCodec {
      * tight enough that the saved coord bits outweigh the preamble.
      */
     private static CoordPicked pickCoordMode(WaypointGroup g, StringPool pool, Options opts,
-                                             PackingMode mode) throws IOException {
+                                             PackingMode mode, boolean bodyless, int baseGroupFlags,
+                                             boolean customRadius, byte[] bodyPrefix) throws IOException {
         boolean fixedEligible = canUseFixedCompact(g.waypoints());
 
         switch (mode) {
             case FORCE_VECTOR -> {
-                return new CoordPicked(CoordMode.VECTOR, encodeVectorOrAbsolute(g.waypoints(), pool, opts, false));
+                return new CoordPicked(CoordMode.VECTOR,
+                        encodeVectorOrAbsolute(g.waypoints(), pool, opts, false, bodyless));
             }
             case FORCE_ABSOLUTE -> {
-                return new CoordPicked(CoordMode.ABSOLUTE_VARINT, encodeVectorOrAbsolute(g.waypoints(), pool, opts, true));
+                return new CoordPicked(CoordMode.ABSOLUTE_VARINT,
+                        encodeVectorOrAbsolute(g.waypoints(), pool, opts, true, bodyless));
             }
             case FORCE_FIXED -> {
                 if (!fixedEligible) {
                     throw new IllegalArgumentException(
                             "FORCE_FIXED requested but group contains coords outside FIXED_COMPACT bounds");
                 }
-                return new CoordPicked(CoordMode.FIXED_COMPACT, encodeFixedCompact(g.waypoints(), pool, opts));
+                return new CoordPicked(CoordMode.FIXED_COMPACT,
+                        encodeFixedCompact(g.waypoints(), pool, opts, bodyless));
             }
             case FORCE_FIT -> {
-                return new CoordPicked(CoordMode.FIT_COMPACT, encodeFitCompact(g.waypoints(), pool, opts));
+                return new CoordPicked(CoordMode.FIT_COMPACT,
+                        encodeFitCompact(g.waypoints(), pool, opts, bodyless));
             }
             default -> {
-                byte[] v = encodeVectorOrAbsolute(g.waypoints(), pool, opts, false);
-                byte[] a = encodeVectorOrAbsolute(g.waypoints(), pool, opts, true);
-                byte[] f = fixedEligible ? encodeFixedCompact(g.waypoints(), pool, opts) : null;
-                byte[] t = encodeFitCompact(g.waypoints(), pool, opts);
+                byte[] v = encodeVectorOrAbsolute(g.waypoints(), pool, opts, false, bodyless);
+                byte[] a = encodeVectorOrAbsolute(g.waypoints(), pool, opts, true, bodyless);
+                byte[] f = fixedEligible ? encodeFixedCompact(g.waypoints(), pool, opts, bodyless) : null;
+                byte[] t = encodeFitCompact(g.waypoints(), pool, opts, bodyless);
 
-                // Rank by POST-DEFLATE size, not raw. Raw-byte size mis-ranks
-                // candidates whose contents compress very differently. Concrete
-                // example: a VECTOR stream of 20 identical (+1, +0, +2) deltas
-                // has zero entropy and deflates to near-nothing, while a
-                // FIT_COMPACT stream of the same input is already near the
-                // entropy bound and barely shrinks. Raw bytes say FIT wins;
-                // compressed bytes say VECTOR wins by ~15%. This is a
-                // per-group approximation of the true final size (cross-group
-                // compression context can still shift the ranking marginally),
-                // but it's strictly more accurate than comparing raw bytes and
-                // cheap enough that a user-triggered encode doesn't notice.
-                int vScore = compressedScore(v);
-                int aScore = compressedScore(a);
-                int fScore = f != null ? compressedScore(f) : Integer.MAX_VALUE;
-                int tScore = compressedScore(t);
+                // Rank by final text size, not raw bytes. Raw-byte size mis-ranks
+                // candidates whose contents compress differently, and the v3
+                // stream text layer can make equal compressed byte counts differ
+                // by a character. This remains a per-group approximation (later
+                // groups can still affect cross-group compression context), but
+                // it is close to the actual share-string length users care about.
+                int vScore = encodedGroupScore(bodyPrefix, g, pool, CoordMode.VECTOR, v,
+                        baseGroupFlags, customRadius);
+                int aScore = encodedGroupScore(bodyPrefix, g, pool, CoordMode.ABSOLUTE_VARINT, a,
+                        baseGroupFlags, customRadius);
+                int fScore = f != null
+                        ? encodedGroupScore(bodyPrefix, g, pool, CoordMode.FIXED_COMPACT, f,
+                                baseGroupFlags, customRadius)
+                        : Integer.MAX_VALUE;
+                int tScore = encodedGroupScore(bodyPrefix, g, pool, CoordMode.FIT_COMPACT, t,
+                        baseGroupFlags, customRadius);
 
                 CoordPicked best = new CoordPicked(CoordMode.VECTOR, v);
                 int bestScore = vScore;
@@ -685,7 +809,7 @@ public final class WaypointCodec {
      * {@link #readCoords} call on the decode side works for every mode.
      */
     private static byte[] encodeVectorOrAbsolute(List<Waypoint> pts, StringPool pool, Options opts,
-                                                 boolean absolute) throws IOException {
+                                                 boolean absolute, boolean bodyless) throws IOException {
         ByteArrayOutputStream scratch = new ByteArrayOutputStream();
         DataOutputStream out = new DataOutputStream(scratch);
 
@@ -703,7 +827,9 @@ public final class WaypointCodec {
             writeZigzag(out, dz);
             lx = w.x(); ly = w.y(); lz = w.z();
         }
-        for (Waypoint w : pts) writeWaypointBody(out, w, pool, opts);
+        if (!bodyless) {
+            for (Waypoint w : pts) writeWaypointBody(out, w, pool, opts);
+        }
         out.flush();
         return scratch.toByteArray();
     }
@@ -715,7 +841,8 @@ public final class WaypointCodec {
      * shape of the other modes and keeps the bit writer simple (at most 7 bits
      * of padding regardless of waypoint count).
      */
-    private static byte[] encodeFixedCompact(List<Waypoint> pts, StringPool pool, Options opts) throws IOException {
+    private static byte[] encodeFixedCompact(List<Waypoint> pts, StringPool pool, Options opts,
+                                             boolean bodyless) throws IOException {
         ByteArrayOutputStream scratch = new ByteArrayOutputStream();
         BitWriter bits = new BitWriter(scratch);
         for (Waypoint w : pts) {
@@ -726,7 +853,9 @@ public final class WaypointCodec {
         bits.flush();
 
         DataOutputStream out = new DataOutputStream(scratch);
-        for (Waypoint w : pts) writeWaypointBody(out, w, pool, opts);
+        if (!bodyless) {
+            for (Waypoint w : pts) writeWaypointBody(out, w, pool, opts);
+        }
         out.flush();
         return scratch.toByteArray();
     }
@@ -750,7 +879,8 @@ public final class WaypointCodec {
      * encode it cleanly so the contest's byte-count comparison doesn't need a
      * special case.
      */
-    private static byte[] encodeFitCompact(List<Waypoint> pts, StringPool pool, Options opts) throws IOException {
+    private static byte[] encodeFitCompact(List<Waypoint> pts, StringPool pool, Options opts,
+                                           boolean bodyless) throws IOException {
         int xMin = Integer.MAX_VALUE, yMin = Integer.MAX_VALUE, zMin = Integer.MAX_VALUE;
         int xMax = Integer.MIN_VALUE, yMax = Integer.MIN_VALUE, zMax = Integer.MIN_VALUE;
         for (Waypoint w : pts) {
@@ -794,7 +924,9 @@ public final class WaypointCodec {
         }
         bits.flush();
 
-        for (Waypoint w : pts) writeWaypointBody(out, w, pool, opts);
+        if (!bodyless) {
+            for (Waypoint w : pts) writeWaypointBody(out, w, pool, opts);
+        }
         out.flush();
         return scratch.toByteArray();
     }
@@ -809,13 +941,39 @@ public final class WaypointCodec {
         return 64 - Long.numberOfLeadingZeros(span);
     }
 
+    private static boolean hasEmptyWaypointBodies(List<Waypoint> pts, StringPool pool, Options opts) {
+        for (Waypoint w : pts) {
+            if (waypointFlags(w, pool, opts) != 0) return false;
+        }
+        return true;
+    }
+
     private static void writeWaypointBody(DataOutputStream out, Waypoint w, StringPool pool, Options opts)
             throws IOException {
+        int wpFlags = waypointFlags(w, pool, opts);
+        out.writeByte(wpFlags);
+
+        if ((wpFlags & WP_FLAG_HAS_NAME) != 0) {
+            if ((wpFlags & WP_FLAG_NAME_INLINE) != 0) {
+                writeUtf8String(out, w.name());
+            } else {
+                writeVarint(out, pool.index(w.name()));
+            }
+        }
+        if ((wpFlags & WP_FLAG_HAS_COLOR) != 0) {
+            int c = w.color() & 0xFFFFFF;
+            out.writeByte((c >> 16) & 0xFF);
+            out.writeByte((c >>  8) & 0xFF);
+            out.writeByte( c        & 0xFF);
+        }
+        if ((wpFlags & WP_FLAG_HAS_RADIUS) != 0) writeVarint(out, (int) Math.round(w.customRadius() * 10.0));
+        if ((wpFlags & WP_FLAG_EXTENDED)   != 0) writeVarint(out, w.flags() & 0xFF);
+    }
+
+    private static int waypointFlags(Waypoint w, StringPool pool, Options opts) {
         // Each "include" toggle gates an entire field family: when the sender
         // opts out, we don't emit the bit OR the value, so the decoder reads
         // back the recipient-side default (DEFAULT_COLOR, group radius, no flags).
-        // This keeps the decode path completely unaware of opt-outs -- it just
-        // sees a payload where some flags happen to be unset.
         boolean hasName   = opts.includeNames && w.hasName();
         boolean hasColor  = opts.includeColors
                 && (w.color() & 0xFFFFFF) != (Waypoint.DEFAULT_COLOR & 0xFFFFFF);
@@ -823,26 +981,20 @@ public final class WaypointCodec {
         boolean extended  = opts.includeWaypointFlags && w.flags() != 0;
 
         int wpFlags = 0;
-        if (hasName)   wpFlags |= WP_FLAG_HAS_NAME;
+        if (hasName) {
+            wpFlags |= WP_FLAG_HAS_NAME;
+            if (!pool.shouldPoolWaypointName(w.name())) wpFlags |= WP_FLAG_NAME_INLINE;
+        }
         if (hasColor)  wpFlags |= WP_FLAG_HAS_COLOR;
         if (hasRadius) wpFlags |= WP_FLAG_HAS_RADIUS;
         if (extended)  wpFlags |= WP_FLAG_EXTENDED;
-        out.writeByte(wpFlags);
-
-        if (hasName)   writeVarint(out, pool.index(w.name()));
-        if (hasColor) {
-            int c = w.color() & 0xFFFFFF;
-            out.writeByte((c >> 16) & 0xFF);
-            out.writeByte((c >>  8) & 0xFF);
-            out.writeByte( c        & 0xFF);
-        }
-        if (hasRadius) writeVarint(out, (int) Math.round(w.customRadius() * 10.0));
-        if (extended)  writeVarint(out, w.flags() & 0xFF);
+        return wpFlags;
     }
 
     // --- reader -------------------------------------------------------------------------------
 
-    private static List<WaypointGroup> readBody(byte[] bytes, DebugCapture cap, DecodedHeader headerOut)
+    private static List<WaypointGroup> readBody(byte[] bytes, DebugCapture cap, DecodedHeader headerOut,
+                                                int expectedVersion, boolean legacyV2)
             throws IOException {
         TrackedByteStream bais = new TrackedByteStream(bytes);
         DataInputStream in = new DataInputStream(bais);
@@ -851,9 +1003,9 @@ public final class WaypointCodec {
         // error message instead of a garbled field read downstream.
         int header = in.readUnsignedByte();
         int version = header & HEADER_VERSION_MASK;
-        if (version != WIRE_VERSION) {
+        if (version != expectedVersion) {
             throw new IOException("unsupported wire version " + version
-                    + " (this build speaks v" + WIRE_VERSION + ")");
+                    + " (expected v" + expectedVersion + ")");
         }
         // includesNames is informational only -- each waypoint carries its own
         // WP_FLAG_HAS_NAME bit. Other flag bits are reserved and ignored.
@@ -875,7 +1027,9 @@ public final class WaypointCodec {
         List<WaypointGroup> groups = new ArrayList<>(groupCount);
 
         for (int gi = 0; gi < groupCount; gi++) {
-            groups.add(readGroup(in, bais, pool, cap, gi));
+            groups.add(legacyV2
+                    ? readLegacyV2Group(in, bais, pool, cap, gi)
+                    : readGroup(in, bais, pool, cap, gi));
         }
         return groups;
     }
@@ -883,9 +1037,22 @@ public final class WaypointCodec {
     private static WaypointGroup readGroup(DataInputStream in, TrackedByteStream bais, List<String> pool,
                                            DebugCapture cap, int groupIndex)
             throws IOException {
+        return readGroupRecord(in, bais, pool, cap, groupIndex, false);
+    }
+
+    private static WaypointGroup readLegacyV2Group(DataInputStream in, TrackedByteStream bais, List<String> pool,
+                                                  DebugCapture cap, int groupIndex)
+            throws IOException {
+        return readGroupRecord(in, bais, pool, cap, groupIndex, true);
+    }
+
+    private static WaypointGroup readGroupRecord(DataInputStream in, TrackedByteStream bais, List<String> pool,
+                                                 DebugCapture cap, int groupIndex, boolean legacyV2)
+            throws IOException {
         String name = poolGet(pool, readVarint(in));
-        String zone = poolGet(pool, readVarint(in));
+        String zone = legacyV2 ? poolGet(pool, readVarint(in)) : readZoneRef(in, pool);
         int groupFlags = in.readUnsignedByte();
+        boolean bodyless     = !legacyV2 && (groupFlags & GROUP_FLAG_BODYLESS_WAYPOINTS) != 0;
         boolean autoGrad     = (groupFlags & GROUP_FLAG_GRAD_AUTO)     != 0;
         boolean sequence     = (groupFlags & GROUP_FLAG_LOAD_SEQUENCE) != 0;
         boolean customRadius = (groupFlags & GROUP_FLAG_CUSTOM_RADIUS) != 0;
@@ -929,8 +1096,13 @@ public final class WaypointCodec {
 
         for (int i = 0; i < pointCount; i++) {
             int x = coords[i][0], y = coords[i][1], z = coords[i][2];
-            int wpFlags = in.readUnsignedByte();
-            String wname = (wpFlags & WP_FLAG_HAS_NAME) != 0 ? poolGet(pool, readVarint(in)) : "";
+            int wpFlags = bodyless ? 0 : in.readUnsignedByte();
+            String wname = "";
+            if ((wpFlags & WP_FLAG_HAS_NAME) != 0) {
+                wname = !legacyV2 && (wpFlags & WP_FLAG_NAME_INLINE) != 0
+                        ? readUtf8String(in)
+                        : poolGet(pool, readVarint(in));
+            }
             int color    = (wpFlags & WP_FLAG_HAS_COLOR) != 0
                     ? (in.readUnsignedByte() << 16) | (in.readUnsignedByte() << 8) | in.readUnsignedByte()
                     : Waypoint.DEFAULT_COLOR;
@@ -1159,8 +1331,8 @@ public final class WaypointCodec {
             return g;
         }
 
-        DecodeDebug build(String rawInput, String payload, byte[] compressed, byte[] raw,
-                          List<WaypointGroup> decoded, long nanos) {
+        DecodeDebug build(String rawInput, String payload, String textEncoding, byte[] compressed,
+                          byte[] raw, List<WaypointGroup> decoded, long nanos) {
             double ratio = raw.length == 0 ? 0.0 : (double) rawInput.length() / raw.length;
             List<DecodeDebug.GroupDebug> gs = new ArrayList<>(groups.size());
             for (GroupBuilder b : groups) gs.add(b.build());
@@ -1169,6 +1341,7 @@ public final class WaypointCodec {
                     rawInput.length(),
                     MAGIC,
                     payload.length(),
+                    textEncoding,
                     compressed.length,
                     raw.length,
                     ratio,
@@ -1240,22 +1413,43 @@ public final class WaypointCodec {
     }
 
     /**
-     * Approximate post-deflate size of a single coord-mode candidate, used to
+     * Approximate final text size of a single coord-mode candidate, used to
      * rank AUTO candidates. Lower = better.
      *
-     * Uses the same dictionary as the real encode path so dictionary hits get
-     * counted. Doesn't include cross-group compression context, so the score
-     * is a heuristic rather than a true final size -- but it's dramatically
-     * more accurate than raw-byte comparisons for streams that differ in
-     * entropy characteristics.
+     * Uses the same dictionary and text codec as the real encode path so both
+     * dictionary hits and variable text-packing tails get counted. Doesn't
+     * include cross-group compression context, so the score is a heuristic
+     * rather than a true final size -- but it's dramatically more accurate than
+     * raw-byte comparisons for streams that differ in entropy characteristics.
      *
      * Returns {@link Integer#MAX_VALUE} on I/O failure so the caller simply
      * never picks the affected candidate; in practice {@link Deflater} on an
      * in-memory buffer cannot actually fail.
      */
-    private static int compressedScore(byte[] raw) {
+    private static int encodedGroupScore(byte[] bodyPrefix, WaypointGroup g, StringPool pool, CoordMode mode,
+                                         byte[] coordAndBody, int baseGroupFlags, boolean customRadius) {
         try {
-            return deflate(raw).length;
+            ByteArrayOutputStream scratch = new ByteArrayOutputStream();
+            scratch.write(bodyPrefix);
+            DataOutputStream out = new DataOutputStream(scratch);
+            writeVarint(out, pool.index(g.name()));
+            writeZoneRef(out, g.zoneId(), pool);
+            int groupFlags = baseGroupFlags
+                    | ((mode.wireValue << GROUP_FLAG_COORD_MODE_SHIFT) & GROUP_FLAG_COORD_MODE_MASK);
+            out.writeByte(groupFlags);
+            if (customRadius) writeVarint(out, (int) Math.round(g.defaultRadius() * 10.0));
+            writeVarint(out, g.size());
+            out.write(coordAndBody);
+            out.flush();
+            return encodedScore(scratch.toByteArray());
+        } catch (IOException ioe) {
+            return Integer.MAX_VALUE;
+        }
+    }
+
+    private static int encodedScore(byte[] raw) {
+        try {
+            return AsciiStreamCodec.encode(deflate(raw)).length();
         } catch (IOException ioe) {
             return Integer.MAX_VALUE;
         }
@@ -1294,6 +1488,7 @@ public final class WaypointCodec {
     static final class StringPool {
         private final Map<String, Integer> idx = new HashMap<>();
         private final List<String> list = new ArrayList<>();
+        private final Set<String> pooledWaypointNames = new HashSet<>();
 
         int intern(String s) {
             String k = s == null ? "" : s;
@@ -1310,12 +1505,21 @@ public final class WaypointCodec {
             return v == null ? 0 : v;
         }
 
+        void internWaypointName(String s) {
+            String k = s == null ? "" : s;
+            if (k.isEmpty()) return;
+            pooledWaypointNames.add(k);
+            intern(k);
+        }
+
+        boolean shouldPoolWaypointName(String s) {
+            return pooledWaypointNames.contains(s == null ? "" : s);
+        }
+
         void writeTo(DataOutputStream out) throws IOException {
             writeVarint(out, list.size());
             for (String s : list) {
-                byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
-                writeVarint(out, bytes.length);
-                out.write(bytes);
+                writeUtf8String(out, s);
             }
         }
 
@@ -1324,11 +1528,7 @@ public final class WaypointCodec {
             if (count < 0 || count > 1 << 16) throw new IOException("string pool too large: " + count);
             List<String> out = new ArrayList<>(count);
             for (int i = 0; i < count; i++) {
-                int len = readVarint(in);
-                if (len < 0 || len > 1 << 20) throw new IOException("string too long: " + len);
-                byte[] bytes = in.readNBytes(len);
-                if (bytes.length != len) throw new IOException("truncated string");
-                out.add(new String(bytes, StandardCharsets.UTF_8));
+                out.add(readUtf8String(in));
             }
             return out;
         }

--- a/src/main/java/dev/ethan/waypointer/config/WaypointerConfig.java
+++ b/src/main/java/dev/ethan/waypointer/config/WaypointerConfig.java
@@ -93,6 +93,12 @@ public final class WaypointerConfig {
      */
     private boolean hideTracerOnStaticRoutes = true;
     /**
+     * Optional checklist behavior for STATIC groups: when the player enters a
+     * waypoint's reach radius, that marker hides until every waypoint in the
+     * group has been reached, then the whole group becomes visible again.
+     */
+    private boolean hideReachedStaticWaypointsUntilCycleComplete = false;
+    /**
      * When {@code true}, each waypoint label draws a translucent black rectangle
      * behind its text for readability. Some players find it obtrusive in busy
      * routes where labels stack -- turning it off lets the text sit directly
@@ -287,6 +293,7 @@ public final class WaypointerConfig {
     public boolean showTracer()               { return showTracer; }
     public boolean dimSequenceContextWaypoints() { return dimSequenceContextWaypoints; }
     public boolean hideTracerOnStaticRoutes() { return hideTracerOnStaticRoutes; }
+    public boolean hideReachedStaticWaypointsUntilCycleComplete() { return hideReachedStaticWaypointsUntilCycleComplete; }
     public boolean showLabelBackdrop()        { return showLabelBackdrop; }
     public double labelHeightOffset()         { return labelHeightOffset; }
     public BoxStyle boxStyle()                { return boxStyle == null ? BoxStyle.OUTLINED : boxStyle; }
@@ -319,6 +326,10 @@ public final class WaypointerConfig {
     public void setShowTracer(boolean v)               { this.showTracer = v; save(); }
     public void setDimSequenceContextWaypoints(boolean v) { this.dimSequenceContextWaypoints = v; save(); }
     public void setHideTracerOnStaticRoutes(boolean v) { this.hideTracerOnStaticRoutes = v; save(); }
+    public void setHideReachedStaticWaypointsUntilCycleComplete(boolean v) {
+        this.hideReachedStaticWaypointsUntilCycleComplete = v;
+        save();
+    }
     public void setPreferScoreboardFallback(boolean v) { this.preferScoreboardFallback = v; save(); }
     public void setChatCoordDetection(boolean v)       { this.chatCoordDetection = v; save(); }
     public void setAutoAddChatTempWaypoints(boolean v) { this.autoAddChatTempWaypoints = v; save(); }

--- a/src/main/java/dev/ethan/waypointer/core/WaypointGroup.java
+++ b/src/main/java/dev/ethan/waypointer/core/WaypointGroup.java
@@ -75,6 +75,12 @@ public final class WaypointGroup {
     // so "next" is visually the calmest point on a route.
     private int gradientStartColor = 0x00BFFF;
     private int gradientEndColor   = 0xFF3040;
+    /**
+     * Session-only reach state for static-route cycling. Unlike currentIndex,
+     * this is unordered: a static map overlay lets the player visit points in
+     * any order, hiding each one until the whole set has been touched.
+     */
+    private transient boolean[] staticReached;
 
     public WaypointGroup(String id, String name, String zoneId) {
         this.id = Objects.requireNonNull(id);
@@ -217,12 +223,14 @@ public final class WaypointGroup {
 
     public void add(Waypoint w) {
         waypoints.add(w);
+        staticReached = null;
         applyGradientIfAuto();
     }
 
     public void insert(int index, Waypoint w) {
         waypoints.add(index, w);
         if (index <= currentIndex) currentIndex++;
+        staticReached = null;
         applyGradientIfAuto();
     }
 
@@ -230,6 +238,7 @@ public final class WaypointGroup {
         waypoints.remove(index);
         if (currentIndex > index) currentIndex--;
         currentIndex = Math.min(currentIndex, waypoints.size());
+        staticReached = null;
         applyGradientIfAuto();
     }
 
@@ -240,6 +249,7 @@ public final class WaypointGroup {
         if (currentIndex == from) currentIndex = to;
         else if (from < currentIndex && to >= currentIndex) currentIndex--;
         else if (from > currentIndex && to <= currentIndex) currentIndex++;
+        staticReached = null;
         applyGradientIfAuto();
     }
 
@@ -263,6 +273,36 @@ public final class WaypointGroup {
 
     public void resetProgress() {
         currentIndex = 0;
+        resetStaticReachState();
+    }
+
+    public boolean isStaticWaypointReached(int index) {
+        return staticReached != null
+                && index >= 0
+                && index < staticReached.length
+                && staticReached[index];
+    }
+
+    /**
+     * Mark one static waypoint as reached. If that completes the visible set,
+     * the cycle immediately resets so every waypoint appears again for the next
+     * pass through the route.
+     */
+    public boolean markStaticWaypointReached(int index) {
+        if (index < 0 || index >= waypoints.size()) return false;
+
+        ensureStaticReachState();
+        if (staticReached[index]) return false;
+
+        staticReached[index] = true;
+        if (allStaticWaypointsReached()) {
+            resetStaticReachState();
+        }
+        return true;
+    }
+
+    public void resetStaticReachState() {
+        staticReached = null;
     }
 
     /**
@@ -313,5 +353,20 @@ public final class WaypointGroup {
 
     private void applyGradientIfAuto() {
         if (gradientMode == GradientMode.AUTO) GradientColorizer.apply(this);
+    }
+
+    private void ensureStaticReachState() {
+        if (staticReached == null || staticReached.length != waypoints.size()) {
+            staticReached = new boolean[waypoints.size()];
+        }
+    }
+
+    private boolean allStaticWaypointsReached() {
+        if (staticReached == null || staticReached.length == 0) return false;
+
+        for (boolean reached : staticReached) {
+            if (!reached) return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/dev/ethan/waypointer/core/WaypointGroup.java
+++ b/src/main/java/dev/ethan/waypointer/core/WaypointGroup.java
@@ -81,6 +81,12 @@ public final class WaypointGroup {
      * any order, hiding each one until the whole set has been touched.
      */
     private transient boolean[] staticReached;
+    /**
+     * Set when a static reach pass completes the full set and clears {@link #staticReached}.
+     * Lets {@link dev.ethan.waypointer.progression.ProximityTracker} stop scanning for the
+     * rest of the tick so every waypoint shows as visible for at least one frame.
+     */
+    private transient boolean staticCycleJustCompleted;
 
     public WaypointGroup(String id, String name, String zoneId) {
         this.id = Objects.requireNonNull(id);
@@ -297,11 +303,23 @@ public final class WaypointGroup {
         staticReached[index] = true;
         if (allStaticWaypointsReached()) {
             resetStaticReachState();
+            staticCycleJustCompleted = true;
         }
         return true;
     }
 
+    /**
+     * Whether this group just finished a static reach cycle on the current tick.
+     * Clears the flag so it is a one-shot signal for callers that batch marks per tick.
+     */
+    public boolean consumeStaticCycleJustCompleted() {
+        boolean v = staticCycleJustCompleted;
+        staticCycleJustCompleted = false;
+        return v;
+    }
+
     public void resetStaticReachState() {
+        staticCycleJustCompleted = false;
         staticReached = null;
     }
 

--- a/src/test/java/dev/ethan/waypointer/chat/CodecScannerTest.java
+++ b/src/test/java/dev/ethan/waypointer/chat/CodecScannerTest.java
@@ -112,7 +112,7 @@ class CodecScannerTest {
         // v2 uses an ASCII alphabet, so without the word-boundary guard a chat
         // line like "fileWP:stuff" would fire the import pill. The scanner
         // must require the character immediately before the magic to be
-        // outside the base-85 alphabet (or be at the start of the string).
+        // outside the codec alphabet (or be at the start of the string).
         String export = sampleExport();
         assertTrue(CodecScanner.scan("file" + export).isEmpty(),
                 "magic preceded by ASCII alphanumeric must not match");

--- a/src/test/java/dev/ethan/waypointer/codec/AsciiStreamCodecTest.java
+++ b/src/test/java/dev/ethan/waypointer/codec/AsciiStreamCodecTest.java
@@ -1,0 +1,78 @@
+package dev.ethan.waypointer.codec;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Safety net for the v3 chat text layer. The codec sits outside DEFLATE, so a
+ * single bit-packing regression makes every otherwise-valid waypoint share fail
+ * before the binary body version guard can explain what happened.
+ */
+class AsciiStreamCodecTest {
+
+    @Test
+    void round_trips_arbitrary_byte_patterns() {
+        Random r = new Random(0xA511C0DE);
+        for (int trial = 0; trial < 500; trial++) {
+            byte[] input = new byte[r.nextInt(500)];
+            r.nextBytes(input);
+
+            byte[] decoded = AsciiStreamCodec.decode(AsciiStreamCodec.encode(input));
+            assertArrayEquals(input, decoded, "trial " + trial + " len=" + input.length);
+        }
+    }
+
+    @Test
+    void empty_input_round_trips_without_a_trailer() {
+        assertEquals("", AsciiStreamCodec.encode(new byte[0]));
+        assertArrayEquals(new byte[0], AsciiStreamCodec.decode(""));
+    }
+
+    @Test
+    void alphabet_is_printable_ascii_without_space_or_period() {
+        byte[] input = new byte[512];
+        new Random(0x5AFE).nextBytes(input);
+
+        String encoded = AsciiStreamCodec.encode(input);
+        assertFalse(encoded.contains(" "));
+        assertFalse(encoded.contains("."));
+        assertFalse(encoded.contains("\u00A7"));
+        for (int i = 0; i < encoded.length(); i++) {
+            char c = encoded.charAt(i);
+            assertTrue(c >= 0x21 && c <= 0x7E,
+                    "non-printable output at " + i + ": 0x" + Integer.toHexString(c));
+            assertTrue(AsciiStreamCodec.isAlphabetChar(c),
+                    "output char missing from alphabet at " + i + ": '" + c + "'");
+        }
+    }
+
+    @Test
+    void uses_all_printable_ascii_except_space_and_period() {
+        assertEquals(93, AsciiStreamCodec.alphabetSize());
+        assertFalse(AsciiStreamCodec.isAlphabetChar(' '));
+        assertFalse(AsciiStreamCodec.isAlphabetChar('.'));
+        assertTrue(AsciiStreamCodec.isAlphabetChar('~'));
+        assertTrue(AsciiStreamCodec.isAlphabetChar('_'));
+        assertTrue(AsciiStreamCodec.isAlphabetChar('"'));
+    }
+
+    @Test
+    void rejects_out_of_alphabet_characters() {
+        String valid = AsciiStreamCodec.encode("payload".getBytes(StandardCharsets.UTF_8));
+        String bad = valid.substring(0, 1) + "." + valid.substring(2);
+
+        assertThrows(IllegalArgumentException.class, () -> AsciiStreamCodec.decode(bad));
+    }
+
+    @Test
+    void beats_base85_on_representative_payloads() {
+        byte[] input = "The quick brown fox jumps over the lazy dog's back 0123456789"
+                .getBytes(StandardCharsets.UTF_8);
+
+        assertTrue(AsciiStreamCodec.encode(input).length() < AsciiPackCodec.encode(input).length());
+    }
+}

--- a/src/test/java/dev/ethan/waypointer/codec/CodecBenchmark.java
+++ b/src/test/java/dev/ethan/waypointer/codec/CodecBenchmark.java
@@ -32,7 +32,7 @@ class CodecBenchmark {
         String nameless = WaypointCodec.encode(groups, WaypointCodec.Options.NO_NAMES);
         int pts = 0;
         for (WaypointGroup g : groups) pts += g.size();
-        // Under v2 (base-85, ASCII) char count == UTF-8 byte count for the body. Printing
+        // The native ASCII text layer makes char count == UTF-8 byte count. Printing
         // both the char count and the hypothetical command-packet size (prefix
         // "/pc " + body) lets us see at a glance whether a payload fits the
         // 256-byte command-packet cap.

--- a/src/test/java/dev/ethan/waypointer/codec/WaypointCodecDebugTest.java
+++ b/src/test/java/dev/ethan/waypointer/codec/WaypointCodecDebugTest.java
@@ -42,6 +42,7 @@ class WaypointCodecDebugTest {
         assertEquals(encoded.length(), d.inputChars());
         assertEquals(WaypointCodec.MAGIC, d.magic());
         assertEquals(encoded.length() - WaypointCodec.MAGIC.length(), d.payloadChars());
+        assertEquals("ASCII base-93 stream", d.textEncoding());
         assertTrue(d.rawBodyBytes() > 0, "raw body must be non-empty");
         assertTrue(d.compressedBytes() > 0, "compressed must be non-empty");
     }

--- a/src/test/java/dev/ethan/waypointer/codec/WaypointCodecTest.java
+++ b/src/test/java/dev/ethan/waypointer/codec/WaypointCodecTest.java
@@ -25,6 +25,18 @@ class WaypointCodecTest {
                     .includeGroupMeta(true)
                     .build();
 
+    private static final String LEGACY_V2_SAMPLE = WaypointCodec.MAGIC
+                + "9NEC)tXa-R&pB;-XZcYv:>OTCcUT%MWvWyNh(fK:V)48Ri7YNG^6nQBfSw-seuxx]y/9F^Ag[GiDd?zQ3QD8{XnSR33(3o6&>*5x"
+                + "Ss+fZXP@uK?$}(JOQotG@(9POy-AwI?Ua}B>4s8MNZpP17$v}#?tb+!<*HK:K$0nhGeD!&Woi;Un$Pl[Tg!BeZRr!6*u-V)kNmS4"
+                + "P==fW1elaHF[NI[ar%CokroUX{#MO}?Ga+>qBb6s24OyM1>!T%kT!GJn<T%P4B]#zlBAGup-X:9t0L;]1*aEq=}SZtBq}/zmR1nh"
+                + "q[J2B(#;{O($s}N9%q]gy5QGfMPvfM{$>&lh$]yLQ&f1SvTU+g{vX#P?5boUf}oR3b=k83^Lntz7/}81Zo2oFAu[1o}v?(+/n7*i"
+                + "k%fh{AR6/${wWuPY1g$R]7/#(z%!Pe[xw35-fE1hC1#F3N)}jkI)9IyA0;P{I3az4:Pi<yl/kFU<fUwGnQcVm5PR!kVCGM5:p(zV"
+                + "i&<4H{0Ss^Jmdh/;$kHIO+D8=7^g*0C6#MrTx0Ich[@O}NoNq7ZI%7&+cfQ@BB:no+5u6Z{RMyOZJOMDO{kxy[z:2hjLs8#>JQKU"
+                + "Yf9B$!lOUKDJ2N?tIx7C>A/Hp&nJXI2yHjPGl$nn}0*OYXoN4}M+29^DaA?JZzdQRd%EQ2^[W5V8(#f{vcahp}!aeU?p%MFTdBsH"
+                + "gQt0$Io%SNxfn2i>EAHfJdNVU>cB42F)DVB(]t*:XK}fu3H)]Iftc;#r!X@ANCH]83x@4rOQXR6C*4<EUD}SoxD^$9+Pnm5+VVXx"
+                + "O3qk^V=(z5WvJotkF!)04So1gc/#gM6aS$l9]N+sa%r4pN-D4yb1HZJKqGeGm3e(fwN;495>v-&&WvUGmU@>V7&=7A6xv1qvUf%)"
+                + "RIF}}Hl%nZ688$IaQyT/lk6*5nWFZ12lj-73";
+
     @Test
     void magic_prefix_is_emitted() {
         String s = WaypointCodec.encode(List.of(sampleGroup("A", "hub")));
@@ -54,6 +66,27 @@ class WaypointCodecTest {
         assertEquals(2, decoded.size());
         assertGroupsEqual(a, decoded.get(0));
         assertGroupsEqual(b, decoded.get(1));
+    }
+
+    @Test
+    void decodes_legacy_v2_base85_exports() {
+        WaypointCodec.Decoded decoded = WaypointCodec.decodeFull(LEGACY_V2_SAMPLE);
+        assertEquals("Codec V2", decoded.label());
+        assertEquals(4, decoded.groups().size());
+
+        WaypointGroup first = decoded.groups().get(0);
+        assertEquals("hawcammang", first.name());
+        assertEquals("galatea", first.zoneId());
+        assertEquals(14, first.size());
+
+        WaypointGroup last = decoded.groups().get(3);
+        assertEquals("HideOnLeaf", last.name());
+        assertEquals("galatea", last.zoneId());
+        assertEquals(50, last.size());
+
+        DecodeDebug debug = WaypointCodec.debugDecode(LEGACY_V2_SAMPLE);
+        assertEquals(2, debug.version());
+        assertEquals("ASCII base-85", debug.textEncoding());
     }
 
     @Test
@@ -135,15 +168,15 @@ class WaypointCodecTest {
         String s = WaypointCodec.encode(List.of(g));
         // Density regression guard. JSON for the same 40-point route weighs
         // several kilobytes; the codec should stay well under a quarter of
-        // that on structured data. v2 threshold is 400 chars (= 400 wire
-        // bytes); real output on this fixture is around 330-340, so this
+        // that on structured data. Threshold is 400 chars (= 400 wire
+        // bytes); real output on this fixture is well below that, so this
         // has ~20% slack for dictionary / DEFLATE fluctuations.
         assertTrue(s.length() < 400, "expected packed export < 400 chars, got " + s.length() + ": " + s);
     }
 
     @Test
     void twenty_named_waypoints_fit_in_command_packet() {
-        // Under v2 (base-85, 1 UTF-8 byte per char) the codec string's char
+        // The native text codec uses one UTF-8 byte per char, so char
         // count equals its wire-byte count. The real failure mode is Hypixel's
         // 256-byte ServerboundChatCommandPacket cap: exceeding it disconnects
         // the sender. A 20-waypoint named route is the "reasonable share"
@@ -176,7 +209,7 @@ class WaypointCodecTest {
         String body = s.substring(WaypointCodec.MAGIC.length());
         for (int i = 0; i < body.length(); i++) {
             char c = body.charAt(i);
-            assertTrue(dev.ethan.waypointer.codec.AsciiPackCodec.isAlphabetChar(c),
+            assertTrue(dev.ethan.waypointer.codec.AsciiStreamCodec.isAlphabetChar(c),
                     "body char at " + i + " out of alphabet: '" + c
                             + "' (0x" + Integer.toHexString(c).toUpperCase() + ")");
         }
@@ -243,7 +276,7 @@ class WaypointCodecTest {
 
         String stripped = WaypointCodec.encode(List.of(g), WaypointCodec.Options.NO_NAMES);
         // Name strings themselves shouldn't be in the payload. We can't see through
-        // deflate+base-85 directly, but we can confirm the output is smaller than a names
+        // deflate+base-93 directly, but we can confirm the output is smaller than a names
         // export, and that the decoded waypoints come back nameless.
         String withNames = WaypointCodec.encode(List.of(g), WaypointCodec.Options.WITH_NAMES);
         assertTrue(stripped.length() < withNames.length(),
@@ -423,6 +456,78 @@ class WaypointCodecTest {
                         .includeWaypointFlags(false).includeGroupMeta(false).build()).length();
         assertTrue(stripped < full,
                 "all-toggles-off must beat all-toggles-on; stripped=" + stripped + " full=" + full);
+    }
+
+    @Test
+    void no_optional_waypoint_fields_omit_the_body_block() {
+        WaypointGroup g = WaypointGroup.create("plain", "dungeon_f7");
+        for (int i = 0; i < 20; i++) {
+            g.add(new Waypoint(100 + i, 70, 200 + i, "", Waypoint.DEFAULT_COLOR, 0, 0));
+        }
+
+        DecodeDebug.GroupDebug debug = WaypointCodec.debugDecode(
+                WaypointCodec.encode(List.of(g), WaypointCodec.Options.NO_NAMES)).groups().get(0);
+
+        assertEquals(0, debug.bodyBlockBytes(),
+                "a route with no optional waypoint fields should not spend one zero flag byte per point");
+        assertEquals(20, debug.waypoints().size(),
+                "debug still materializes default waypoint bodies for inspection");
+    }
+
+    @Test
+    void unique_waypoint_names_are_inlined_instead_of_pooled() {
+        WaypointGroup g = WaypointGroup.create("route", "dungeon_f7");
+        g.add(new Waypoint(0, 70, 0, "alpha", Waypoint.DEFAULT_COLOR, 0, 0));
+        g.add(new Waypoint(1, 70, 1, "bravo", Waypoint.DEFAULT_COLOR, 0, 0));
+
+        DecodeDebug debug = WaypointCodec.debugDecode(
+                WaypointCodec.encode(List.of(g), WaypointCodec.Options.WITH_NAMES));
+
+        assertFalse(debug.stringPool().contains("alpha"));
+        assertFalse(debug.stringPool().contains("bravo"));
+        assertEquals("alpha", debug.decodedGroups().get(0).get(0).name());
+        assertEquals("bravo", debug.decodedGroups().get(0).get(1).name());
+    }
+
+    @Test
+    void repeated_waypoint_names_still_use_the_string_pool() {
+        WaypointGroup g = WaypointGroup.create("route", "dungeon_f7");
+        g.add(new Waypoint(0, 70, 0, "Terminal", Waypoint.DEFAULT_COLOR, 0, 0));
+        g.add(new Waypoint(1, 70, 1, "Terminal", Waypoint.DEFAULT_COLOR, 0, 0));
+
+        DecodeDebug debug = WaypointCodec.debugDecode(
+                WaypointCodec.encode(List.of(g), WaypointCodec.Options.WITH_NAMES));
+
+        assertTrue(debug.stringPool().contains("Terminal"),
+                "repeated names should still be pooled so they are stored once");
+        assertEquals("Terminal", debug.decodedGroups().get(0).get(0).name());
+        assertEquals("Terminal", debug.decodedGroups().get(0).get(1).name());
+    }
+
+    @Test
+    void known_zone_ids_use_the_built_in_dictionary() {
+        WaypointGroup g = WaypointGroup.create("route", "dungeon_f7");
+        g.add(Waypoint.at(0, 70, 0));
+
+        DecodeDebug debug = WaypointCodec.debugDecode(
+                WaypointCodec.encode(List.of(g), WaypointCodec.Options.NO_NAMES));
+
+        assertFalse(debug.stringPool().contains("dungeon_f7"),
+                "known zones should be encoded as dictionary refs, not pool strings");
+        assertEquals("dungeon_f7", debug.decodedGroups().get(0).zoneId());
+    }
+
+    @Test
+    void unknown_zone_ids_still_round_trip_through_the_string_pool() {
+        WaypointGroup g = WaypointGroup.create("route", "custom_event_zone");
+        g.add(Waypoint.at(0, 70, 0));
+
+        DecodeDebug debug = WaypointCodec.debugDecode(
+                WaypointCodec.encode(List.of(g), WaypointCodec.Options.NO_NAMES));
+
+        assertTrue(debug.stringPool().contains("custom_event_zone"),
+                "unknown zones need the pool so custom/user-created zones survive");
+        assertEquals("custom_event_zone", debug.decodedGroups().get(0).zoneId());
     }
 
     @Test

--- a/src/test/java/dev/ethan/waypointer/progression/ProximityAdvanceTest.java
+++ b/src/test/java/dev/ethan/waypointer/progression/ProximityAdvanceTest.java
@@ -108,6 +108,33 @@ class ProximityAdvanceTest {
         assertEquals(Waypoint.TEMP_NONE, g.get(0).tempMode());
     }
 
+    @Test
+    void static_reach_tracking_hides_visited_waypoints_without_advancing_route() {
+        WaypointGroup g = line();
+        g.setLoadMode(WaypointGroup.LoadMode.STATIC);
+
+        assertTrue(ProximityTracker.markReachedStaticWaypoints(g, 20.5, 0.5, 0.5));
+
+        assertEquals(0, g.currentIndex());
+        assertFalse(g.isStaticWaypointReached(0));
+        assertTrue(g.isStaticWaypointReached(2));
+    }
+
+    @Test
+    void static_reach_tracking_resets_after_every_waypoint_is_reached() {
+        WaypointGroup g = line();
+        g.setLoadMode(WaypointGroup.LoadMode.STATIC);
+
+        assertTrue(ProximityTracker.markReachedStaticWaypoints(g, 0.5, 0.5, 0.5));
+        assertTrue(ProximityTracker.markReachedStaticWaypoints(g, 10.5, 0.5, 0.5));
+        assertTrue(ProximityTracker.markReachedStaticWaypoints(g, 20.5, 0.5, 0.5));
+        assertTrue(ProximityTracker.markReachedStaticWaypoints(g, 30.5, 0.5, 0.5));
+
+        for (int i = 0; i < g.size(); i++) {
+            assertFalse(g.isStaticWaypointReached(i));
+        }
+    }
+
     private static boolean ProximityAdvanceTester(WaypointGroup g, double px, double py, double pz) {
         return ProximityTracker.advanceIfReached(g, px, py, pz);
     }

--- a/src/test/java/dev/ethan/waypointer/progression/ProximityAdvanceTest.java
+++ b/src/test/java/dev/ethan/waypointer/progression/ProximityAdvanceTest.java
@@ -135,6 +135,28 @@ class ProximityAdvanceTest {
         }
     }
 
+    @Test
+    void static_cycle_reset_does_not_remark_later_indices_same_tick() {
+        WaypointGroup g = WaypointGroup.create("route", "test_zone");
+        g.setLoadMode(WaypointGroup.LoadMode.STATIC);
+        g.setDefaultRadius(6.0);
+        g.add(Waypoint.at(0, 0, 0));
+        g.add(Waypoint.at(10, 0, 0));
+        g.add(Waypoint.at(20, 0, 0));
+        g.add(Waypoint.at(30, 0, 0));
+        g.add(Waypoint.at(40, 0, 0));
+
+        g.markStaticWaypointReached(0);
+        g.markStaticWaypointReached(1);
+        g.markStaticWaypointReached(2);
+
+        assertTrue(ProximityTracker.markReachedStaticWaypoints(g, 35.5, 0.5, 0.5));
+
+        for (int i = 0; i < g.size(); i++) {
+            assertFalse(g.isStaticWaypointReached(i), "index " + i);
+        }
+    }
+
     private static boolean ProximityAdvanceTester(WaypointGroup g, double px, double py, double pz) {
         return ProximityTracker.advanceIfReached(g, px, py, pz);
     }


### PR DESCRIPTION
Updated codec to V3. Even shorter codes! Mod still accepts V2 codes. Thank you Skyblocker for the Zone data.

Added setting to make static waypoints disappear when reached. The group will re-appear again once all the waypoints are reached.can you

Fixed /wp not showing argument suggestions

Fixed static waypoints dimming once reached



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the share/import wire format and encoding pipeline (including new dictionaries and dual v2/v3 decode paths), so regressions could break route sharing/compatibility despite added tests. Also adds client-side command suggestion overriding via reflection, which may be brittle across Minecraft/Fabric/Brigadier versions.
> 
> **Overview**
> Upgrades the Waypointer share codec to **wire v3**: swaps the outer text encoding to a trailer-free **base-93 streaming ASCII** (`AsciiStreamCodec`), adds a **known-zone dictionary** (`CodecZoneDictionary`) with tagged `zoneRef`s, and introduces more compact waypoint records via **inline unique names** and **bodyless groups** when all waypoint bodies are default; AUTO coord-mode selection now ranks candidates by final encoded text length. Decoding, `peekLabel`, and debug tooling were updated to support **both v3 and legacy v2** payloads, with new regression tests and debug metadata (`DecodeDebug.textEncoding`).
> 
> Adds an optional **“hide reached static waypoints until cycle complete”** behavior for STATIC groups: tracks per-waypoint reach state, hides reached markers in rendering, and resets visibility after all points are reached; includes new config UI toggle and progression tests. Separately fixes `/wp` argument suggestions on servers with a server-side `/wp` by replacing only the server suggestion node with a copied client-command suggestion tree via a tick-installed reflection override.
> 
> Bumps `mod_version` to `1.4.1` and updates codec documentation to reflect v3.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fda92a328467256bd3cc0bfd94b5f3514923fa9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->