### PR TITLE
Beta

### DIFF
--- a/API.md
+++ b/API.md
@@ -8,6 +8,7 @@ You can:
 - read the user's routes
 - add temporary markers
 - create normal saved routes
+- edit waypoints in saved routes
 - show routes owned by your mod
 - import waypoint share strings
 - listen for zone or waypoint changes
@@ -86,6 +87,19 @@ String groupId = waypointer.createRoute(RouteSpec.builder()
         .waypoint(WaypointSpec.at(20, 65, 20).name("Vein 1"))
         .waypoint(WaypointSpec.at(30, 66, 30).name("Vein 2"))
         .build());
+```
+
+### Edit A Saved Waypoint
+
+Use `updateWaypoint` when you want to replace one waypoint without changing its
+position in the route. The call returns `false` if the route id or index no
+longer exists.
+
+```java
+boolean changed = waypointer.updateWaypoint(
+        groupId,
+        1,
+        WaypointSpec.at(20, 64, 20).name("Updated Stop"));
 ```
 
 ### Read User Waypoints

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ loader_version=0.18.2
 loom_version=1.15-SNAPSHOT
 
 # Mod Properties
-mod_version=1.5.1
+mod_version=1.5.2
 maven_group=dev.ethan.waypointer
 archives_base_name=waypointer
 

--- a/src/client/java/dev/ethan/waypointer/commands/WaypointerCommands.java
+++ b/src/client/java/dev/ethan/waypointer/commands/WaypointerCommands.java
@@ -19,6 +19,7 @@ import dev.ethan.waypointer.core.Waypoint;
 import dev.ethan.waypointer.core.WaypointGroup;
 import dev.ethan.waypointer.core.Zone;
 import dev.ethan.waypointer.input.WaypointAddFlow;
+import dev.ethan.waypointer.placement.PlayerWaypointPlacement;
 import dev.ethan.waypointer.screen.DebugInspectScreen;
 import dev.ethan.waypointer.screen.ImportFeedback;
 import dev.ethan.waypointer.screen.WaypointerScreen;
@@ -289,17 +290,26 @@ public final class WaypointerCommands {
         return (ctx, builder) -> {
             LocalPlayer player = Minecraft.getInstance().player;
             if (player == null) return builder.buildFuture();
+            PlayerWaypointPlacement.BlockPosition pos = PlayerWaypointPlacement.fromPlayer(
+                    player.getX(), player.getY(), player.getZ(), config);
             int value = switch (axis) {
-                case X -> (int) Math.floor(player.getX());
-                case Y -> (int) Math.floor(player.getY());
-                case Z -> (int) Math.floor(player.getZ());
+                case X -> pos.x();
+                case Y -> pos.y();
+                case Z -> pos.z();
             };
             String raw = Integer.toString(value);
             if (raw.startsWith(builder.getRemaining())) {
-                builder.suggest(value, Component.literal("current player " + axis.name().toLowerCase(Locale.ROOT)));
+                builder.suggest(value, Component.literal(playerCoordSuggestionLabel(axis)));
             }
             return builder.buildFuture();
         };
+    }
+
+    private String playerCoordSuggestionLabel(Axis axis) {
+        if (axis == Axis.Y && config.placeNewWaypointsBelowPlayer()) {
+            return "current player y - 1";
+        }
+        return "current player " + axis.name().toLowerCase(Locale.ROOT);
     }
 
     private SuggestionProvider<FabricClientCommandSource> suggestImportPayloads() {
@@ -592,12 +602,10 @@ public final class WaypointerCommands {
     private int runAdd(FabricClientCommandSource src, String name) {
         LocalPlayer player = Minecraft.getInstance().player;
         if (player == null) { error(src, "Not in a world"); return 0; }
+        PlayerWaypointPlacement.BlockPosition pos = PlayerWaypointPlacement.fromPlayer(
+                player.getX(), player.getY(), player.getZ(), config);
 
-        return runAddAt(src,
-                (int) Math.floor(player.getX()),
-                (int) Math.floor(player.getY()),
-                (int) Math.floor(player.getZ()),
-                name);
+        return runAddAt(src, pos.x(), pos.y(), pos.z(), name);
     }
 
     private int runAddAt(FabricClientCommandSource src, int x, int y, int z, String name) {
@@ -636,8 +644,8 @@ public final class WaypointerCommands {
     }
 
     /**
-     * Inserts a new waypoint at the player's position into the active group's
-     * waypoint list at {@code index}. {@code index == size} appends, matching
+     * Inserts a new waypoint at the configured player-relative position into the
+     * active group's waypoint list at {@code index}. {@code index == size} appends, matching
      * the semantics of {@link java.util.List#add(int, Object)} which
      * {@link WaypointGroup#insert(int, Waypoint)} delegates to.
      */
@@ -653,10 +661,10 @@ public final class WaypointerCommands {
             return 0;
         }
 
-        int x = (int) Math.floor(player.getX());
-        int y = (int) Math.floor(player.getY());
-        int z = (int) Math.floor(player.getZ());
-        target.insert(index, new Waypoint(x, y, z, name == null ? "" : name,
+        PlayerWaypointPlacement.BlockPosition pos = PlayerWaypointPlacement.fromPlayer(
+                player.getX(), player.getY(), player.getZ(), config);
+        target.insert(index, new Waypoint(
+                pos.x(), pos.y(), pos.z(), name == null ? "" : name,
                 Waypoint.DEFAULT_COLOR, 0, 0.0));
         addFlow.afterWaypointAdded(target, index);
         manager.fireDataChanged();

--- a/src/client/java/dev/ethan/waypointer/commands/WaypointerCommands.java
+++ b/src/client/java/dev/ethan/waypointer/commands/WaypointerCommands.java
@@ -906,7 +906,7 @@ public final class WaypointerCommands {
 
     private int runCreateGroup(FabricClientCommandSource src, String name) {
         Zone zone = manager.currentZone() == null ? Zone.UNKNOWN : manager.currentZone();
-        WaypointGroup g = WaypointGroup.create(name, zone.id());
+        WaypointGroup g = WaypointGroup.create(name, zone.id(), config.skipAheadMechanicEnabled());
         manager.add(g);
         success(src, "Created group \"" + name + "\" in " + zone.displayName());
         return 1;

--- a/src/client/java/dev/ethan/waypointer/commands/WaypointerCommands.java
+++ b/src/client/java/dev/ethan/waypointer/commands/WaypointerCommands.java
@@ -609,7 +609,7 @@ public final class WaypointerCommands {
     }
 
     private int runAddAt(FabricClientCommandSource src, int x, int y, int z, String name) {
-        WaypointGroup target = manager.getOrCreateActiveGroup();
+        WaypointGroup target = manager.getOrCreateActiveGroup(config.skipAheadMechanicEnabled());
         target.add(new Waypoint(x, y, z, name == null ? "" : name,
                 Waypoint.DEFAULT_COLOR, 0, 0.0));
         addFlow.afterWaypointAdded(target, target.size() - 1);
@@ -653,7 +653,7 @@ public final class WaypointerCommands {
         LocalPlayer player = Minecraft.getInstance().player;
         if (player == null) { error(src, "Not in a world"); return 0; }
 
-        WaypointGroup target = manager.getOrCreateActiveGroup();
+        WaypointGroup target = manager.getOrCreateActiveGroup(config.skipAheadMechanicEnabled());
         if (index < 0 || index > target.size()) {
             // Mirror the inclusive upper bound from the suggest tooltip so the
             // error message and the completion list agree on what's legal.

--- a/src/client/java/dev/ethan/waypointer/input/WaypointAddFlow.java
+++ b/src/client/java/dev/ethan/waypointer/input/WaypointAddFlow.java
@@ -6,7 +6,6 @@ import dev.ethan.waypointer.core.WaypointGroup;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
-import net.minecraft.client.gui.components.toasts.SystemToast;
 import net.minecraft.network.chat.Component;
 
 /**
@@ -22,15 +21,14 @@ import net.minecraft.network.chat.Component;
  * to static mode so the new marker remains visible, then suppresses proximity
  * for that one index until the player steps away. Without the suppression, a
  * waypoint created at the player's feet would be advanced or hidden on the very
- * next tick. It also auto-disables route skip-ahead so the new waypoint cannot
- * be skipped immediately.
+ * next tick.
  */
 public final class WaypointAddFlow {
 
     /**
      * Call immediately after a new waypoint has been appended or inserted into
-     * {@code group}. Temp groups are intentionally excluded because they never
-     * participate in skip-ahead to begin with, and the toast would be a lie.
+     * {@code group}. Temp groups are intentionally excluded because their static
+     * bucket does not participate in normal route progression.
      */
     public void afterWaypointAdded(WaypointGroup group, int waypointIndex) {
         if (group == null) return;
@@ -49,10 +47,6 @@ public final class WaypointAddFlow {
             showCurrentWaypointFocusedMessage(group.name(), waypointIndex);
         }
 
-        if (group.skipAheadEnabled()) {
-            group.setSkipAheadEnabled(false);
-            showSkipAheadDisabledToast(group.name());
-        }
     }
 
     private static void showWaypointAddedMessage(WaypointGroup group, int waypointIndex) {
@@ -82,25 +76,4 @@ public final class WaypointAddFlow {
         player.displayClientMessage(WaypointerChatFeedback.suppress(message), false);
     }
 
-    /**
-     * Fires a system toast explaining the skip-ahead auto-disable. Kept package-
-     * private so a caller can reuse the exact messaging if it ever needs to
-     * surface the state outside of "just added a waypoint" (e.g. manual toggle
-     * via a command).
-     */
-    private static void showSkipAheadDisabledToast(String groupName) {
-        Minecraft mc = Minecraft.getInstance();
-        if (mc == null) return;
-
-        // "PERIODIC_NOTIFICATION" is Mojang's catch-all id for non-critical
-        // status toasts -- it de-dupes with itself so repeated adds in quick
-        // succession don't stack three toasts on top of each other, they just
-        // refresh the top one.
-        SystemToast.addOrUpdate(
-                mc.getToastManager(),
-                SystemToast.SystemToastId.PERIODIC_NOTIFICATION,
-                Component.literal("Skip-ahead disabled"),
-                Component.literal("\"" + groupName + "\" -- auto-disabled because the new "
-                        + "waypoint is nearby and would be skipped instantly."));
-    }
 }

--- a/src/client/java/dev/ethan/waypointer/input/WaypointerKeybinds.java
+++ b/src/client/java/dev/ethan/waypointer/input/WaypointerKeybinds.java
@@ -175,7 +175,7 @@ public final class WaypointerKeybinds {
 
         PlayerWaypointPlacement.BlockPosition pos = playerWaypointPosition(p);
 
-        WaypointGroup target = manager.getOrCreateActiveGroup();
+        WaypointGroup target = manager.getOrCreateActiveGroup(config.skipAheadMechanicEnabled());
         target.add(new Waypoint(
                 pos.x(), pos.y(), pos.z(), "", Waypoint.DEFAULT_COLOR, 0, 0.0));
         addFlow.afterWaypointAdded(target, target.size() - 1);
@@ -186,7 +186,7 @@ public final class WaypointerKeybinds {
         LocalPlayer p = mc.player;
         if (p == null) return;
         PlayerWaypointPlacement.BlockPosition pos = playerWaypointPosition(p);
-        WaypointGroup target = manager.getOrCreateActiveGroup();
+        WaypointGroup target = manager.getOrCreateActiveGroup(config.skipAheadMechanicEnabled());
         AddNamedWaypointScreen.openAt(
                 null, manager, config, target, pos.x(), pos.y(), pos.z());
     }

--- a/src/client/java/dev/ethan/waypointer/input/WaypointerKeybinds.java
+++ b/src/client/java/dev/ethan/waypointer/input/WaypointerKeybinds.java
@@ -6,6 +6,7 @@ import dev.ethan.waypointer.config.WaypointerConfig;
 import dev.ethan.waypointer.core.ActiveGroupManager;
 import dev.ethan.waypointer.core.Waypoint;
 import dev.ethan.waypointer.core.WaypointGroup;
+import dev.ethan.waypointer.placement.PlayerWaypointPlacement;
 import dev.ethan.waypointer.screen.AddNamedWaypointScreen;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
@@ -164,20 +165,19 @@ public final class WaypointerKeybinds {
     }
 
     /**
-     * Drops a waypoint at the player's feet, reusing the first active group in the
-     * current zone (or bootstrapping one if needed). Coordinates are floored to
-     * match {@code /wp add} so the keybind and command produce identical data.
+     * Drops a waypoint at the configured player-relative position, reusing the
+     * first active group in the current zone (or bootstrapping one if needed).
+     * This matches {@code /wp add} so keybind and command muscle memory align.
      */
     private void addWaypointAtPlayer(Minecraft mc) {
         LocalPlayer p = mc.player;
         if (p == null) return;
 
-        int x = (int) Math.floor(p.getX());
-        int y = (int) Math.floor(p.getY());
-        int z = (int) Math.floor(p.getZ());
+        PlayerWaypointPlacement.BlockPosition pos = playerWaypointPosition(p);
 
         WaypointGroup target = manager.getOrCreateActiveGroup();
-        target.add(new Waypoint(x, y, z, "", Waypoint.DEFAULT_COLOR, 0, 0.0));
+        target.add(new Waypoint(
+                pos.x(), pos.y(), pos.z(), "", Waypoint.DEFAULT_COLOR, 0, 0.0));
         addFlow.afterWaypointAdded(target, target.size() - 1);
         manager.fireDataChanged();
     }
@@ -185,18 +185,17 @@ public final class WaypointerKeybinds {
     private void openNamedWaypointPrompt(Minecraft mc) {
         LocalPlayer p = mc.player;
         if (p == null) return;
-        int x = (int) Math.floor(p.getX());
-        int y = (int) Math.floor(p.getY());
-        int z = (int) Math.floor(p.getZ());
+        PlayerWaypointPlacement.BlockPosition pos = playerWaypointPosition(p);
         WaypointGroup target = manager.getOrCreateActiveGroup();
-        AddNamedWaypointScreen.openAt(null, manager, config, target, x, y, z);
+        AddNamedWaypointScreen.openAt(
+                null, manager, config, target, pos.x(), pos.y(), pos.z());
     }
 
     /**
-     * Drops a temporary waypoint at the player's feet, using the user's last
-     * picks for mode + duration (stored in config). Time-mode temps get their
-     * expiry stamped from {@link System#currentTimeMillis()} at the moment of
-     * creation; other modes ignore duration.
+     * Drops a temporary waypoint at the configured player-relative position,
+     * using the user's last picks for mode + duration (stored in config).
+     * Time-mode temps get their expiry stamped from {@link System#currentTimeMillis()}
+     * at the moment of creation; other modes ignore duration.
      *
      * <p>Temps go into the per-zone temp bucket (see
      * {@link ActiveGroupManager#getOrCreateTempGroup()}), not the player's
@@ -209,9 +208,7 @@ public final class WaypointerKeybinds {
         LocalPlayer p = mc.player;
         if (p == null) return;
 
-        int x = (int) Math.floor(p.getX());
-        int y = (int) Math.floor(p.getY());
-        int z = (int) Math.floor(p.getZ());
+        PlayerWaypointPlacement.BlockPosition pos = playerWaypointPosition(p);
 
         int mode = Waypoint.normalizeTempMode(config.tempDefaultMode());
         int durationMin = Math.max(1, config.tempDefaultDurationMin());
@@ -220,14 +217,19 @@ public final class WaypointerKeybinds {
                 : 0L;
 
         WaypointGroup target = manager.getOrCreateTempGroup();
-        target.add(Waypoint.at(x, y, z).withTemp(mode, expiresAt));
+        target.add(Waypoint.at(pos.x(), pos.y(), pos.z()).withTemp(mode, expiresAt));
         if (config.focusTempWaypoints()) {
             manager.focusTempWaypoint(target, target.size() - 1);
         }
         manager.fireDataChanged();
 
         showFeedback(mc, Component.literal("Temp (" + Waypoint.tempModeName(mode) + ") added at "
-                        + x + ", " + y + ", " + z).withStyle(ChatFormatting.AQUA));
+                + pos.x() + ", " + pos.y() + ", " + pos.z()).withStyle(ChatFormatting.AQUA));
+    }
+
+    private PlayerWaypointPlacement.BlockPosition playerWaypointPosition(LocalPlayer player) {
+        return PlayerWaypointPlacement.fromPlayer(
+                player.getX(), player.getY(), player.getZ(), config);
     }
 
     /**

--- a/src/client/java/dev/ethan/waypointer/progression/ProximityTracker.java
+++ b/src/client/java/dev/ethan/waypointer/progression/ProximityTracker.java
@@ -50,22 +50,29 @@ public final class ProximityTracker {
         boolean globalSkipAhead = config.skipAheadMechanicEnabled();
         boolean hideReachedStatic = config.hideReachedStaticWaypointsUntilCycleComplete();
         for (WaypointGroup group : manager.activeGroups()) {
-            // Temp-only bucket groups don't participate in progression -- they hold
-            // ad-hoc markers whose own expiry modes handle cleanup. Running proximity
-            // on them would re-enter the "advance past waypoint" logic on a container
-            // whose order is meaningless.
-            if (group.temp()) continue;
-            if (hideReachedStatic && group.loadMode() == WaypointGroup.LoadMode.STATIC) {
-                markReachedStaticWaypoints(group, px, py, pz);
-                continue;
-            }
-            // Group-level skip-ahead gate. When a waypoint was just added the
-            // group's flag is flipped off; we respect that regardless of the
-            // global mechanic state. Global off always wins over group on -- the
-            // config is the master switch.
-            boolean allowSkip = globalSkipAhead && group.skipAheadEnabled();
-            advanceIfReached(group, px, py, pz, loop, allowSkip);
+            updateGroupProgress(group, px, py, pz, loop, globalSkipAhead, hideReachedStatic);
         }
+    }
+
+    public static void updateGroupProgress(WaypointGroup group,
+                                           double px, double py, double pz,
+                                           boolean restartWhenComplete,
+                                           boolean globalSkipAhead,
+                                           boolean hideReachedStatic) {
+        // Temp-only bucket groups don't participate in progression -- they hold
+        // ad-hoc markers whose own expiry modes handle cleanup. Running proximity
+        // on them would re-enter the "advance past waypoint" logic on a container
+        // whose order is meaningless.
+        if (group.temp()) return;
+
+        if (hideReachedStatic && group.loadMode() == WaypointGroup.LoadMode.STATIC) {
+            markReachedStaticWaypoints(group, px, py, pz);
+        }
+
+        // Group-level skip-ahead gate. Global off always wins over group on --
+        // the config is the master switch; the group flag is a per-route opt-out.
+        boolean allowSkip = globalSkipAhead && group.skipAheadEnabled();
+        advanceIfReached(group, px, py, pz, restartWhenComplete, allowSkip);
     }
 
     /**

--- a/src/client/java/dev/ethan/waypointer/progression/ProximityTracker.java
+++ b/src/client/java/dev/ethan/waypointer/progression/ProximityTracker.java
@@ -67,6 +67,7 @@ public final class ProximityTracker {
 
         if (hideReachedStatic && group.loadMode() == WaypointGroup.LoadMode.STATIC) {
             markReachedStaticWaypoints(group, px, py, pz);
+            return;
         }
 
         // Group-level skip-ahead gate. Global off always wins over group on --

--- a/src/client/java/dev/ethan/waypointer/render/IrisShaderFallback.java
+++ b/src/client/java/dev/ethan/waypointer/render/IrisShaderFallback.java
@@ -1,0 +1,64 @@
+package dev.ethan.waypointer.render;
+
+import dev.ethan.waypointer.config.WaypointerConfig;
+import net.fabricmc.loader.api.FabricLoader;
+
+import java.lang.reflect.Method;
+
+/**
+ * Detects whether the experimental Iris-safe HUD renderer should replace the
+ * normal world-space waypoint geometry for this frame.
+ *
+ * <p>Iris is optional, so this class talks to its public API reflectively. A
+ * direct dependency would make Waypointer require Iris at runtime; reflection
+ * lets vanilla/Sodium installs keep using the normal renderer with no extra mod
+ * relationship.
+ */
+final class IrisShaderFallback {
+
+    private static final String IRIS_MOD_ID = "iris";
+    private static final String IRIS_API_CLASS = "net.irisshaders.iris.api.v0.IrisApi";
+
+    private static Boolean irisLoaded;
+    private static Object irisApi;
+    private static Method isShaderPackInUse;
+    private static boolean apiUnavailable;
+
+    private IrisShaderFallback() {
+    }
+
+    static boolean shouldUse(WaypointerConfig config) {
+        return config.irisShaderHudFallback() && isShaderPackInUse();
+    }
+
+    private static boolean isShaderPackInUse() {
+        if (!isIrisLoaded()) return false;
+        if (apiUnavailable) return false;
+
+        try {
+            Method method = shaderPackMethod();
+            if (method == null) return false;
+            return Boolean.TRUE.equals(method.invoke(irisApi));
+        } catch (ReflectiveOperationException | RuntimeException ignored) {
+            apiUnavailable = true;
+            return false;
+        }
+    }
+
+    private static boolean isIrisLoaded() {
+        if (irisLoaded == null) {
+            irisLoaded = FabricLoader.getInstance().isModLoaded(IRIS_MOD_ID);
+        }
+        return irisLoaded;
+    }
+
+    private static Method shaderPackMethod() throws ReflectiveOperationException {
+        if (isShaderPackInUse != null) return isShaderPackInUse;
+
+        Class<?> apiClass = Class.forName(IRIS_API_CLASS);
+        Method getInstance = apiClass.getMethod("getInstance");
+        irisApi = getInstance.invoke(null);
+        isShaderPackInUse = apiClass.getMethod("isShaderPackInUse");
+        return isShaderPackInUse;
+    }
+}

--- a/src/client/java/dev/ethan/waypointer/render/RenderHelpers.java
+++ b/src/client/java/dev/ethan/waypointer/render/RenderHelpers.java
@@ -26,6 +26,12 @@ public final class RenderHelpers {
     private static int green(int rgb) { return (rgb >>  8) & 0xFF; }
     private static int blue(int rgb)  { return  rgb        & 0xFF; }
 
+    public static int withAlpha(int argb, float alphaScale) {
+        float clamped = Math.max(0.0f, Math.min(1.0f, alphaScale));
+        int alpha = Math.round(((argb >>> 24) & 0xFF) * clamped);
+        return (alpha << 24) | (argb & 0x00FFFFFF);
+    }
+
     /**
      * Append the 12 segments of an axis-aligned cube outline to {@code consumer}.
      * Caller is responsible for calling {@code endBatch} afterwards (or letting

--- a/src/client/java/dev/ethan/waypointer/render/RenderHelpers.java
+++ b/src/client/java/dev/ethan/waypointer/render/RenderHelpers.java
@@ -35,25 +35,32 @@ public final class RenderHelpers {
                                    float x1, float y1, float z1,
                                    float x2, float y2, float z2,
                                    int rgb, float alpha) {
+        emitLineBox(consumer, ps, x1, y1, z1, x2, y2, z2, rgb, alpha, DEFAULT_LINE_WIDTH);
+    }
+
+    public static void emitLineBox(VertexConsumer consumer, PoseStack ps,
+                                   float x1, float y1, float z1,
+                                   float x2, float y2, float z2,
+                                   int rgb, float alpha, float width) {
         int r = red(rgb), g = green(rgb), b = blue(rgb);
         int a = (int) (alpha * 255f) & 0xFF;
         PoseStack.Pose pose = ps.last();
 
         // bottom rectangle
-        seg(consumer, pose, x1, y1, z1, x2, y1, z1, r, g, b, a, 1, 0, 0);
-        seg(consumer, pose, x2, y1, z1, x2, y1, z2, r, g, b, a, 0, 0, 1);
-        seg(consumer, pose, x2, y1, z2, x1, y1, z2, r, g, b, a, -1, 0, 0);
-        seg(consumer, pose, x1, y1, z2, x1, y1, z1, r, g, b, a, 0, 0, -1);
+        seg(consumer, pose, x1, y1, z1, x2, y1, z1, r, g, b, a, 1, 0, 0, width);
+        seg(consumer, pose, x2, y1, z1, x2, y1, z2, r, g, b, a, 0, 0, 1, width);
+        seg(consumer, pose, x2, y1, z2, x1, y1, z2, r, g, b, a, -1, 0, 0, width);
+        seg(consumer, pose, x1, y1, z2, x1, y1, z1, r, g, b, a, 0, 0, -1, width);
         // top rectangle
-        seg(consumer, pose, x1, y2, z1, x2, y2, z1, r, g, b, a, 1, 0, 0);
-        seg(consumer, pose, x2, y2, z1, x2, y2, z2, r, g, b, a, 0, 0, 1);
-        seg(consumer, pose, x2, y2, z2, x1, y2, z2, r, g, b, a, -1, 0, 0);
-        seg(consumer, pose, x1, y2, z2, x1, y2, z1, r, g, b, a, 0, 0, -1);
+        seg(consumer, pose, x1, y2, z1, x2, y2, z1, r, g, b, a, 1, 0, 0, width);
+        seg(consumer, pose, x2, y2, z1, x2, y2, z2, r, g, b, a, 0, 0, 1, width);
+        seg(consumer, pose, x2, y2, z2, x1, y2, z2, r, g, b, a, -1, 0, 0, width);
+        seg(consumer, pose, x1, y2, z2, x1, y2, z1, r, g, b, a, 0, 0, -1, width);
         // verticals
-        seg(consumer, pose, x1, y1, z1, x1, y2, z1, r, g, b, a, 0, 1, 0);
-        seg(consumer, pose, x2, y1, z1, x2, y2, z1, r, g, b, a, 0, 1, 0);
-        seg(consumer, pose, x2, y1, z2, x2, y2, z2, r, g, b, a, 0, 1, 0);
-        seg(consumer, pose, x1, y1, z2, x1, y2, z2, r, g, b, a, 0, 1, 0);
+        seg(consumer, pose, x1, y1, z1, x1, y2, z1, r, g, b, a, 0, 1, 0, width);
+        seg(consumer, pose, x2, y1, z1, x2, y2, z1, r, g, b, a, 0, 1, 0, width);
+        seg(consumer, pose, x2, y1, z2, x2, y2, z2, r, g, b, a, 0, 1, 0, width);
+        seg(consumer, pose, x1, y1, z2, x1, y2, z2, r, g, b, a, 0, 1, 0, width);
     }
 
     /**

--- a/src/client/java/dev/ethan/waypointer/render/RenderHelpers.java
+++ b/src/client/java/dev/ethan/waypointer/render/RenderHelpers.java
@@ -16,9 +16,8 @@ public final class RenderHelpers {
 
     // 1.21.11 added LineWidth to the lines vertex format, so every vertex must carry
     // a line width or the buffer check throws "Missing elements in vertex: LineWidth".
-    // We use a chunky 3px so the outlined boxes and the crosshair tracer stay legible
-    // at distance and against busy biomes -- 1px (vanilla default) was disappearing
-    // against grass and reeds.
+    // We use a chunky 3px so outlined boxes stay legible at distance and against
+    // busy biomes -- 1px (vanilla default) was disappearing against grass and reeds.
     private static final float DEFAULT_LINE_WIDTH = 3.0f;
 
     private RenderHelpers() {}
@@ -124,6 +123,14 @@ public final class RenderHelpers {
                                 float x1, float y1, float z1,
                                 float x2, float y2, float z2,
                                 int rgb, float alpha) {
+        emitLine(consumer, ps, x1, y1, z1, x2, y2, z2, rgb, alpha, DEFAULT_LINE_WIDTH);
+    }
+
+    /** Append a single line segment using a caller-controlled pixel width. */
+    public static void emitLine(VertexConsumer consumer, PoseStack ps,
+                                float x1, float y1, float z1,
+                                float x2, float y2, float z2,
+                                int rgb, float alpha, float width) {
         int r = red(rgb), g = green(rgb), b = blue(rgb);
         int a = (int) (alpha * 255f) & 0xFF;
         float nx = x2 - x1, ny = y2 - y1, nz = z2 - z1;
@@ -131,7 +138,7 @@ public final class RenderHelpers {
         if (len > 1e-5f) { nx /= len; ny /= len; nz /= len; }
         else { nx = 0; ny = 1; nz = 0; }
         PoseStack.Pose pose = ps.last();
-        seg(consumer, pose, x1, y1, z1, x2, y2, z2, r, g, b, a, nx, ny, nz);
+        seg(consumer, pose, x1, y1, z1, x2, y2, z2, r, g, b, a, nx, ny, nz, width);
     }
 
     /** Force-flush a render type from a batched MultiBufferSource. No-op if not a BufferSource. */
@@ -160,13 +167,22 @@ public final class RenderHelpers {
                             float x2, float y2, float z2,
                             int r, int g, int b, int a,
                             float nx, float ny, float nz) {
+        seg(c, pose, x1, y1, z1, x2, y2, z2, r, g, b, a,
+                nx, ny, nz, DEFAULT_LINE_WIDTH);
+    }
+
+    private static void seg(VertexConsumer c, PoseStack.Pose pose,
+                            float x1, float y1, float z1,
+                            float x2, float y2, float z2,
+                            int r, int g, int b, int a,
+                            float nx, float ny, float nz, float width) {
         // Call order must match the vertex format declaration: POSITION, COLOR, NORMAL,
         // LINE_WIDTH. setLineWidth is new in 1.21.11; writing it in the wrong slot causes
         // BufferBuilder's endLastVertex to throw "Not building!" on the next addVertex
         // because the previous vertex was detected as incomplete and it closed the buffer.
         c.addVertex(pose, x1, y1, z1).setColor(r, g, b, a)
-                .setNormal(pose, nx, ny, nz).setLineWidth(DEFAULT_LINE_WIDTH);
+                .setNormal(pose, nx, ny, nz).setLineWidth(width);
         c.addVertex(pose, x2, y2, z2).setColor(r, g, b, a)
-                .setNormal(pose, nx, ny, nz).setLineWidth(DEFAULT_LINE_WIDTH);
+                .setNormal(pose, nx, ny, nz).setLineWidth(width);
     }
 }

--- a/src/client/java/dev/ethan/waypointer/render/TracerRenderer.java
+++ b/src/client/java/dev/ethan/waypointer/render/TracerRenderer.java
@@ -2,18 +2,26 @@ package dev.ethan.waypointer.render;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
+import dev.ethan.waypointer.Waypointer;
 import dev.ethan.waypointer.config.WaypointerConfig;
 import dev.ethan.waypointer.core.ActiveGroupManager;
 import dev.ethan.waypointer.core.Waypoint;
 import dev.ethan.waypointer.core.WaypointGroup;
+import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElement;
+import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElementRegistry;
+import net.fabricmc.fabric.api.client.rendering.v1.hud.VanillaHudElements;
 import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderContext;
 import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderEvents;
 import net.minecraft.client.Camera;
+import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.ClientAvatarState;
+import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.rendertype.RenderType;
+import net.minecraft.resources.Identifier;
 import net.minecraft.util.Mth;
 import net.minecraft.world.phys.Vec3;
 import org.joml.Vector3fc;
@@ -35,7 +43,10 @@ import org.joml.Vector3fc;
  * tracer vanishes the moment you look at a wall between you and the current
  * waypoint.
  */
-public final class TracerRenderer {
+public final class TracerRenderer implements HudElement {
+
+    private static final Identifier HUD_FALLBACK_ID =
+            Identifier.fromNamespaceAndPath(Waypointer.MOD_ID, "iris_tracer_fallback");
 
     /**
      * Distance (in blocks) to push the tracer origin forward along the camera's
@@ -51,6 +62,8 @@ public final class TracerRenderer {
     private final ActiveGroupManager manager;
     private final WaypointerConfig config;
     private final float[] tracerOriginDelta = new float[3];
+    private final WorldScreenProjector projector = new WorldScreenProjector();
+    private final double[] screenScratch = new double[2];
 
     public TracerRenderer(ActiveGroupManager manager, WaypointerConfig config) {
         this.manager = manager;
@@ -59,9 +72,12 @@ public final class TracerRenderer {
 
     public void install() {
         WorldRenderEvents.END_MAIN.register(this::onRender);
+        HudElementRegistry.attachElementBefore(VanillaHudElements.CHAT, HUD_FALLBACK_ID, this);
     }
 
     private void onRender(WorldRenderContext ctx) {
+        if (IrisShaderFallback.shouldUse(config)) return;
+
         var groups = manager.activeGroups();
         if (groups.isEmpty()) return;
         boolean tempFocus = manager.tempWaypointFocusActive();
@@ -121,6 +137,84 @@ public final class TracerRenderer {
         RenderHelpers.endBatch(buffers, lineType);
     }
 
+    @Override
+    public void render(GuiGraphics g, DeltaTracker tick) {
+        if (!IrisShaderFallback.shouldUse(config)) return;
+
+        var groups = manager.activeGroups();
+        if (groups.isEmpty()) return;
+        boolean tempFocus = manager.tempWaypointFocusActive();
+        if (!tempFocus && !config.showTracer()) return;
+
+        Minecraft mc = Minecraft.getInstance();
+        GameRenderer renderer = mc.gameRenderer;
+        Camera camera = renderer.getMainCamera();
+        if (!camera.isInitialized()) return;
+
+        projector.prepare(renderer, camera);
+        int screenW = g.guiWidth();
+        int screenH = g.guiHeight();
+        double fromX = screenW / 2.0;
+        double fromY = screenH / 2.0;
+        float alpha = (float) config.tracerOpacity();
+        if (tempFocus) {
+            alpha = Math.max(alpha, TEMP_FOCUS_TRACER_ALPHA_FLOOR);
+        }
+        boolean matchWaypoint = config.matchTracerToWaypointColor();
+        int overrideColor = config.tracerColor();
+        double thickness = config.tracerThickness();
+
+        for (WaypointGroup group : groups) {
+            if (!tempFocus
+                    && config.hideTracerOnStaticRoutes()
+                    && group.loadMode() == WaypointGroup.LoadMode.STATIC) {
+                continue;
+            }
+
+            Waypoint target = group.current();
+            if (target == null) continue;
+            if (!projector.project(target.x() + 0.5, target.y() + 0.5, target.z() + 0.5,
+                    screenW, screenH, screenScratch)) {
+                projectOffscreenTarget(camera, target, screenW, screenH, screenScratch);
+            }
+
+            int color = matchWaypoint ? target.color() : overrideColor;
+            int argb = withAlpha(0xFF000000 | (color & 0xFFFFFF), alpha);
+            WaypointRenderer.drawScreenLine(g, fromX, fromY,
+                    screenScratch[0], screenScratch[1], argb, thickness);
+        }
+    }
+
+    private static void projectOffscreenTarget(Camera camera, Waypoint target,
+                                               int screenW, int screenH,
+                                               double[] out) {
+        Vec3 cameraPos = camera.position();
+        Vector3fc left = camera.leftVector();
+        Vector3fc up = camera.upVector();
+
+        double dx = target.x() + 0.5 - cameraPos.x;
+        double dy = target.y() + 0.5 - cameraPos.y;
+        double dz = target.z() + 0.5 - cameraPos.z;
+
+        double screenDirX = -(dx * left.x() + dy * left.y() + dz * left.z());
+        double screenDirY = -(dx * up.x() + dy * up.y() + dz * up.z());
+        if (screenDirX * screenDirX + screenDirY * screenDirY < 1.0e-6) {
+            screenDirY = 1.0;
+        }
+
+        double centerX = screenW / 2.0;
+        double centerY = screenH / 2.0;
+        double t = Double.POSITIVE_INFINITY;
+        if (screenDirX > 0.0) t = Math.min(t, (screenW - centerX) / screenDirX);
+        else if (screenDirX < 0.0) t = Math.min(t, -centerX / screenDirX);
+        if (screenDirY > 0.0) t = Math.min(t, (screenH - centerY) / screenDirY);
+        else if (screenDirY < 0.0) t = Math.min(t, -centerY / screenDirY);
+        if (!Double.isFinite(t) || t <= 0.0) t = 1.0;
+
+        out[0] = centerX + screenDirX * t;
+        out[1] = centerY + screenDirY * t;
+    }
+
     private static void writeTracerOriginDelta(Minecraft mc, Camera cam, LocalPlayer player,
                                                float[] out) {
         Vector3fc left = cam.leftVector();
@@ -162,6 +256,12 @@ public final class TracerRenderer {
         out[0] = -left.x() * rolledX + up.x() * pitchedY - forward.x() * pitchedZ;
         out[1] = -left.y() * rolledX + up.y() * pitchedY - forward.y() * pitchedZ;
         out[2] = -left.z() * rolledX + up.z() * pitchedY - forward.z() * pitchedZ;
+    }
+
+    private static int withAlpha(int argb, float alphaScale) {
+        float clamped = Math.max(0.0f, Math.min(1.0f, alphaScale));
+        int alpha = Math.round(((argb >>> 24) & 0xFF) * clamped);
+        return (alpha << 24) | (argb & 0x00FFFFFF);
     }
 
 }

--- a/src/client/java/dev/ethan/waypointer/render/TracerRenderer.java
+++ b/src/client/java/dev/ethan/waypointer/render/TracerRenderer.java
@@ -179,7 +179,7 @@ public final class TracerRenderer implements HudElement {
             }
 
             int color = matchWaypoint ? target.color() : overrideColor;
-            int argb = withAlpha(0xFF000000 | (color & 0xFFFFFF), alpha);
+            int argb = WaypointRenderer.withAlpha(0xFF000000 | (color & 0xFFFFFF), alpha);
             WaypointRenderer.drawScreenLine(g, fromX, fromY,
                     screenScratch[0], screenScratch[1], argb, thickness);
         }
@@ -256,12 +256,6 @@ public final class TracerRenderer implements HudElement {
         out[0] = -left.x() * rolledX + up.x() * pitchedY - forward.x() * pitchedZ;
         out[1] = -left.y() * rolledX + up.y() * pitchedY - forward.y() * pitchedZ;
         out[2] = -left.z() * rolledX + up.z() * pitchedY - forward.z() * pitchedZ;
-    }
-
-    private static int withAlpha(int argb, float alphaScale) {
-        float clamped = Math.max(0.0f, Math.min(1.0f, alphaScale));
-        int alpha = Math.round(((argb >>> 24) & 0xFF) * clamped);
-        return (alpha << 24) | (argb & 0x00FFFFFF);
     }
 
 }

--- a/src/client/java/dev/ethan/waypointer/render/TracerRenderer.java
+++ b/src/client/java/dev/ethan/waypointer/render/TracerRenderer.java
@@ -96,10 +96,11 @@ public final class TracerRenderer {
         }
         // Matching the tracer to the live waypoint colour means gradient groups
         // draw a tracer whose hue advances with progress, and manually-coloured
-        // checkpoints light their tracer in the same tint. The flat-override path is still available for
-        // users who prefer a single distinctive tracer colour across groups.
+        // checkpoints light their tracer in the same tint. The flat-override path
+        // is still available for users who prefer one tracer colour across groups.
         boolean matchWaypoint = config.matchTracerToWaypointColor();
         int overrideColor = config.tracerColor();
+        float thickness = (float) config.tracerThickness();
 
         for (WaypointGroup g : groups) {
             if (!tempFocus
@@ -113,7 +114,7 @@ public final class TracerRenderer {
             RenderHelpers.emitLine(lines, ps,
                     fromX, fromY, fromZ,
                     target.x() + 0.5f, target.y() + 0.5f, target.z() + 0.5f,
-                    color, alpha);
+                    color, alpha, thickness);
         }
 
         ps.popPose();

--- a/src/client/java/dev/ethan/waypointer/render/TracerRenderer.java
+++ b/src/client/java/dev/ethan/waypointer/render/TracerRenderer.java
@@ -179,7 +179,7 @@ public final class TracerRenderer implements HudElement {
             }
 
             int color = matchWaypoint ? target.color() : overrideColor;
-            int argb = WaypointRenderer.withAlpha(0xFF000000 | (color & 0xFFFFFF), alpha);
+            int argb = RenderHelpers.withAlpha(0xFF000000 | (color & 0xFFFFFF), alpha);
             WaypointRenderer.drawScreenLine(g, fromX, fromY,
                     screenScratch[0], screenScratch[1], argb, thickness);
         }

--- a/src/client/java/dev/ethan/waypointer/render/WaypointRenderer.java
+++ b/src/client/java/dev/ethan/waypointer/render/WaypointRenderer.java
@@ -254,7 +254,7 @@ public final class WaypointRenderer implements HudElement {
             if (isStaticBeyondDistanceLimit(g, w, camPos, maxStaticDistanceSq)) return;
 
             State state = stateFor(g, i, currentIdx);
-            if (state == State.COMPLETED && (!showCompleted || w.hasFlag(Waypoint.FLAG_HIDE_BEACON))) return;
+            if (shouldHideCompletedSequenceWaypoint(g, i, currentIdx, state, showCompleted, w)) return;
 
             float alpha = alphaFor(g, state) * beaconOpacity;
             float x = w.x(), y = w.y(), z = w.z();
@@ -276,7 +276,7 @@ public final class WaypointRenderer implements HudElement {
             if (isStaticBeyondDistanceLimit(g, w, camPos, maxStaticDistanceSq)) return;
 
             State state = stateFor(g, i, currentIdx);
-            if (state == State.COMPLETED && (!showCompleted || w.hasFlag(Waypoint.FLAG_HIDE_BEACON))) return;
+            if (shouldHideCompletedSequenceWaypoint(g, i, currentIdx, state, showCompleted, w)) return;
 
             float alpha = alphaFor(g, state) * beaconOpacity;
             float x = w.x(), y = w.y(), z = w.z();
@@ -316,7 +316,7 @@ public final class WaypointRenderer implements HudElement {
         if (isStaticBeyondDistanceLimit(g, w, camPos, maxStaticDistanceSq)) return;
 
         State state = stateFor(g, i, currentIdx);
-        if (state == State.COMPLETED && (!showCompleted || w.hasFlag(Waypoint.FLAG_HIDE_BEACON))) return;
+        if (shouldHideCompletedSequenceWaypoint(g, i, currentIdx, state, showCompleted, w)) return;
 
         float alpha = alphaFor(g, state) * (float) config.beaconOpacity() * BEAM_ALPHA_SCALE;
         if (alpha <= 0.0f) return;
@@ -416,8 +416,8 @@ public final class WaypointRenderer implements HudElement {
             if (isStaticBeyondDistanceLimit(group, waypoint, camPos, maxStaticDistanceSq)) return;
 
             State state = stateFor(group, i, currentIdx);
-            if (state == State.COMPLETED
-                    && (!showCompleted || waypoint.hasFlag(Waypoint.FLAG_HIDE_BEACON))) {
+            if (shouldHideCompletedSequenceWaypoint(
+                    group, i, currentIdx, state, showCompleted, waypoint)) {
                 return;
             }
 
@@ -498,7 +498,7 @@ public final class WaypointRenderer implements HudElement {
 
             Waypoint w = group.get(i);
             State state = stateFor(group, i, currentIdx);
-            if (state == State.COMPLETED && (!showCompleted || w.hasFlag(Waypoint.FLAG_HIDE_BEACON))) return;
+            if (shouldHideCompletedSequenceWaypoint(group, i, currentIdx, state, showCompleted, w)) return;
             if (w.hasFlag(Waypoint.FLAG_HIDE_NAME)) return;
 
             double ax = w.x() + 0.5;
@@ -661,6 +661,24 @@ public final class WaypointRenderer implements HudElement {
         if (i < currentIdx) return State.COMPLETED;
         if (i == currentIdx) return State.CURRENT;
         return State.UPCOMING;
+    }
+
+    private boolean shouldHideCompletedSequenceWaypoint(WaypointGroup group,
+                                                        int index,
+                                                        int currentIdx,
+                                                        State state,
+                                                        boolean showCompleted,
+                                                        Waypoint waypoint) {
+        if (state != State.COMPLETED) return false;
+        if (waypoint.hasFlag(Waypoint.FLAG_HIDE_BEACON)) return true;
+        if (showCompleted) return false;
+
+        return !isImmediateSequenceContext(group, index, currentIdx);
+    }
+
+    private boolean isImmediateSequenceContext(WaypointGroup group, int index, int currentIdx) {
+        return group.loadMode() == WaypointGroup.LoadMode.SEQUENCE
+                && index == currentIdx - 1;
     }
 
     private boolean shouldHideStaticReached(WaypointGroup group, int index) {

--- a/src/client/java/dev/ethan/waypointer/render/WaypointRenderer.java
+++ b/src/client/java/dev/ethan/waypointer/render/WaypointRenderer.java
@@ -728,7 +728,7 @@ public final class WaypointRenderer implements HudElement {
         return state.alpha;
     }
 
-    private static int withAlpha(int argb, float alphaScale) {
+    static int withAlpha(int argb, float alphaScale) {
         float clamped = Math.max(0.0f, Math.min(1.0f, alphaScale));
         int alpha = Math.round(((argb >>> 24) & 0xFF) * clamped);
         return (alpha << 24) | (argb & 0x00FFFFFF);
@@ -736,77 +736,7 @@ public final class WaypointRenderer implements HudElement {
 
     static void drawScreenLine(GuiGraphics g, double x1, double y1,
                                double x2, double y2, int argb, double thickness) {
-        double guiScale = Minecraft.getInstance().getWindow().getGuiScale();
-        double scaledThickness = Math.max(1.0 / guiScale, thickness / guiScale);
-        double margin = HUD_LINE_CULL_MARGIN / guiScale;
-        double minX = -margin;
-        double minY = -margin;
-        double maxX = g.guiWidth() + margin;
-        double maxY = g.guiHeight() + margin;
-        int out1 = outCode(x1, y1, minX, minY, maxX, maxY);
-        int out2 = outCode(x2, y2, minX, minY, maxX, maxY);
-        while ((out1 | out2) != 0) {
-            if ((out1 & out2) != 0) return;
-
-            int outside = out1 != 0 ? out1 : out2;
-            double x;
-            double y;
-            if ((outside & 8) != 0) {
-                x = x1 + (x2 - x1) * (maxY - y1) / (y2 - y1);
-                y = maxY;
-            } else if ((outside & 4) != 0) {
-                x = x1 + (x2 - x1) * (minY - y1) / (y2 - y1);
-                y = minY;
-            } else if ((outside & 2) != 0) {
-                y = y1 + (y2 - y1) * (maxX - x1) / (x2 - x1);
-                x = maxX;
-            } else {
-                y = y1 + (y2 - y1) * (minX - x1) / (x2 - x1);
-                x = minX;
-            }
-
-            if (outside == out1) {
-                x1 = x;
-                y1 = y;
-                out1 = outCode(x1, y1, minX, minY, maxX, maxY);
-            } else {
-                x2 = x;
-                y2 = y;
-                out2 = outCode(x2, y2, minX, minY, maxX, maxY);
-            }
-        }
-
-        double dx = x2 - x1;
-        double dy = y2 - y1;
-        double length = Math.sqrt(dx * dx + dy * dy);
-        if (length < 0.5) return;
-
-        double half = scaledThickness * 0.5;
-        double aaWidth = Math.max(0.75 / guiScale, 0.25);
-        int drawMinX = (int) Math.floor(Math.min(x1, x2) - half - aaWidth);
-        int drawMaxX = (int) Math.ceil(Math.max(x1, x2) + half + aaWidth);
-        int drawMinY = (int) Math.floor(Math.min(y1, y2) - half - aaWidth);
-        int drawMaxY = (int) Math.ceil(Math.max(y1, y2) + half + aaWidth);
-        double invLengthSq = 1.0 / (dx * dx + dy * dy);
-        int baseAlpha = (argb >>> 24) & 0xFF;
-
-        for (int y = drawMinY; y <= drawMaxY; y++) {
-            for (int x = drawMinX; x <= drawMaxX; x++) {
-                double px = x + 0.5;
-                double py = y + 0.5;
-                double t = ((px - x1) * dx + (py - y1) * dy) * invLengthSq;
-                t = Math.max(0.0, Math.min(1.0, t));
-                double closestX = x1 + dx * t;
-                double closestY = y1 + dy * t;
-                double dist = Math.hypot(px - closestX, py - closestY);
-                double coverage = (half + aaWidth - dist) / aaWidth;
-                if (coverage <= 0.0) continue;
-
-                int alpha = (int) Math.round(baseAlpha * Math.min(1.0, coverage));
-                if (alpha <= 0) continue;
-                g.fill(x, y, x + 1, y + 1, (alpha << 24) | (argb & 0x00FFFFFF));
-            }
-        }
+        drawFastScreenLine(g, x1, y1, x2, y2, argb, thickness);
     }
 
     private static void drawFastScreenLine(GuiGraphics g, double x1, double y1,

--- a/src/client/java/dev/ethan/waypointer/render/WaypointRenderer.java
+++ b/src/client/java/dev/ethan/waypointer/render/WaypointRenderer.java
@@ -104,11 +104,14 @@ public final class WaypointRenderer implements HudElement {
      * frame. The array is still tiny compared with a single route import.
      */
     private static final int DISTANCE_CACHE_MAX = 4096;
+    private static final int HUD_LINE_CULL_MARGIN = 64;
     private static final String[] DISTANCE_CACHE;
     static {
         DISTANCE_CACHE = new String[DISTANCE_CACHE_MAX];
         for (int i = 0; i < DISTANCE_CACHE_MAX; i++) DISTANCE_CACHE[i] = i + "m";
     }
+    private static final int[] BOX_EDGE_A = {0, 1, 3, 2, 4, 5, 7, 6, 0, 1, 2, 3};
+    private static final int[] BOX_EDGE_B = {1, 3, 2, 0, 5, 7, 6, 4, 4, 5, 6, 7};
 
     /**
      * Bounded cache for generated labels like "#34" and "Next (34/120)".
@@ -135,6 +138,12 @@ public final class WaypointRenderer implements HudElement {
     private final String[] nextLabelCache = new String[NEXT_LABEL_CACHE_SIZE];
     private final WorldScreenProjector labelProjector = new WorldScreenProjector();
     private final double[] labelScreenScratch = new double[2];
+    private final double[] boxScreenScratch = new double[16];
+    private final boolean[] boxCornerVisible = new boolean[8];
+    private double projectedBoxMinX;
+    private double projectedBoxMinY;
+    private double projectedBoxMaxX;
+    private double projectedBoxMaxY;
     private final ArrayList<LabelCandidate> labelCandidates = new ArrayList<>();
     private int labelCandidateCount;
 
@@ -169,6 +178,8 @@ public final class WaypointRenderer implements HudElement {
     private static final int DEFAULT_MAX_BUILD_Y = 320;
 
     private void onWorldRender(WorldRenderContext ctx) {
+        if (IrisShaderFallback.shouldUse(config)) return;
+
         var groups = manager.activeGroups();
         if (groups.isEmpty()) return;
 
@@ -234,6 +245,7 @@ public final class WaypointRenderer implements HudElement {
         int currentIdx = g.currentIndex();
         boolean showCompleted = config.showCompleted();
         float beaconOpacity = (float) config.beaconOpacity();
+        float outlineThickness = (float) config.waypointOutlineThickness();
 
         g.forEachVisibleIndex(i -> {
             if (shouldHideStaticReached(g, i)) return;
@@ -246,7 +258,8 @@ public final class WaypointRenderer implements HudElement {
 
             float alpha = alphaFor(g, state) * beaconOpacity;
             float x = w.x(), y = w.y(), z = w.z();
-            RenderHelpers.emitLineBox(lines, ps, x, y, z, x + 1f, y + 1f, z + 1f, w.color(), alpha);
+            RenderHelpers.emitLineBox(lines, ps, x, y, z, x + 1f, y + 1f, z + 1f,
+                    w.color(), alpha, outlineThickness);
         });
     }
 
@@ -335,7 +348,8 @@ public final class WaypointRenderer implements HudElement {
     public void render(GuiGraphics g, DeltaTracker tick) {
         boolean showNames = config.showWaypointNames();
         boolean showDistances = config.showWaypointDistances();
-        if (!showNames && !showDistances) return;
+        boolean drawHudFallback = IrisShaderFallback.shouldUse(config);
+        if (!showNames && !showDistances && !drawHudFallback) return;
 
         var groups = manager.activeGroups();
         if (groups.isEmpty()) return;
@@ -354,13 +368,118 @@ public final class WaypointRenderer implements HudElement {
         double maxStaticDistanceSq = squaredDistanceLimit(config.maxStaticWaypointRenderDistance());
         labelCandidateCount = 0;
 
-        for (WaypointGroup group : groups) {
-            drawGroupLabels(g, font, camPos, screenW, screenH, group,
-                    showNames, showDistances, labelBudget, maxStaticDistanceSq);
+        if (drawHudFallback) {
+            drawHudFallbackBoxes(g, camPos, screenW, screenH, groups, maxStaticDistanceSq);
         }
-        if (labelBudget > 0 && labelCandidateCount > 0) {
-            drawBudgetedLabels(g, font, Math.min(labelBudget, labelCandidateCount));
+
+        if (showNames || showDistances) {
+            for (WaypointGroup group : groups) {
+                drawGroupLabels(g, font, camPos, screenW, screenH, group,
+                        showNames, showDistances, labelBudget, maxStaticDistanceSq);
+            }
+            if (labelBudget > 0 && labelCandidateCount > 0) {
+                drawBudgetedLabels(g, font, Math.min(labelBudget, labelCandidateCount));
+            }
         }
+    }
+
+    private void drawHudFallbackBoxes(GuiGraphics g, Vec3 camPos, int screenW,
+                                      int screenH, Iterable<WaypointGroup> groups,
+                                      double maxStaticDistanceSq) {
+        WaypointerConfig.BoxStyle style = config.boxStyle();
+        if (style == WaypointerConfig.BoxStyle.FILLED) {
+            // The HUD fallback cannot faithfully preserve translucent 3D faces
+            // after projection. Draw an outline anyway so FILLED users still get
+            // a visible shader-safe marker instead of losing boxes entirely.
+            style = WaypointerConfig.BoxStyle.OUTLINED;
+        }
+        if (style == WaypointerConfig.BoxStyle.OUTLINED
+                || style == WaypointerConfig.BoxStyle.FILLED_OUTLINED) {
+            for (WaypointGroup group : groups) {
+                drawHudFallbackGroupBoxes(g, camPos, screenW, screenH,
+                        group, maxStaticDistanceSq);
+            }
+        }
+    }
+
+    private void drawHudFallbackGroupBoxes(GuiGraphics g, Vec3 camPos, int screenW,
+                                           int screenH, WaypointGroup group,
+                                           double maxStaticDistanceSq) {
+        int currentIdx = group.currentIndex();
+        boolean showCompleted = config.showCompleted();
+        float beaconOpacity = (float) config.beaconOpacity();
+
+        group.forEachVisibleIndex(i -> {
+            if (shouldHideStaticReached(group, i)) return;
+
+            Waypoint waypoint = group.get(i);
+            if (isStaticBeyondDistanceLimit(group, waypoint, camPos, maxStaticDistanceSq)) return;
+
+            State state = stateFor(group, i, currentIdx);
+            if (state == State.COMPLETED
+                    && (!showCompleted || waypoint.hasFlag(Waypoint.FLAG_HIDE_BEACON))) {
+                return;
+            }
+
+            float alpha = alphaFor(group, state) * beaconOpacity;
+            int argb = withAlpha(0xFF000000 | (waypoint.color() & 0xFFFFFF), alpha);
+            if (!projectBoxCorners(waypoint, screenW, screenH)) return;
+
+            double outlineThickness = config.waypointOutlineThickness();
+            for (int edge = 0; edge < BOX_EDGE_A.length; edge++) {
+                int a = BOX_EDGE_A[edge];
+                int b = BOX_EDGE_B[edge];
+                if (!boxCornerVisible[a] || !boxCornerVisible[b]) continue;
+                drawFastScreenLine(g,
+                        boxScreenScratch[a * 2], boxScreenScratch[a * 2 + 1],
+                        boxScreenScratch[b * 2], boxScreenScratch[b * 2 + 1],
+                        argb, outlineThickness);
+            }
+        });
+    }
+
+    private boolean projectBoxCorners(Waypoint waypoint, int screenW, int screenH) {
+        projectedBoxMinX = Double.POSITIVE_INFINITY;
+        projectedBoxMinY = Double.POSITIVE_INFINITY;
+        projectedBoxMaxX = Double.NEGATIVE_INFINITY;
+        projectedBoxMaxY = Double.NEGATIVE_INFINITY;
+
+        double x1 = waypoint.x();
+        double y1 = waypoint.y();
+        double z1 = waypoint.z();
+        double x2 = x1 + 1.0;
+        double y2 = y1 + 1.0;
+        double z2 = z1 + 1.0;
+
+        projectBoxCorner(0, x1, y1, z1, screenW, screenH);
+        projectBoxCorner(1, x2, y1, z1, screenW, screenH);
+        projectBoxCorner(2, x1, y1, z2, screenW, screenH);
+        projectBoxCorner(3, x2, y1, z2, screenW, screenH);
+        projectBoxCorner(4, x1, y2, z1, screenW, screenH);
+        projectBoxCorner(5, x2, y2, z1, screenW, screenH);
+        projectBoxCorner(6, x1, y2, z2, screenW, screenH);
+        projectBoxCorner(7, x2, y2, z2, screenW, screenH);
+
+        if (!Double.isFinite(projectedBoxMinX)) return false;
+        double margin = HUD_LINE_CULL_MARGIN / Minecraft.getInstance().getWindow().getGuiScale();
+        return projectedBoxMaxX >= -margin
+                && projectedBoxMinX <= screenW + margin
+                && projectedBoxMaxY >= -margin
+                && projectedBoxMinY <= screenH + margin;
+    }
+
+    private void projectBoxCorner(int index, double x, double y, double z,
+                                  int screenW, int screenH) {
+        int offset = index * 2;
+        boxCornerVisible[index] = labelProjector.project(x, y, z, screenW, screenH, labelScreenScratch);
+        if (!boxCornerVisible[index]) return;
+
+        boxScreenScratch[offset] = labelScreenScratch[0];
+        boxScreenScratch[offset + 1] = labelScreenScratch[1];
+        projectedBoxMinX = Math.min(projectedBoxMinX, labelScreenScratch[0]);
+        projectedBoxMinY = Math.min(projectedBoxMinY, labelScreenScratch[1]);
+        projectedBoxMaxX = Math.max(projectedBoxMaxX, labelScreenScratch[0]);
+        projectedBoxMaxY = Math.max(projectedBoxMaxY, labelScreenScratch[1]);
     }
 
     private void drawGroupLabels(GuiGraphics g, Font font, Vec3 camPos,
@@ -595,6 +714,150 @@ public final class WaypointRenderer implements HudElement {
         float clamped = Math.max(0.0f, Math.min(1.0f, alphaScale));
         int alpha = Math.round(((argb >>> 24) & 0xFF) * clamped);
         return (alpha << 24) | (argb & 0x00FFFFFF);
+    }
+
+    static void drawScreenLine(GuiGraphics g, double x1, double y1,
+                               double x2, double y2, int argb, double thickness) {
+        double guiScale = Minecraft.getInstance().getWindow().getGuiScale();
+        double scaledThickness = Math.max(1.0 / guiScale, thickness / guiScale);
+        double margin = HUD_LINE_CULL_MARGIN / guiScale;
+        double minX = -margin;
+        double minY = -margin;
+        double maxX = g.guiWidth() + margin;
+        double maxY = g.guiHeight() + margin;
+        int out1 = outCode(x1, y1, minX, minY, maxX, maxY);
+        int out2 = outCode(x2, y2, minX, minY, maxX, maxY);
+        while ((out1 | out2) != 0) {
+            if ((out1 & out2) != 0) return;
+
+            int outside = out1 != 0 ? out1 : out2;
+            double x;
+            double y;
+            if ((outside & 8) != 0) {
+                x = x1 + (x2 - x1) * (maxY - y1) / (y2 - y1);
+                y = maxY;
+            } else if ((outside & 4) != 0) {
+                x = x1 + (x2 - x1) * (minY - y1) / (y2 - y1);
+                y = minY;
+            } else if ((outside & 2) != 0) {
+                y = y1 + (y2 - y1) * (maxX - x1) / (x2 - x1);
+                x = maxX;
+            } else {
+                y = y1 + (y2 - y1) * (minX - x1) / (x2 - x1);
+                x = minX;
+            }
+
+            if (outside == out1) {
+                x1 = x;
+                y1 = y;
+                out1 = outCode(x1, y1, minX, minY, maxX, maxY);
+            } else {
+                x2 = x;
+                y2 = y;
+                out2 = outCode(x2, y2, minX, minY, maxX, maxY);
+            }
+        }
+
+        double dx = x2 - x1;
+        double dy = y2 - y1;
+        double length = Math.sqrt(dx * dx + dy * dy);
+        if (length < 0.5) return;
+
+        double half = scaledThickness * 0.5;
+        double aaWidth = Math.max(0.75 / guiScale, 0.25);
+        int drawMinX = (int) Math.floor(Math.min(x1, x2) - half - aaWidth);
+        int drawMaxX = (int) Math.ceil(Math.max(x1, x2) + half + aaWidth);
+        int drawMinY = (int) Math.floor(Math.min(y1, y2) - half - aaWidth);
+        int drawMaxY = (int) Math.ceil(Math.max(y1, y2) + half + aaWidth);
+        double invLengthSq = 1.0 / (dx * dx + dy * dy);
+        int baseAlpha = (argb >>> 24) & 0xFF;
+
+        for (int y = drawMinY; y <= drawMaxY; y++) {
+            for (int x = drawMinX; x <= drawMaxX; x++) {
+                double px = x + 0.5;
+                double py = y + 0.5;
+                double t = ((px - x1) * dx + (py - y1) * dy) * invLengthSq;
+                t = Math.max(0.0, Math.min(1.0, t));
+                double closestX = x1 + dx * t;
+                double closestY = y1 + dy * t;
+                double dist = Math.hypot(px - closestX, py - closestY);
+                double coverage = (half + aaWidth - dist) / aaWidth;
+                if (coverage <= 0.0) continue;
+
+                int alpha = (int) Math.round(baseAlpha * Math.min(1.0, coverage));
+                if (alpha <= 0) continue;
+                g.fill(x, y, x + 1, y + 1, (alpha << 24) | (argb & 0x00FFFFFF));
+            }
+        }
+    }
+
+    private static void drawFastScreenLine(GuiGraphics g, double x1, double y1,
+                                           double x2, double y2, int argb,
+                                           double thickness) {
+        double guiScale = Minecraft.getInstance().getWindow().getGuiScale();
+        double scaledThickness = Math.max(1.0 / guiScale, thickness / guiScale);
+        double margin = HUD_LINE_CULL_MARGIN / guiScale;
+        double minX = -margin;
+        double minY = -margin;
+        double maxX = g.guiWidth() + margin;
+        double maxY = g.guiHeight() + margin;
+        int out1 = outCode(x1, y1, minX, minY, maxX, maxY);
+        int out2 = outCode(x2, y2, minX, minY, maxX, maxY);
+        while ((out1 | out2) != 0) {
+            if ((out1 & out2) != 0) return;
+
+            int outside = out1 != 0 ? out1 : out2;
+            double x;
+            double y;
+            if ((outside & 8) != 0) {
+                x = x1 + (x2 - x1) * (maxY - y1) / (y2 - y1);
+                y = maxY;
+            } else if ((outside & 4) != 0) {
+                x = x1 + (x2 - x1) * (minY - y1) / (y2 - y1);
+                y = minY;
+            } else if ((outside & 2) != 0) {
+                y = y1 + (y2 - y1) * (maxX - x1) / (x2 - x1);
+                x = maxX;
+            } else {
+                y = y1 + (y2 - y1) * (minX - x1) / (x2 - x1);
+                x = minX;
+            }
+
+            if (outside == out1) {
+                x1 = x;
+                y1 = y;
+                out1 = outCode(x1, y1, minX, minY, maxX, maxY);
+            } else {
+                x2 = x;
+                y2 = y;
+                out2 = outCode(x2, y2, minX, minY, maxX, maxY);
+            }
+        }
+
+        double dx = x2 - x1;
+        double dy = y2 - y1;
+        double length = Math.sqrt(dx * dx + dy * dy);
+        if (length < 0.5) return;
+
+        double step = Math.max(1.0, scaledThickness * 0.75);
+        int samples = Math.max(1, (int) Math.ceil(length / step));
+        int radius = Math.max(0, (int) Math.floor(scaledThickness * 0.5));
+        for (int i = 0; i <= samples; i++) {
+            double t = i / (double) samples;
+            int x = (int) Math.round(x1 + dx * t);
+            int y = (int) Math.round(y1 + dy * t);
+            g.fill(x - radius, y - radius, x + radius + 1, y + radius + 1, argb);
+        }
+    }
+
+    private static int outCode(double x, double y, double minX, double minY,
+                               double maxX, double maxY) {
+        int code = 0;
+        if (x < minX) code |= 1;
+        else if (x > maxX) code |= 2;
+        if (y < minY) code |= 4;
+        else if (y > maxY) code |= 8;
+        return code;
     }
 
     private enum State {

--- a/src/client/java/dev/ethan/waypointer/render/WaypointRenderer.java
+++ b/src/client/java/dev/ethan/waypointer/render/WaypointRenderer.java
@@ -422,7 +422,7 @@ public final class WaypointRenderer implements HudElement {
             }
 
             float alpha = alphaFor(group, state) * beaconOpacity;
-            int argb = withAlpha(0xFF000000 | (waypoint.color() & 0xFFFFFF), alpha);
+            int argb = RenderHelpers.withAlpha(0xFF000000 | (waypoint.color() & 0xFFFFFF), alpha);
             if (!projectBoxCorners(waypoint, screenW, screenH)) return;
 
             double outlineThickness = config.waypointOutlineThickness();
@@ -534,12 +534,12 @@ public final class WaypointRenderer implements HudElement {
 
             double rowY = sy;
             if (showNames) {
-                drawCenteredLabel(g, font, name, sx, rowY, withAlpha(nameColor, alpha), alpha);
+                drawCenteredLabel(g, font, name, sx, rowY, RenderHelpers.withAlpha(nameColor, alpha), alpha);
                 rowY += font.lineHeight + DISTANCE_ROW_GAP;
             }
             if (showDistances) {
                 drawCenteredLabel(g, font, distanceText, sx, rowY,
-                        withAlpha(DISTANCE_ARGB, alpha), alpha);
+                        RenderHelpers.withAlpha(DISTANCE_ARGB, alpha), alpha);
             }
         });
     }
@@ -551,12 +551,12 @@ public final class WaypointRenderer implements HudElement {
             double rowY = candidate.screenY;
             if (candidate.name != null) {
                 drawCenteredLabel(g, font, candidate.name, candidate.screenX, rowY,
-                        withAlpha(candidate.nameColor, candidate.alpha), candidate.alpha);
+                        RenderHelpers.withAlpha(candidate.nameColor, candidate.alpha), candidate.alpha);
                 rowY += font.lineHeight + DISTANCE_ROW_GAP;
             }
             if (candidate.distance != null) {
                 drawCenteredLabel(g, font, candidate.distance, candidate.screenX, rowY,
-                        withAlpha(DISTANCE_ARGB, candidate.alpha), candidate.alpha);
+                        RenderHelpers.withAlpha(DISTANCE_ARGB, candidate.alpha), candidate.alpha);
             }
         }
     }
@@ -612,7 +612,7 @@ public final class WaypointRenderer implements HudElement {
             int backdropBottom = drawY + font.lineHeight - 1 + BACKDROP_PAD_Y;
             g.fill(drawX - BACKDROP_PAD_X, backdropTop,
                     drawX + width + BACKDROP_PAD_X, backdropBottom,
-                    withAlpha(LABEL_BACKDROP_ARGB, alpha));
+                    RenderHelpers.withAlpha(LABEL_BACKDROP_ARGB, alpha));
         }
         // drawString's shadow flag stays on in both modes -- without the backdrop the
         // drop shadow is doing all the work keeping text readable against bright biomes.
@@ -726,12 +726,6 @@ public final class WaypointRenderer implements HudElement {
             return Math.min(state.alpha, SEQUENCE_CONTEXT_ALPHA);
         }
         return state.alpha;
-    }
-
-    static int withAlpha(int argb, float alphaScale) {
-        float clamped = Math.max(0.0f, Math.min(1.0f, alphaScale));
-        int alpha = Math.round(((argb >>> 24) & 0xFF) * clamped);
-        return (alpha << 24) | (argb & 0x00FFFFFF);
     }
 
     static void drawScreenLine(GuiGraphics g, double x1, double y1,

--- a/src/client/java/dev/ethan/waypointer/screen/AddNamedWaypointScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/AddNamedWaypointScreen.java
@@ -140,7 +140,9 @@ public final class AddNamedWaypointScreen extends Screen {
             y = pos.y();
             z = pos.z();
         }
-        WaypointGroup target = targetGroup == null ? manager.getOrCreateActiveGroup() : targetGroup;
+        WaypointGroup target = targetGroup == null
+                ? manager.getOrCreateActiveGroup(config.skipAheadMechanicEnabled())
+                : targetGroup;
 
         target.add(new Waypoint(x, y, z, nameBox.getValue().trim(),
                 Waypoint.DEFAULT_COLOR, 0, 0.0));

--- a/src/client/java/dev/ethan/waypointer/screen/AddNamedWaypointScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/AddNamedWaypointScreen.java
@@ -5,6 +5,7 @@ import dev.ethan.waypointer.core.ActiveGroupManager;
 import dev.ethan.waypointer.core.Waypoint;
 import dev.ethan.waypointer.core.WaypointGroup;
 import dev.ethan.waypointer.input.WaypointAddFlow;
+import dev.ethan.waypointer.placement.PlayerWaypointPlacement;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
@@ -133,9 +134,11 @@ public final class AddNamedWaypointScreen extends Screen {
                 onClose();
                 return;
             }
-            x = (int) Math.floor(player.getX());
-            y = (int) Math.floor(player.getY());
-            z = (int) Math.floor(player.getZ());
+            PlayerWaypointPlacement.BlockPosition pos = PlayerWaypointPlacement.fromPlayer(
+                    player.getX(), player.getY(), player.getZ(), config);
+            x = pos.x();
+            y = pos.y();
+            z = pos.z();
         }
         WaypointGroup target = targetGroup == null ? manager.getOrCreateActiveGroup() : targetGroup;
 

--- a/src/client/java/dev/ethan/waypointer/screen/AddTempScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/AddTempScreen.java
@@ -4,6 +4,7 @@ import dev.ethan.waypointer.config.WaypointerConfig;
 import dev.ethan.waypointer.core.ActiveGroupManager;
 import dev.ethan.waypointer.core.Waypoint;
 import dev.ethan.waypointer.core.WaypointGroup;
+import dev.ethan.waypointer.placement.PlayerWaypointPlacement;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
@@ -18,7 +19,7 @@ import static dev.ethan.waypointer.screen.GuiTokens.*;
 /**
  * Modal for creating a temporary waypoint. Three expiry modes are offered and
  * a duration (minutes) for the one mode that needs it; every mode produces a
- * waypoint at the player's current block position.
+ * waypoint at the configured player-relative position.
  *
  * <p>The mode + duration defaults come from
  * {@link WaypointerConfig#tempDefaultMode()} / {@link WaypointerConfig#tempDefaultDurationMin()}
@@ -136,10 +137,9 @@ public final class AddTempScreen extends Screen {
                 ? System.currentTimeMillis() + durationMin * 60_000L
                 : 0L;
 
-        Waypoint base = Waypoint.at(
-                (int) Math.floor(p.getX()),
-                (int) Math.floor(p.getY()),
-                (int) Math.floor(p.getZ()));
+        PlayerWaypointPlacement.BlockPosition pos = PlayerWaypointPlacement.fromPlayer(
+                p.getX(), p.getY(), p.getZ(), config);
+        Waypoint base = Waypoint.at(pos.x(), pos.y(), pos.z());
         WaypointGroup target = manager.getOrCreateTempGroup();
         target.add(base.withTemp(mode, expiresAt));
         if (config.focusTempWaypoints()) {

--- a/src/client/java/dev/ethan/waypointer/screen/ColorSwatchButton.java
+++ b/src/client/java/dev/ethan/waypointer/screen/ColorSwatchButton.java
@@ -9,8 +9,8 @@ import net.minecraft.network.chat.Component;
 
 /**
  * Square-ish button whose primary visual IS the colour it represents -- the
- * fill spans the full button, with a small caption in the corner so the user
- * still knows what they're looking at (e.g. "Start" vs "End").
+ * fill spans the full button, with centered text so the control still reads
+ * as an action rather than a passive chip.
  *
  * <p>Replaces the previous text-only Button that read e.g. {@code "Start #F6FBFC"}.
  * Players picking a gradient want to see the actual colour alongside the label;
@@ -25,6 +25,9 @@ public final class ColorSwatchButton extends AbstractButton {
     private static final int BORDER_IDLE    = 0xFF000000;
     private static final int BORDER_HOVER   = 0xFFFFFFFF;
     private static final int BORDER_FOCUS   = 0xFFFFD35A;
+    private static final int INNER_SHADOW   = 0x66000000;
+    private static final int INNER_HIGHLIGHT = 0x33FFFFFF;
+    private static final int DISABLED_OVERLAY = 0xAA000000;
 
     private final Runnable onPress;
     private final String caption;
@@ -57,21 +60,29 @@ public final class ColorSwatchButton extends AbstractButton {
         int x2 = x1 + getWidth();
         int y2 = y1 + getHeight();
 
-        int border = isFocused() ? BORDER_FOCUS : (isHoveredOrFocused() ? BORDER_HOVER : BORDER_IDLE);
+        int border = active && isFocused()
+                ? BORDER_FOCUS
+                : active && isHoveredOrFocused() ? BORDER_HOVER : BORDER_IDLE;
 
         g.fill(x1, y1, x2, y2, border);
         g.fill(x1 + 1, y1 + 1, x2 - 1, y2 - 1, 0xFF000000 | rgb);
+        g.fill(x1 + 1, y1 + 1, x2 - 1, y1 + 2, INNER_HIGHLIGHT);
+        g.fill(x1 + 1, y2 - 2, x2 - 1, y2 - 1, INNER_SHADOW);
+        if (!active) {
+            g.fill(x1 + 1, y1 + 1, x2 - 1, y2 - 1, DISABLED_OVERLAY);
+        }
 
         // Caption with a dark 1px drop shadow offset by (+1, +1). Drop shadow is
         // enough contrast for the bright-swatch case without needing to pick a
         // fully inverted text colour per swatch.
-        int textColor = isLightColor(rgb) ? 0xFF101216 : 0xFFE6E9EC;
+        int textColor = !active ? 0xFF9A9A9A : isLightColor(rgb) ? 0xFF101216 : 0xFFE6E9EC;
         int shadow = textColor == 0xFF101216 ? 0x40FFFFFF : 0x80000000;
         var font = Minecraft.getInstance().font;
-        int textX = x1 + 4;
+        String clipped = font.plainSubstrByWidth(caption, getWidth() - 8);
+        int textX = x1 + (getWidth() - font.width(clipped)) / 2;
         int textY = y1 + (getHeight() - 8) / 2;
-        g.drawString(font, caption, textX + 1, textY + 1, shadow, false);
-        g.drawString(font, caption, textX, textY, textColor, false);
+        g.drawString(font, clipped, textX + 1, textY + 1, shadow, false);
+        g.drawString(font, clipped, textX, textY, textColor, false);
     }
 
     /** Cheap perceptual-luminance threshold to flip caption colour for contrast. */

--- a/src/client/java/dev/ethan/waypointer/screen/ConfigScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/ConfigScreen.java
@@ -126,6 +126,10 @@ public final class ConfigScreen extends Screen {
         y += rowH;
         addBoxStyleRow(col1, y, colW);
         y += rowH;
+        addNumberRow(col1, y, colW, "Outline thickness (px)",
+                config.waypointOutlineThickness(), config::setWaypointOutlineThickness,
+                "Width of waypoint outlines.");
+        y += rowH;
         addBeamModeRow(col1, y, colW);
         y += rowH;
         addBoolRow(col1, y, "Beam extends below waypoint",
@@ -316,10 +320,16 @@ public final class ConfigScreen extends Screen {
                 "Prefer Hypixel-style scoreboard hints when resolving the current zone ID,\n"
               + "even when other signals exist. Use if tab/location detection misbehaves.");
 
-        addBoolRow(col2, rowsY, "Check for updates on startup",
+        int y2 = rowsY;
+        addBoolRow(col2, y2, "Check for updates on startup",
                 config.checkForUpdates(), config::setCheckForUpdates,
                 "On client start, checks GitHub once for a newer Waypointer release.\n"
               + "Off avoids any update HTTP request.");
+        y2 += rowH;
+        addBoolRow(col2, y2, "Experimental Iris HUD fallback",
+                config.irisShaderHudFallback(), config::setIrisShaderHudFallback,
+                "Allows tracers and waypoints to render with iris shaders enabled.\n"
+              + "The appearance will be degraded.");
     }
 
     private int leftHeaderX;

--- a/src/client/java/dev/ethan/waypointer/screen/ConfigScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/ConfigScreen.java
@@ -383,8 +383,8 @@ public final class ConfigScreen extends Screen {
 
     private void addTracerColorRow(int x, int y, int colW, BooleanSupplier enabled,
                                    String tooltip) {
-        int swatchW = 44;
-        int boxW = 80;
+        int swatchW = 72;
+        int boxW = 76;
         int labelW = colW - boxW - swatchW - GAP * 2;
         addRenderableOnly(new LabelWidget(x, y + 6,
                 "Tracer color (hex RRGGBB)", labelW, enabled));
@@ -396,8 +396,8 @@ public final class ConfigScreen extends Screen {
         box.setTooltip(Tooltip.create(Component.literal(tooltip)));
 
         ColorSwatchButton swatch = new ColorSwatchButton(
-                x + labelW + GAP + boxW + GAP, y, swatchW, BTN_H,
-                "Pick", config.tracerColor(), () -> ColorPickerScreen.open(this,
+                x + labelW + GAP + boxW + GAP, y + 2, swatchW, BTN_H,
+                "Pick color", config.tracerColor(), () -> ColorPickerScreen.open(this,
                 "Tracer Colour", config.tracerColor(), picked -> {
                     config.setTracerColor(picked);
                     box.setValue(String.format("%06X", picked & 0xFFFFFF));

--- a/src/client/java/dev/ethan/waypointer/screen/ConfigScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/ConfigScreen.java
@@ -176,6 +176,12 @@ public final class ConfigScreen extends Screen {
                 "Opacity of the line drawn from the crosshair to the active waypoint.\n"
               + "0 is fully transparent, 1 is solid.");
         y2 += rowH;
+        addNumberRow(col2, y2, colW, "Tracer thickness (px)",
+                config.tracerThickness(), config::setTracerThickness,
+                config::showTracer,
+                "Pixel width of the crosshair tracer line. Values are clamped\n"
+              + "from 1 to 12 so it stays visible without flooding the screen.");
+        y2 += rowH;
         addTracerColorRow(col2, y2, colW,
                 () -> config.showTracer() && !config.matchTracerToWaypointColor(),
                 "Fixed tracer color as hex RRGGBB (e.g. 4FE05A). Only used when\n"
@@ -246,6 +252,11 @@ public final class ConfigScreen extends Screen {
                 config.restartRouteWhenComplete(), config::setRestartRouteWhenComplete,
                 "After you complete the final waypoint, progress wraps to the first point\n"
               + "so loop and farm routes do not sit in a \"finished\" state.");
+        y += rowH;
+        addBoolRow(col1, y, "Add new waypoints below player",
+                config.placeNewWaypointsBelowPlayer(), config::setPlaceNewWaypointsBelowPlayer,
+                "When adding at your position, place the marker one block below your feet.\n"
+              + "Turn off to use your exact standing block. Typed coordinates stay exact.");
 
         int y2 = rowsY;
         addBoolRow(col2, y2, "Dim sequence context waypoints",

--- a/src/client/java/dev/ethan/waypointer/screen/GroupEditScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/GroupEditScreen.java
@@ -432,14 +432,22 @@ public final class GroupEditScreen extends Screen {
         if (p == null) return;
         PlayerWaypointPlacement.BlockPosition pos = PlayerWaypointPlacement.fromPlayer(
                 p.getX(), p.getY(), p.getZ(), config);
-        group.add(new Waypoint(
+        Waypoint newWaypoint = new Waypoint(
                 pos.x(), pos.y(), pos.z(),
-                "", Waypoint.DEFAULT_COLOR, 0, 0.0));
+                "", Waypoint.DEFAULT_COLOR, 0, 0.0);
+        int newIndex;
+        if (hasSelectedWaypoint()) {
+            newIndex = selectedIndex + 1;
+            group.insert(newIndex, newWaypoint);
+        } else {
+            group.add(newWaypoint);
+            newIndex = group.size() - 1;
+        }
         // Run the shared post-add flow (focus + mode/toast updates) so the
         // GUI add button behaves identically to /wp add and the keybind path.
-        new WaypointAddFlow().afterWaypointAdded(group, group.size() - 1);
+        new WaypointAddFlow().afterWaypointAdded(group, newIndex);
         if (skipAheadBtn != null) skipAheadBtn.setMessage(skipAheadLabel());
-        selectWaypoint(group.size() - 1);
+        selectWaypoint(newIndex);
         manager.fireDataChanged();
     }
 

--- a/src/client/java/dev/ethan/waypointer/screen/GroupEditScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/GroupEditScreen.java
@@ -447,6 +447,7 @@ public final class GroupEditScreen extends Screen {
     private void removeSelected() {
         if (selectedIndex < 0 || selectedIndex >= group.size()) return;
         group.remove(selectedIndex);
+        coordinateEditorIndex = -1;
         selectWaypoint(Math.min(selectedIndex, group.size() - 1));
         manager.fireDataChanged();
     }

--- a/src/client/java/dev/ethan/waypointer/screen/GroupEditScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/GroupEditScreen.java
@@ -432,17 +432,10 @@ public final class GroupEditScreen extends Screen {
         if (p == null) return;
         PlayerWaypointPlacement.BlockPosition pos = PlayerWaypointPlacement.fromPlayer(
                 p.getX(), p.getY(), p.getZ(), config);
-        Waypoint newWaypoint = new Waypoint(
+        group.add(new Waypoint(
                 pos.x(), pos.y(), pos.z(),
-                "", Waypoint.DEFAULT_COLOR, 0, 0.0);
-        int newIndex;
-        if (hasSelectedWaypoint()) {
-            newIndex = selectedIndex + 1;
-            group.insert(newIndex, newWaypoint);
-        } else {
-            group.add(newWaypoint);
-            newIndex = group.size() - 1;
-        }
+                "", Waypoint.DEFAULT_COLOR, 0, 0.0));
+        int newIndex = group.size() - 1;
         // Run the shared post-add flow (focus + mode/toast updates) so the
         // GUI add button behaves identically to /wp add and the keybind path.
         new WaypointAddFlow().afterWaypointAdded(group, newIndex);

--- a/src/client/java/dev/ethan/waypointer/screen/GroupEditScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/GroupEditScreen.java
@@ -71,6 +71,11 @@ public final class GroupEditScreen extends Screen {
     private Button sortBtn;
     private Button radiusMinusBtn;
     private Button radiusPlusBtn;
+    private Button skipAheadBtn;
+    private Button moveSelectedHereBtn;
+    private EditBox coordXBox;
+    private EditBox coordYBox;
+    private EditBox coordZBox;
     // Two small colour swatch buttons for the gradient endpoints. Stored so
     // the colour-picker callback can push the new colour back onto the
     // correct widget without chasing it through the widget tree.
@@ -80,6 +85,8 @@ public final class GroupEditScreen extends Screen {
     private SortMode sortMode = SortMode.MANUAL;
     private int scrollOffset;
     private int selectedIndex = -1;
+    private int coordinateEditorIndex = -1;
+    private boolean syncingCoordinateEditors;
 
     // Inline per-row label editor: shown only while the user is renaming a waypoint,
     // positioned in render() so it tracks the row through scroll. We hold one EditBox
@@ -212,6 +219,28 @@ public final class GroupEditScreen extends Screen {
           .tooltip(Tooltip.create(Component.literal(
                   "Set current waypoint to #1.")))
           .build());
+        y += BTN_H + GAP;
+
+        skipAheadBtn = Button.builder(skipAheadLabel(), this::toggleSkipAhead)
+                .bounds(sidebarInner, y, fieldW, BTN_H)
+                .tooltip(Tooltip.create(Component.literal(
+                        "Route-specific skip-ahead gate.\n"
+                      + "OFF forces this group to advance in order even when\n"
+                      + "the global skip-ahead setting is enabled.")))
+                .build();
+        addRenderableWidget(skipAheadBtn);
+        y += BTN_H + GAP;
+
+        addCoordinateEditors(sidebarInner, y, fieldW);
+        y += BTN_H + GAP;
+
+        moveSelectedHereBtn = Button.builder(Component.literal("Move Selected Here"), b -> moveSelectedHere())
+                .bounds(sidebarInner, y, fieldW, BTN_H)
+                .tooltip(Tooltip.create(Component.literal(
+                        "Replace the selected waypoint's coordinates with your\n"
+                      + "current block position.")))
+                .build();
+        addRenderableWidget(moveSelectedHereBtn);
 
         // Inline label editor -- kept invisible until the user double-clicks a row.
         // Added last so it paints on top of the row it's editing. A fresh widget per
@@ -221,6 +250,7 @@ public final class GroupEditScreen extends Screen {
         labelEditor.setMaxLength(64);
         labelEditor.setVisible(false);
         addRenderableWidget(labelEditor);
+        syncCoordinateEditors();
 
         // Footer
         int footerY = height - FOOTER_H;
@@ -300,6 +330,64 @@ public final class GroupEditScreen extends Screen {
         manager.fireDataChanged();
     }
 
+    private Component skipAheadLabel() {
+        return Component.literal("Skip Ahead: " + (group.skipAheadEnabled() ? "ON" : "OFF"));
+    }
+
+    private void toggleSkipAhead(Button b) {
+        group.setSkipAheadEnabled(!group.skipAheadEnabled());
+        b.setMessage(skipAheadLabel());
+        manager.fireDataChanged();
+    }
+
+    private void addCoordinateEditors(int x, int y, int width) {
+        int boxW = (width - GAP_TIGHT * 2) / 3;
+        coordXBox = createCoordinateEditor("X", 0);
+        coordYBox = createCoordinateEditor("Y", 1);
+        coordZBox = createCoordinateEditor("Z", 2);
+
+        coordXBox.setX(x);
+        coordYBox.setX(x + boxW + GAP_TIGHT);
+        coordZBox.setX(x + (boxW + GAP_TIGHT) * 2);
+        coordXBox.setY(y);
+        coordYBox.setY(y);
+        coordZBox.setY(y);
+        coordXBox.setWidth(boxW);
+        coordYBox.setWidth(boxW);
+        coordZBox.setWidth(width - boxW * 2 - GAP_TIGHT * 2);
+
+        addRenderableWidget(coordXBox);
+        addRenderableWidget(coordYBox);
+        addRenderableWidget(coordZBox);
+    }
+
+    private EditBox createCoordinateEditor(String label, int axis) {
+        EditBox box = new EditBox(font, 0, 0, 40, BTN_H, Component.literal(label));
+        box.setMaxLength(12);
+        box.setHint(Component.literal(label));
+        box.setTooltip(Tooltip.create(Component.literal(
+                "Edit the selected waypoint's " + label + " coordinate.")));
+        box.setResponder(v -> updateSelectedCoordinate(axis, v));
+        return box;
+    }
+
+    private void updateSelectedCoordinate(int axis, String raw) {
+        if (syncingCoordinateEditors) return;
+        if (!hasSelectedWaypoint() || raw.isBlank()) return;
+
+        try {
+            int value = Integer.parseInt(raw.trim());
+            Waypoint w = group.get(selectedIndex);
+            int x = axis == 0 ? value : w.x();
+            int y = axis == 1 ? value : w.y();
+            int z = axis == 2 ? value : w.z();
+            group.set(selectedIndex, w.withPos(x, y, z));
+            manager.fireDataChanged();
+        } catch (NumberFormatException ignored) {
+            // Partial integer edits such as "-" are expected while typing.
+        }
+    }
+
     private Component sortLabel() {
         return Component.literal("Sort: " + sortMode.label);
     }
@@ -355,6 +443,59 @@ public final class GroupEditScreen extends Screen {
 
     // --- actions ----------------------------------------------------------------------------
 
+    private boolean hasSelectedWaypoint() {
+        return selectedIndex >= 0 && selectedIndex < group.size();
+    }
+
+    private void selectWaypoint(int index) {
+        selectedIndex = index >= 0 && index < group.size() ? index : -1;
+        syncCoordinateEditors();
+    }
+
+    private void syncCoordinateEditors() {
+        if (coordXBox == null || coordYBox == null || coordZBox == null) return;
+
+        boolean hasSelection = hasSelectedWaypoint();
+        coordXBox.active = hasSelection;
+        coordYBox.active = hasSelection;
+        coordZBox.active = hasSelection;
+        if (moveSelectedHereBtn != null) moveSelectedHereBtn.active = hasSelection;
+
+        if (!hasSelection) {
+            coordinateEditorIndex = -1;
+            setCoordinateEditorValues("", "", "");
+            return;
+        }
+
+        if (coordinateEditorIndex == selectedIndex) return;
+        Waypoint w = group.get(selectedIndex);
+        coordinateEditorIndex = selectedIndex;
+        setCoordinateEditorValues(Integer.toString(w.x()), Integer.toString(w.y()), Integer.toString(w.z()));
+    }
+
+    private void setCoordinateEditorValues(String x, String y, String z) {
+        syncingCoordinateEditors = true;
+        coordXBox.setValue(x);
+        coordYBox.setValue(y);
+        coordZBox.setValue(z);
+        syncingCoordinateEditors = false;
+    }
+
+    private void moveSelectedHere() {
+        if (!hasSelectedWaypoint()) return;
+
+        LocalPlayer p = Minecraft.getInstance().player;
+        if (p == null) return;
+
+        PlayerWaypointPlacement.BlockPosition pos = PlayerWaypointPlacement.fromPlayer(
+                p.getX(), p.getY(), p.getZ(), config);
+        Waypoint w = group.get(selectedIndex);
+        group.set(selectedIndex, w.withPos(pos.x(), pos.y(), pos.z()));
+        coordinateEditorIndex = -1;
+        syncCoordinateEditors();
+        manager.fireDataChanged();
+    }
+
     private void addTempHere() {
         // Temps always land in the per-zone temp bucket regardless of which
         // group we opened this screen from -- see AddTempScreen for the
@@ -377,6 +518,8 @@ public final class GroupEditScreen extends Screen {
         // Run the shared post-add flow (auto-disable skip-ahead + toast) so the
         // GUI add button behaves identically to /wp add and the keybind path.
         new WaypointAddFlow().afterWaypointAdded(group, group.size() - 1);
+        if (skipAheadBtn != null) skipAheadBtn.setMessage(skipAheadLabel());
+        selectWaypoint(group.size() - 1);
         manager.fireDataChanged();
         onManualEdit();
     }
@@ -439,13 +582,15 @@ public final class GroupEditScreen extends Screen {
         group.replaceWaypoints(pts);
         group.setGradientMode(mode);
         group.setCurrentIndex(0);
+        coordinateEditorIndex = -1;
+        syncCoordinateEditors();
         manager.fireDataChanged();
     }
 
     private void removeSelected() {
         if (selectedIndex < 0 || selectedIndex >= group.size()) return;
         group.remove(selectedIndex);
-        selectedIndex = Math.min(selectedIndex, group.size() - 1);
+        selectWaypoint(Math.min(selectedIndex, group.size() - 1));
         manager.fireDataChanged();
         onManualEdit();
     }
@@ -455,7 +600,7 @@ public final class GroupEditScreen extends Screen {
         int to = Math.max(0, Math.min(group.size() - 1, selectedIndex + delta));
         if (to == selectedIndex) return;
         group.move(selectedIndex, to);
-        selectedIndex = to;
+        selectWaypoint(to);
         manager.fireDataChanged();
         onManualEdit();
     }
@@ -623,7 +768,7 @@ public final class GroupEditScreen extends Screen {
             int idx = rowIndexAt(event.x(), event.y());
             if (idx >= 0) {
                 group.setCurrentIndex(idx);
-                selectedIndex = idx;
+                selectWaypoint(idx);
                 manager.fireDataChanged();
                 return true;
             }
@@ -649,7 +794,7 @@ public final class GroupEditScreen extends Screen {
                 } else {
                     openWaypointColorPicker(swatchIdx);
                 }
-                selectedIndex = swatchIdx;
+                selectWaypoint(swatchIdx);
                 return true;
             }
         }
@@ -659,7 +804,7 @@ public final class GroupEditScreen extends Screen {
 
         int idx = rowIndexAt(event.x(), event.y());
         if (idx < 0) return false;
-        selectedIndex = idx;
+        selectWaypoint(idx);
 
         if (doubleClick) beginLabelEdit(idx);
         return true;
@@ -777,7 +922,7 @@ public final class GroupEditScreen extends Screen {
      */
     private void beginLabelEdit(int index) {
         if (index < 0 || index >= group.size()) return;
-        selectedIndex = index;
+        selectWaypoint(index);
         editingIndex = index;
 
         Waypoint w = group.get(index);

--- a/src/client/java/dev/ethan/waypointer/screen/GroupEditScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/GroupEditScreen.java
@@ -355,7 +355,7 @@ public final class GroupEditScreen extends Screen {
             int x = axis == 0 ? value : w.x();
             int y = axis == 1 ? value : w.y();
             int z = axis == 2 ? value : w.z();
-            group.moveWaypointTo(selectedIndex, x, y, z);
+            group.set(selectedIndex, w.withPos(x, y, z));
             manager.fireDataChanged();
         } catch (NumberFormatException ignored) {
             // Partial integer edits such as "-" are expected while typing.

--- a/src/client/java/dev/ethan/waypointer/screen/GroupEditScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/GroupEditScreen.java
@@ -7,6 +7,7 @@ import dev.ethan.waypointer.core.ActiveGroupManager;
 import dev.ethan.waypointer.core.Waypoint;
 import dev.ethan.waypointer.core.WaypointGroup;
 import dev.ethan.waypointer.input.WaypointAddFlow;
+import dev.ethan.waypointer.placement.PlayerWaypointPlacement;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
@@ -368,8 +369,10 @@ public final class GroupEditScreen extends Screen {
     private void addHere() {
         LocalPlayer p = Minecraft.getInstance().player;
         if (p == null) return;
+        PlayerWaypointPlacement.BlockPosition pos = PlayerWaypointPlacement.fromPlayer(
+                p.getX(), p.getY(), p.getZ(), config);
         group.add(new Waypoint(
-                (int) Math.floor(p.getX()), (int) Math.floor(p.getY()), (int) Math.floor(p.getZ()),
+                pos.x(), pos.y(), pos.z(),
                 "", Waypoint.DEFAULT_COLOR, 0, 0.0));
         // Run the shared post-add flow (auto-disable skip-ahead + toast) so the
         // GUI add button behaves identically to /wp add and the keybind path.

--- a/src/client/java/dev/ethan/waypointer/screen/GroupEditScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/GroupEditScreen.java
@@ -54,12 +54,6 @@ import static dev.ethan.waypointer.screen.GuiTokens.*;
  */
 public final class GroupEditScreen extends Screen {
 
-    private enum SortMode {
-        MANUAL("Manual"), NEAREST("Nearest"), Y_ASC("Y asc"), Y_DESC("Y desc");
-        final String label;
-        SortMode(String label) { this.label = label; }
-    }
-
     private final Screen parent;
     private final ActiveGroupManager manager;
     private final WaypointerConfig config;
@@ -68,7 +62,6 @@ public final class GroupEditScreen extends Screen {
     private EditBox nameBox;
     private Button gradientBtn;
     private Button modeBtn;
-    private Button sortBtn;
     private Button radiusMinusBtn;
     private Button radiusPlusBtn;
     private Button skipAheadBtn;
@@ -82,7 +75,6 @@ public final class GroupEditScreen extends Screen {
     private ColorSwatchButton gradientStartBtn;
     private ColorSwatchButton gradientEndBtn;
 
-    private SortMode sortMode = SortMode.MANUAL;
     private int scrollOffset;
     private int selectedIndex = -1;
     private int coordinateEditorIndex = -1;
@@ -99,21 +91,6 @@ public final class GroupEditScreen extends Screen {
     private static final int GLFW_KEY_ESCAPE   = 256;
     private static final int GLFW_KEY_ENTER    = 257;
     private static final int GLFW_KEY_KP_ENTER = 335;
-
-    /**
-     * Snapshot of the manual state so cycling through the sort modes never loses
-     * the route the player hand-arranged. Order AND current progress index are both
-     * captured so an accidental cycle restores the editor to the exact state the
-     * player would expect -- order alone would resurrect the route but leave them
-     * at progress 0 after Nearest reset it on the way through.
-     *
-     * Captured on the first transition away from MANUAL, refreshed whenever the
-     * player makes a manual edit (add/move/remove), restored when the cycle wraps
-     * back to MANUAL. {@code null} means "nothing to restore": we don't pretend
-     * there's a saved order before the user ever pressed the sort button.
-     */
-    private record ManualSnapshot(List<Waypoint> order, int currentIndex) {}
-    private ManualSnapshot manualSnapshot = null;
 
     public GroupEditScreen(Screen parent, ActiveGroupManager manager, WaypointerConfig config, WaypointGroup group) {
         super(Component.literal("Edit: " + group.name()));
@@ -170,6 +147,7 @@ public final class GroupEditScreen extends Screen {
               + "Applies in AUTO mode.")));
         addRenderableWidget(gradientStartBtn);
         addRenderableWidget(gradientEndBtn);
+        updateGradientButtons();
         y += BTN_H + GAP_TIGHT;
 
         // Mode toggle
@@ -203,30 +181,10 @@ public final class GroupEditScreen extends Screen {
         addRenderableWidget(radiusPlusBtn);
         y += BTN_H + GAP;
 
-        // Sort cycle
-        sortBtn = Button.builder(sortLabel(), this::cycleSort)
-                .bounds(sidebarInner, y, fieldW, BTN_H)
-                .tooltip(sortTooltip())
-                .build();
-        addRenderableWidget(sortBtn);
-        y += BTN_H + GAP;
-
-        // Reset progress (de-emphasized)
-        addRenderableWidget(Button.builder(Component.literal("Reset Progress"), b -> {
-            group.resetProgress();
-            manager.fireDataChanged();
-        }).bounds(sidebarInner, y, fieldW, BTN_H)
-          .tooltip(Tooltip.create(Component.literal(
-                  "Set current waypoint to #1.")))
-          .build());
-        y += BTN_H + GAP;
-
         skipAheadBtn = Button.builder(skipAheadLabel(), this::toggleSkipAhead)
                 .bounds(sidebarInner, y, fieldW, BTN_H)
                 .tooltip(Tooltip.create(Component.literal(
-                        "Route-specific skip-ahead gate.\n"
-                      + "OFF forces this group to advance in order even when\n"
-                      + "the global skip-ahead setting is enabled.")))
+                        "Toggle skipping waypoints for this group.")))
                 .build();
         addRenderableWidget(skipAheadBtn);
         y += BTN_H + GAP;
@@ -241,6 +199,16 @@ public final class GroupEditScreen extends Screen {
                       + "current block position.")))
                 .build();
         addRenderableWidget(moveSelectedHereBtn);
+
+        int sidebarBottom = height - FOOTER_H - GAP_SECTION;
+        int resetY = sidebarBottom - BTN_H - GAP;
+        addRenderableWidget(Button.builder(Component.literal("Reset Progress"), b -> {
+            group.resetProgress();
+            manager.fireDataChanged();
+        }).bounds(sidebarInner, resetY, fieldW, BTN_H)
+          .tooltip(Tooltip.create(Component.literal(
+                  "Set current waypoint to #1.")))
+          .build());
 
         // Inline label editor -- kept invisible until the user double-clicks a row.
         // Added last so it paints on top of the row it's editing. A fresh widget per
@@ -289,7 +257,14 @@ public final class GroupEditScreen extends Screen {
         group.setGradientMode(group.gradientMode() == WaypointGroup.GradientMode.AUTO
                 ? WaypointGroup.GradientMode.MANUAL : WaypointGroup.GradientMode.AUTO);
         b.setMessage(gradientLabel());
+        updateGradientButtons();
         manager.fireDataChanged();
+    }
+
+    private void updateGradientButtons() {
+        boolean active = group.gradientMode() == WaypointGroup.GradientMode.AUTO;
+        if (gradientStartBtn != null) gradientStartBtn.active = active;
+        if (gradientEndBtn != null) gradientEndBtn.active = active;
     }
 
     private void openGradientPicker(boolean start) {
@@ -313,9 +288,8 @@ public final class GroupEditScreen extends Screen {
 
     private static Tooltip modeTooltip() {
         return Tooltip.create(Component.literal(
-                "World display mode.\n"
-              + "STATIC: show all waypoints.\n"
-              + "SEQUENCE: show previous, current, next."));
+                "Static: Show all waypoints\n"
+              + "Sequenced: Go one-by-one"));
     }
 
     private void toggleLoadMode(Button b) {
@@ -381,64 +355,11 @@ public final class GroupEditScreen extends Screen {
             int x = axis == 0 ? value : w.x();
             int y = axis == 1 ? value : w.y();
             int z = axis == 2 ? value : w.z();
-            group.set(selectedIndex, w.withPos(x, y, z));
+            group.moveWaypointTo(selectedIndex, x, y, z);
             manager.fireDataChanged();
         } catch (NumberFormatException ignored) {
             // Partial integer edits such as "-" are expected while typing.
         }
-    }
-
-    private Component sortLabel() {
-        return Component.literal("Sort: " + sortMode.label);
-    }
-
-    private static Tooltip sortTooltip() {
-        return Tooltip.create(Component.literal(
-                "Click to change route order.\n"
-              + "Manual -> Nearest -> Y asc -> Y desc.\n"
-              + "Manual restores your custom order."));
-    }
-
-    // Cycles through MANUAL -> NEAREST -> Y asc -> Y desc -> MANUAL. Leaving MANUAL
-    // snapshots the current order so cycling back restores it verbatim; auto-sort
-    // modes apply immediately. A Manual -> Manual cycle is impossible by construction.
-    private void cycleSort(Button b) {
-        SortMode next = switch (sortMode) {
-            case MANUAL  -> SortMode.NEAREST;
-            case NEAREST -> SortMode.Y_ASC;
-            case Y_ASC   -> SortMode.Y_DESC;
-            case Y_DESC  -> SortMode.MANUAL;
-        };
-
-        // The transition out of MANUAL is the last safe moment to capture what the
-        // user considers "manual" -- any auto-sort below would overwrite the list,
-        // and we need something to hand back when the cycle lands on MANUAL again.
-        if (sortMode == SortMode.MANUAL && next != SortMode.MANUAL) {
-            manualSnapshot = new ManualSnapshot(new ArrayList<>(group.waypoints()), group.currentIndex());
-        }
-
-        sortMode = next;
-        b.setMessage(sortLabel());
-
-        switch (sortMode) {
-            case NEAREST -> sortByDistance();
-            case Y_ASC   -> sortByY(true);
-            case Y_DESC  -> sortByY(false);
-            case MANUAL  -> restoreManualOrder();
-        }
-    }
-
-    /**
-     * Puts the group back into the player's last hand-arranged order AND progress
-     * index. If we never snapshotted (i.e. the player never left MANUAL this
-     * session) the existing state IS the manual state, and we no-op rather than
-     * clobber it.
-     */
-    private void restoreManualOrder() {
-        if (manualSnapshot == null) return;
-        replaceAll(manualSnapshot.order());
-        group.setCurrentIndex(manualSnapshot.currentIndex());
-        manager.fireDataChanged();
     }
 
     // --- actions ----------------------------------------------------------------------------
@@ -489,8 +410,7 @@ public final class GroupEditScreen extends Screen {
 
         PlayerWaypointPlacement.BlockPosition pos = PlayerWaypointPlacement.fromPlayer(
                 p.getX(), p.getY(), p.getZ(), config);
-        Waypoint w = group.get(selectedIndex);
-        group.set(selectedIndex, w.withPos(pos.x(), pos.y(), pos.z()));
+        group.moveWaypointTo(selectedIndex, pos.x(), pos.y(), pos.z());
         coordinateEditorIndex = -1;
         syncCoordinateEditors();
         manager.fireDataChanged();
@@ -515,75 +435,11 @@ public final class GroupEditScreen extends Screen {
         group.add(new Waypoint(
                 pos.x(), pos.y(), pos.z(),
                 "", Waypoint.DEFAULT_COLOR, 0, 0.0));
-        // Run the shared post-add flow (auto-disable skip-ahead + toast) so the
+        // Run the shared post-add flow (focus + mode/toast updates) so the
         // GUI add button behaves identically to /wp add and the keybind path.
         new WaypointAddFlow().afterWaypointAdded(group, group.size() - 1);
         if (skipAheadBtn != null) skipAheadBtn.setMessage(skipAheadLabel());
         selectWaypoint(group.size() - 1);
-        manager.fireDataChanged();
-        onManualEdit();
-    }
-
-    /**
-     * Called after any manual mutation of the list (add / move / remove). Drops the
-     * sort label back to MANUAL and refreshes the snapshot so the new order IS the
-     * manual state: cycling Nearest -> Y asc -> Y desc -> Manual will hand it back
-     * unchanged. Without this, the snapshot would go stale and "restore" to a
-     * pre-edit list, silently undoing the player's edit.
-     */
-    private void onManualEdit() {
-        if (sortMode != SortMode.MANUAL) {
-            sortMode = SortMode.MANUAL;
-            if (sortBtn != null) sortBtn.setMessage(sortLabel());
-        }
-        manualSnapshot = new ManualSnapshot(new ArrayList<>(group.waypoints()), group.currentIndex());
-    }
-
-    private void sortByDistance() {
-        LocalPlayer p = Minecraft.getInstance().player;
-        if (p == null || group.size() <= 1) return;
-        // Nearest-neighbour greedy sort: does what the player means by "put the nearest
-        // one first" better than raw distance-to-player (which would reorder globally
-        // even when the current head is already fine).
-        double cx = p.getX(), cy = p.getY(), cz = p.getZ();
-        List<Waypoint> pts = new ArrayList<>(group.waypoints());
-        List<Waypoint> sorted = new ArrayList<>(pts.size());
-        while (!pts.isEmpty()) {
-            int best = 0;
-            double bestDist = Double.MAX_VALUE;
-            for (int i = 0; i < pts.size(); i++) {
-                Waypoint w = pts.get(i);
-                double dx = (w.x() + 0.5) - cx;
-                double dy = (w.y() + 0.5) - cy;
-                double dz = (w.z() + 0.5) - cz;
-                double d = dx * dx + dy * dy + dz * dz;
-                if (d < bestDist) { bestDist = d; best = i; }
-            }
-            Waypoint w = pts.remove(best);
-            sorted.add(w);
-            cx = w.x(); cy = w.y(); cz = w.z();
-        }
-        replaceAll(sorted);
-    }
-
-    private void sortByY(boolean ascending) {
-        if (group.size() <= 1) return;
-        List<Waypoint> pts = new ArrayList<>(group.waypoints());
-        pts.sort((a, b) -> ascending ? Integer.compare(a.y(), b.y()) : Integer.compare(b.y(), a.y()));
-        replaceAll(pts);
-    }
-
-    private void replaceAll(List<Waypoint> pts) {
-        // Preserve gradient mode + progress intentionally: user expects the colors to
-        // re-gradient across the new order, and starting progress over is the least
-        // surprising behaviour after a sort.
-        WaypointGroup.GradientMode mode = group.gradientMode();
-        group.setGradientMode(WaypointGroup.GradientMode.MANUAL);
-        group.replaceWaypoints(pts);
-        group.setGradientMode(mode);
-        group.setCurrentIndex(0);
-        coordinateEditorIndex = -1;
-        syncCoordinateEditors();
         manager.fireDataChanged();
     }
 
@@ -592,7 +448,6 @@ public final class GroupEditScreen extends Screen {
         group.remove(selectedIndex);
         selectWaypoint(Math.min(selectedIndex, group.size() - 1));
         manager.fireDataChanged();
-        onManualEdit();
     }
 
     private void moveSelected(int delta) {
@@ -602,7 +457,6 @@ public final class GroupEditScreen extends Screen {
         group.move(selectedIndex, to);
         selectWaypoint(to);
         manager.fireDataChanged();
-        onManualEdit();
     }
 
     private void export() {

--- a/src/client/java/dev/ethan/waypointer/screen/WaypointerScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/WaypointerScreen.java
@@ -436,7 +436,8 @@ public final class WaypointerScreen extends Screen {
     // --- actions -----------------------------------------------------------------------------
 
     private void createGroup() {
-        WaypointGroup g = WaypointGroup.create("New group", selectedZoneId);
+        WaypointGroup g = WaypointGroup.create(
+                "New group", selectedZoneId, config.skipAheadMechanicEnabled());
         g.setDefaultRadius(config.defaultReachRadius());
         manager.add(g);
         minecraft.setScreen(new GroupEditScreen(this, manager, config, g));

--- a/src/main/java/dev/ethan/waypointer/api/DefaultWaypointerApi.java
+++ b/src/main/java/dev/ethan/waypointer/api/DefaultWaypointerApi.java
@@ -78,6 +78,19 @@ public final class DefaultWaypointerApi implements WaypointerApi {
     }
 
     @Override
+    public boolean updateWaypoint(String groupId, int waypointIndex, WaypointSpec replacement) {
+        Objects.requireNonNull(groupId, "groupId");
+        Objects.requireNonNull(replacement, "replacement");
+        WaypointGroup group = manager.get(groupId);
+        if (group == null) return false;
+        if (waypointIndex < 0 || waypointIndex >= group.size()) return false;
+
+        group.set(waypointIndex, replacement.toWaypoint());
+        manager.fireDataChanged();
+        return true;
+    }
+
+    @Override
     public WaypointGroupSnapshot addTempWaypoint(WaypointSpec waypoint) {
         Objects.requireNonNull(waypoint, "waypoint");
         WaypointGroup group = manager.getOrCreateTempGroup(waypoint.source());

--- a/src/main/java/dev/ethan/waypointer/api/WaypointerApi.java
+++ b/src/main/java/dev/ethan/waypointer/api/WaypointerApi.java
@@ -78,6 +78,17 @@ public interface WaypointerApi {
     boolean addWaypoint(String groupId, WaypointSpec waypoint);
 
     /**
+     * Replace one waypoint in an existing route.
+     *
+     * <p>Use this for edits that should keep the waypoint in the same list
+     * position while changing its coordinates, name, color, flags, or radius.
+     *
+     * @return {@code true} when the waypoint was replaced, {@code false} when the
+     *         route id did not exist or the index was outside the route
+     */
+    boolean updateWaypoint(String groupId, int waypointIndex, WaypointSpec replacement);
+
+    /**
      * Add one session-only marker to Waypointer's temp bucket for the current zone.
      *
      * <p>Use this for short-lived markers such as chat coordinates, burrows, or

--- a/src/main/java/dev/ethan/waypointer/config/Storage.java
+++ b/src/main/java/dev/ethan/waypointer/config/Storage.java
@@ -166,6 +166,7 @@ public final class Storage {
         o.addProperty("gradientMode", g.gradientMode().name());
         o.addProperty("loadMode", g.loadMode().name());
         o.addProperty("defaultRadius", g.defaultRadius());
+        o.addProperty("skipAheadEnabled", g.skipAheadEnabled());
         // Per-group gradient endpoints. Stored as ints rather than hex strings
         // because the rest of the waypoint colour fields are already ints -- one
         // less parser branch in load().
@@ -194,6 +195,7 @@ public final class Storage {
                 o.get("gradientMode").getAsString()).ifPresent(g::setGradientMode);
         if (o.has("loadMode")) parseEnum(WaypointGroup.LoadMode.class,
                 o.get("loadMode").getAsString()).ifPresent(g::setLoadMode);
+        if (o.has("skipAheadEnabled")) g.setSkipAheadEnabled(o.get("skipAheadEnabled").getAsBoolean());
         // Gradient endpoints were added after schema v1 so both fields are optional;
         // missing values leave the group on its built-in cyan/red defaults.
         if (o.has("gradientStartColor")) g.setGradientStartColor(o.get("gradientStartColor").getAsInt());

--- a/src/main/java/dev/ethan/waypointer/config/WaypointerConfig.java
+++ b/src/main/java/dev/ethan/waypointer/config/WaypointerConfig.java
@@ -85,6 +85,12 @@ public final class WaypointerConfig {
      * tracers or giant lines that flood the screen.
      */
     private double tracerThickness = 3.0;
+    /**
+     * Pixel width for waypoint box outlines in both the normal world renderer
+     * and the Iris HUD fallback. Kept separate from tracer thickness because
+     * users often want a subtle box but a stronger navigation line.
+     */
+    private double waypointOutlineThickness = 3.0;
     private double beaconOpacity = 0.8;
     private boolean showWaypointNames = true;
     private boolean showWaypointDistances = true;
@@ -234,6 +240,13 @@ public final class WaypointerConfig {
      * privacy-minded users can disable it without losing the rest of the mod.
      */
     private boolean checkForUpdates = true;
+    /**
+     * Experimental compatibility path for Iris shader packs that composite after
+     * Waypointer's no-depth world render pass. When enabled, active Iris shaders
+     * draw waypoint boxes/tracers as projected HUD overlays instead of world
+     * geometry so shader depth buffers cannot hide them.
+     */
+    private boolean irisShaderHudFallback = false;
 
     /**
      * Default mode for the "Add Temp Waypoint Here" keybind, and the pre-selected
@@ -319,6 +332,7 @@ public final class WaypointerConfig {
     public boolean matchTracerToWaypointColor() { return matchTracerToWaypointColor; }
     public double tracerOpacity()             { return tracerOpacity; }
     public double tracerThickness()           { return clamp(tracerThickness, 1.0, 12.0); }
+    public double waypointOutlineThickness()  { return clamp(waypointOutlineThickness, 1.0, 12.0); }
     public double beaconOpacity()             { return beaconOpacity; }
     public boolean showWaypointNames()        { return showWaypointNames; }
     public boolean showWaypointDistances()    { return showWaypointDistances; }
@@ -353,6 +367,7 @@ public final class WaypointerConfig {
     public boolean dungeonWaypointsFeatureEnabled() { return dungeonWaypointsFeatureEnabled; }
     public boolean skipAheadMechanicEnabled() { return skipAheadMechanicEnabled; }
     public boolean checkForUpdates()            { return checkForUpdates; }
+    public boolean irisShaderHudFallback()      { return irisShaderHudFallback; }
     public int tempDefaultMode()                { return tempDefaultMode; }
     public int tempDefaultDurationMin()         { return tempDefaultDurationMin; }
 
@@ -365,6 +380,11 @@ public final class WaypointerConfig {
     public void setTracerThickness(double v) {
         if (!Double.isFinite(v)) return;
         this.tracerThickness = clamp(v, 1.0, 12.0);
+        save();
+    }
+    public void setWaypointOutlineThickness(double v) {
+        if (!Double.isFinite(v)) return;
+        this.waypointOutlineThickness = clamp(v, 1.0, 12.0);
         save();
     }
     public void setBeaconOpacity(double v)             { this.beaconOpacity = clamp(v, 0, 1); save(); }
@@ -417,6 +437,7 @@ public final class WaypointerConfig {
     }
     public void setSkipAheadMechanicEnabled(boolean v) { this.skipAheadMechanicEnabled = v; save(); }
     public void setCheckForUpdates(boolean v)          { this.checkForUpdates = v; save(); }
+    public void setIrisShaderHudFallback(boolean v)    { this.irisShaderHudFallback = v; save(); }
     public void setTempDefaultMode(int v) {
         int clamped = (v < 1 || v > 3) ? 2 : v;
         this.tempDefaultMode = clamped;

--- a/src/main/java/dev/ethan/waypointer/config/WaypointerConfig.java
+++ b/src/main/java/dev/ethan/waypointer/config/WaypointerConfig.java
@@ -79,6 +79,12 @@ public final class WaypointerConfig {
      */
     private boolean matchTracerToWaypointColor = true;
     private double tracerOpacity = 0.95;
+    /**
+     * Pixel width for the crosshair tracer line. Defaults to the historical
+     * hardcoded width; clamped so accidental config edits cannot create invisible
+     * tracers or giant lines that flood the screen.
+     */
+    private double tracerThickness = 3.0;
     private double beaconOpacity = 0.8;
     private boolean showWaypointNames = true;
     private boolean showWaypointDistances = true;
@@ -161,6 +167,13 @@ public final class WaypointerConfig {
      * message.
      */
     private boolean autoAddChatTempWaypoints = true;
+    /**
+     * Player-relative add flows default to the block below the player's feet so
+     * newly-created markers sit on the floor instead of inside the player's body.
+     * Explicit coordinate flows, such as {@code /wp add at}, keep using exactly
+     * what the user typed.
+     */
+    private boolean placeNewWaypointsBelowPlayer = true;
     /**
      * When enabled, every user-created temp waypoint becomes the only waypoint
      * shown in the active zone until the server session ends or the temp vanishes.
@@ -305,6 +318,7 @@ public final class WaypointerConfig {
     public int tracerColor()                  { return tracerColor; }
     public boolean matchTracerToWaypointColor() { return matchTracerToWaypointColor; }
     public double tracerOpacity()             { return tracerOpacity; }
+    public double tracerThickness()           { return clamp(tracerThickness, 1.0, 12.0); }
     public double beaconOpacity()             { return beaconOpacity; }
     public boolean showWaypointNames()        { return showWaypointNames; }
     public boolean showWaypointDistances()    { return showWaypointDistances; }
@@ -328,6 +342,7 @@ public final class WaypointerConfig {
     public boolean preferScoreboardFallback() { return preferScoreboardFallback; }
     public boolean chatCoordDetection()       { return chatCoordDetection; }
     public boolean autoAddChatTempWaypoints() { return autoAddChatTempWaypoints; }
+    public boolean placeNewWaypointsBelowPlayer() { return placeNewWaypointsBelowPlayer; }
     public boolean focusTempWaypoints()       { return focusTempWaypoints; }
     public boolean chatCodecDetection()       { return chatCodecDetection; }
     public boolean exportIncludeNames()        { return exportIncludeNames; }
@@ -347,6 +362,11 @@ public final class WaypointerConfig {
     public void setTracerColor(int v)                  { this.tracerColor = v & 0xFFFFFF; save(); }
     public void setMatchTracerToWaypointColor(boolean v) { this.matchTracerToWaypointColor = v; save(); }
     public void setTracerOpacity(double v)             { this.tracerOpacity = clamp(v, 0, 1); save(); }
+    public void setTracerThickness(double v) {
+        if (!Double.isFinite(v)) return;
+        this.tracerThickness = clamp(v, 1.0, 12.0);
+        save();
+    }
     public void setBeaconOpacity(double v)             { this.beaconOpacity = clamp(v, 0, 1); save(); }
     public void setShowWaypointNames(boolean v)        { this.showWaypointNames = v; save(); }
     public void setShowWaypointDistances(boolean v)    { this.showWaypointDistances = v; save(); }
@@ -362,6 +382,7 @@ public final class WaypointerConfig {
     public void setPreferScoreboardFallback(boolean v) { this.preferScoreboardFallback = v; save(); }
     public void setChatCoordDetection(boolean v)       { this.chatCoordDetection = v; save(); }
     public void setAutoAddChatTempWaypoints(boolean v) { this.autoAddChatTempWaypoints = v; save(); }
+    public void setPlaceNewWaypointsBelowPlayer(boolean v) { this.placeNewWaypointsBelowPlayer = v; save(); }
     public void setFocusTempWaypoints(boolean v)       { this.focusTempWaypoints = v; save(); }
     public void setChatCodecDetection(boolean v)       { this.chatCodecDetection = v; save(); }
     public void setExportIncludeNames(boolean v)        { this.exportIncludeNames = v; save(); }

--- a/src/main/java/dev/ethan/waypointer/core/ActiveGroupManager.java
+++ b/src/main/java/dev/ethan/waypointer/core/ActiveGroupManager.java
@@ -137,11 +137,17 @@ public final class ActiveGroupManager {
      * listeners see the change without the caller needing to remember.
      */
     public WaypointGroup getOrCreateActiveGroup() {
+        return getOrCreateActiveGroup(true);
+    }
+
+    public WaypointGroup getOrCreateActiveGroup(boolean skipAheadDefault) {
         WaypointGroup existing = firstActiveRouteGroup();
         if (existing != null) return existing;
         Zone zone = currentZone == null ? Zone.UNKNOWN : currentZone;
         WaypointGroup g = WaypointGroup.create(
-                "Route -- " + zone.displayName().toLowerCase(Locale.ROOT), zone.id());
+                "Route -- " + zone.displayName().toLowerCase(Locale.ROOT),
+                zone.id(),
+                skipAheadDefault);
         add(g);
         return g;
     }

--- a/src/main/java/dev/ethan/waypointer/core/WaypointGroup.java
+++ b/src/main/java/dev/ethan/waypointer/core/WaypointGroup.java
@@ -127,6 +127,12 @@ public final class WaypointGroup {
         return new WaypointGroup(UUID.randomUUID().toString(), name, zoneId);
     }
 
+    public static WaypointGroup create(String name, String zoneId, boolean skipAheadEnabled) {
+        WaypointGroup group = create(name, zoneId);
+        group.setSkipAheadEnabled(skipAheadEnabled);
+        return group;
+    }
+
     public String id()            { return id; }
     public String name()          { return name; }
     public String zoneId()        { return zoneId; }
@@ -218,6 +224,17 @@ public final class WaypointGroup {
     public void set(int index, Waypoint replacement) {
         waypoints.set(index, replacement);
         invalidateProximityIndex();
+    }
+
+    /**
+     * Repositioning a waypoint is a visibility-affecting edit, not just a data
+     * replacement: if static reach hiding had already hidden this index, the
+     * moved marker would stay invisible until the whole static cycle reset.
+     */
+    public void moveWaypointTo(int index, int x, int y, int z) {
+        waypoints.set(index, waypoints.get(index).withPos(x, y, z));
+        invalidateProximityIndex();
+        focusNewWaypoint(index);
     }
 
     public void add(Waypoint w) {

--- a/src/main/java/dev/ethan/waypointer/placement/PlayerWaypointPlacement.java
+++ b/src/main/java/dev/ethan/waypointer/placement/PlayerWaypointPlacement.java
@@ -1,0 +1,35 @@
+package dev.ethan.waypointer.placement;
+
+import dev.ethan.waypointer.config.WaypointerConfig;
+
+import java.util.Objects;
+
+/**
+ * Converts a player's precise world position into the block coordinates used
+ * for player-relative waypoint creation.
+ *
+ * <p>The setting lives in config, but all add flows need the same interpretation:
+ * floor the player's current block and, by default, target the block below the
+ * player's feet so markers are visible on the floor instead of inside the player.
+ */
+public final class PlayerWaypointPlacement {
+
+    private PlayerWaypointPlacement() {
+    }
+
+    public static BlockPosition fromPlayer(double x, double y, double z, WaypointerConfig config) {
+        Objects.requireNonNull(config, "config");
+
+        int blockY = (int) Math.floor(y);
+        if (config.placeNewWaypointsBelowPlayer()) {
+            blockY -= 1;
+        }
+
+        return new BlockPosition(
+                (int) Math.floor(x),
+                blockY,
+                (int) Math.floor(z));
+    }
+
+    public record BlockPosition(int x, int y, int z) {}
+}

--- a/src/main/java/dev/ethan/waypointer/placement/PlayerWaypointPlacement.java
+++ b/src/main/java/dev/ethan/waypointer/placement/PlayerWaypointPlacement.java
@@ -8,11 +8,15 @@ import java.util.Objects;
  * Converts a player's precise world position into the block coordinates used
  * for player-relative waypoint creation.
  *
- * <p>The setting lives in config, but all add flows need the same interpretation:
- * floor the player's current block and, by default, target the block below the
- * player's feet so markers are visible on the floor instead of inside the player.
+ * <p>The setting lives in config, but all add flows need the same interpretation.
+ * Player Y is the bottom of the collision box: full blocks put it on an integer
+ * boundary, while slabs, carpets, and other partial blocks put it inside the
+ * supporting block's Y coordinate. When placing below the player, resolve the
+ * supporting block directly instead of subtracting after flooring.
  */
 public final class PlayerWaypointPlacement {
+
+    private static final double FEET_BOUNDARY_EPSILON = 1.0E-5;
 
     private PlayerWaypointPlacement() {
     }
@@ -20,14 +24,13 @@ public final class PlayerWaypointPlacement {
     public static BlockPosition fromPlayer(double x, double y, double z, WaypointerConfig config) {
         Objects.requireNonNull(config, "config");
 
-        int blockY = (int) Math.floor(y);
-        if (config.placeNewWaypointsBelowPlayer()) {
-            blockY -= 1;
-        }
+        double placementY = config.placeNewWaypointsBelowPlayer()
+                ? y - FEET_BOUNDARY_EPSILON
+                : y;
 
         return new BlockPosition(
                 (int) Math.floor(x),
-                blockY,
+                (int) Math.floor(placementY),
                 (int) Math.floor(z));
     }
 

--- a/src/test/java/dev/ethan/waypointer/api/DefaultWaypointerApiTest.java
+++ b/src/test/java/dev/ethan/waypointer/api/DefaultWaypointerApiTest.java
@@ -52,6 +52,39 @@ class DefaultWaypointerApiTest {
     }
 
     @Test
+    void updateWaypointReplacesOneWaypointAndFiresDataChanged() {
+        ActiveGroupManager manager = new ActiveGroupManager();
+        WaypointerApi api = new DefaultWaypointerApi(manager);
+        AtomicInteger changes = new AtomicInteger();
+        api.onDataChanged(changes::incrementAndGet);
+
+        String groupId = api.createRoute(RouteSpec.builder()
+                .name("Route")
+                .waypoint(WaypointSpec.at(1, 2, 3).name("old"))
+                .waypoint(WaypointSpec.at(4, 5, 6))
+                .build());
+
+        assertTrue(api.updateWaypoint(groupId, 0, WaypointSpec.builder()
+                .position(10, 11, 12)
+                .name("new")
+                .color(0x123456)
+                .radius(4.5)
+                .build()));
+        assertFalse(api.updateWaypoint(groupId, -1, WaypointSpec.at(0, 0, 0)));
+        assertFalse(api.updateWaypoint(groupId, 2, WaypointSpec.at(0, 0, 0)));
+        assertFalse(api.updateWaypoint("missing", 0, WaypointSpec.at(0, 0, 0)));
+
+        WaypointSnapshot updated = api.allGroups().get(0).waypoints().get(0);
+        assertEquals(10, updated.x());
+        assertEquals(11, updated.y());
+        assertEquals(12, updated.z());
+        assertEquals("new", updated.name());
+        assertEquals(0x123456, updated.color());
+        assertEquals(4.5, updated.radius());
+        assertEquals(2, changes.get(), "invalid updates must not notify listeners");
+    }
+
+    @Test
     void addTempWaypointUsesSessionOnlyTempBucket() {
         ActiveGroupManager manager = new ActiveGroupManager();
         manager.onZoneChanged(new Zone("hub", "Hub"));

--- a/src/test/java/dev/ethan/waypointer/config/StorageJsonTest.java
+++ b/src/test/java/dev/ethan/waypointer/config/StorageJsonTest.java
@@ -179,6 +179,18 @@ class StorageJsonTest {
     }
 
     @Test
+    void group_skipAheadSettingRoundTrips() {
+        WaypointGroup g = WaypointGroup.create("strict-route", "dungeon_f7");
+        g.setSkipAheadEnabled(false);
+
+        JsonObject json = Storage.groupToJson(g);
+        WaypointGroup copy = Storage.groupFromJson(json);
+
+        assertFalse(copy.skipAheadEnabled(),
+                "per-route skip-ahead preference must survive reloads");
+    }
+
+    @Test
     void group_roundTripPreservesProgressAndOrder() {
         WaypointGroup g = WaypointGroup.create("my-route", "dungeon_f7");
         g.setName("Terminals route");

--- a/src/test/java/dev/ethan/waypointer/config/WaypointerConfigTest.java
+++ b/src/test/java/dev/ethan/waypointer/config/WaypointerConfigTest.java
@@ -186,6 +186,34 @@ class WaypointerConfigTest {
     }
 
     @Test
+    void waypointOutlineThicknessDefaultsToHistoricalWidthAndClampsToSafeRange() {
+        WaypointerConfig config = new WaypointerConfig();
+
+        assertEquals(3.0, config.waypointOutlineThickness());
+
+        config.setWaypointOutlineThickness(5.5);
+        assertEquals(5.5, config.waypointOutlineThickness());
+
+        config.setWaypointOutlineThickness(0.0);
+        assertEquals(1.0, config.waypointOutlineThickness());
+
+        config.setWaypointOutlineThickness(99.0);
+        assertEquals(12.0, config.waypointOutlineThickness());
+    }
+
+    @Test
+    void waypointOutlineThicknessRejectsNonFiniteValues() {
+        WaypointerConfig config = new WaypointerConfig();
+        config.setWaypointOutlineThickness(4.0);
+
+        config.setWaypointOutlineThickness(Double.NaN);
+        assertEquals(4.0, config.waypointOutlineThickness());
+
+        config.setWaypointOutlineThickness(Double.POSITIVE_INFINITY);
+        assertEquals(4.0, config.waypointOutlineThickness());
+    }
+
+    @Test
     void tracerThicknessRejectsNonFiniteValues() {
         WaypointerConfig config = new WaypointerConfig();
         config.setTracerThickness(4.0);
@@ -240,5 +268,16 @@ class WaypointerConfigTest {
         WaypointerConfig config = new WaypointerConfig();
 
         assertEquals(false, config.dungeonWaypointsFeatureEnabled());
+    }
+
+    @Test
+    void irisHudFallbackDefaultsOffButCanBeEnabled() {
+        WaypointerConfig config = new WaypointerConfig();
+
+        assertFalse(config.irisShaderHudFallback());
+
+        config.setIrisShaderHudFallback(true);
+
+        assertTrue(config.irisShaderHudFallback());
     }
 }

--- a/src/test/java/dev/ethan/waypointer/config/WaypointerConfigTest.java
+++ b/src/test/java/dev/ethan/waypointer/config/WaypointerConfigTest.java
@@ -239,17 +239,26 @@ class WaypointerConfigTest {
     }
 
     @Test
-    void playerWaypointPlacementDefaultsBelowPlayerButCanUseStandingBlock() {
+    void playerWaypointPlacementTargetsSupportingBlockByDefault() {
         WaypointerConfig config = new WaypointerConfig();
 
-        PlayerWaypointPlacement.BlockPosition below = PlayerWaypointPlacement.fromPlayer(
-                10.9, 64.2, -3.1, config);
-        assertEquals(new PlayerWaypointPlacement.BlockPosition(10, 63, -4), below);
+        PlayerWaypointPlacement.BlockPosition fullBlock = PlayerWaypointPlacement.fromPlayer(
+                10.9, 65.0, -3.1, config);
+        assertEquals(new PlayerWaypointPlacement.BlockPosition(10, 64, -4), fullBlock);
+
+        PlayerWaypointPlacement.BlockPosition partialBlock = PlayerWaypointPlacement.fromPlayer(
+                10.9, 64.5, -3.1, config);
+        assertEquals(new PlayerWaypointPlacement.BlockPosition(10, 64, -4), partialBlock);
+    }
+
+    @Test
+    void playerWaypointPlacementCanUseExactFootBlock() {
+        WaypointerConfig config = new WaypointerConfig();
 
         config.setPlaceNewWaypointsBelowPlayer(false);
         PlayerWaypointPlacement.BlockPosition standing = PlayerWaypointPlacement.fromPlayer(
-                10.9, 64.2, -3.1, config);
-        assertEquals(new PlayerWaypointPlacement.BlockPosition(10, 64, -4), standing);
+                10.9, 65.0, -3.1, config);
+        assertEquals(new PlayerWaypointPlacement.BlockPosition(10, 65, -4), standing);
     }
 
     @Test

--- a/src/test/java/dev/ethan/waypointer/config/WaypointerConfigTest.java
+++ b/src/test/java/dev/ethan/waypointer/config/WaypointerConfigTest.java
@@ -1,5 +1,6 @@
 package dev.ethan.waypointer.config;
 
+import dev.ethan.waypointer.placement.PlayerWaypointPlacement;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -169,15 +170,58 @@ class WaypointerConfigTest {
     }
 
     @Test
+    void tracerThicknessDefaultsToHistoricalWidthAndClampsToSafeRange() {
+        WaypointerConfig config = new WaypointerConfig();
+
+        assertEquals(3.0, config.tracerThickness());
+
+        config.setTracerThickness(6.5);
+        assertEquals(6.5, config.tracerThickness());
+
+        config.setTracerThickness(0.0);
+        assertEquals(1.0, config.tracerThickness());
+
+        config.setTracerThickness(99.0);
+        assertEquals(12.0, config.tracerThickness());
+    }
+
+    @Test
+    void tracerThicknessRejectsNonFiniteValues() {
+        WaypointerConfig config = new WaypointerConfig();
+        config.setTracerThickness(4.0);
+
+        config.setTracerThickness(Double.NaN);
+        assertEquals(4.0, config.tracerThickness());
+
+        config.setTracerThickness(Double.POSITIVE_INFINITY);
+        assertEquals(4.0, config.tracerThickness());
+    }
+
+    @Test
     void defaultExportAndDetectionTogglesStayUserFriendly() {
         WaypointerConfig config = new WaypointerConfig();
 
         assertTrue(config.chatCoordDetection());
         assertTrue(config.autoAddChatTempWaypoints());
+        assertTrue(config.placeNewWaypointsBelowPlayer());
         assertTrue(config.chatCodecDetection());
         assertTrue(config.dimSequenceContextWaypoints());
         assertFalse(config.exportIncludeColors());
         assertTrue(config.exportIncludeGroupMeta());
+    }
+
+    @Test
+    void playerWaypointPlacementDefaultsBelowPlayerButCanUseStandingBlock() {
+        WaypointerConfig config = new WaypointerConfig();
+
+        PlayerWaypointPlacement.BlockPosition below = PlayerWaypointPlacement.fromPlayer(
+                10.9, 64.2, -3.1, config);
+        assertEquals(new PlayerWaypointPlacement.BlockPosition(10, 63, -4), below);
+
+        config.setPlaceNewWaypointsBelowPlayer(false);
+        PlayerWaypointPlacement.BlockPosition standing = PlayerWaypointPlacement.fromPlayer(
+                10.9, 64.2, -3.1, config);
+        assertEquals(new PlayerWaypointPlacement.BlockPosition(10, 64, -4), standing);
     }
 
     @Test

--- a/src/test/java/dev/ethan/waypointer/core/WaypointGroupTest.java
+++ b/src/test/java/dev/ethan/waypointer/core/WaypointGroupTest.java
@@ -89,6 +89,22 @@ class WaypointGroupTest {
     }
 
     @Test
+    void moveWaypointTo_focusesMovedWaypointAndClearsStaticReachState() {
+        WaypointGroup g = route();
+        g.markStaticWaypointReached(0);
+
+        g.moveWaypointTo(2, 25, 71, -4);
+
+        Waypoint moved = g.get(2);
+        assertEquals(25, moved.x());
+        assertEquals(71, moved.y());
+        assertEquals(-4, moved.z());
+        assertEquals(2, g.currentIndex());
+        assertTrue(g.isProximitySuppressed(2));
+        assertFalse(g.isStaticWaypointReached(0));
+    }
+
+    @Test
     void restartIfRouteCompleted_wraps_when_enabled() {
         WaypointGroup g = route();
         g.advancePast(3);
@@ -204,6 +220,25 @@ class WaypointGroupTest {
         WaypointGroup g = WaypointGroup.create("r", "z");
         assertEquals(WaypointGroup.LoadMode.SEQUENCE, g.loadMode(),
                 "loaded routes default to SEQUENCE so the intended order is visible");
+    }
+
+    @Test
+    void create_canSeedSkipAheadFromGlobalDefault() {
+        WaypointGroup enabled = WaypointGroup.create("on", "hub", true);
+        WaypointGroup disabled = WaypointGroup.create("off", "hub", false);
+
+        assertTrue(enabled.skipAheadEnabled());
+        assertFalse(disabled.skipAheadEnabled());
+    }
+
+    @Test
+    void manager_getOrCreateActiveGroupSeedsSkipAheadDefault() {
+        ActiveGroupManager manager = new ActiveGroupManager();
+        manager.onZoneChanged(new Zone("hub", "Hub"));
+
+        WaypointGroup route = manager.getOrCreateActiveGroup(false);
+
+        assertFalse(route.skipAheadEnabled());
     }
 
     @Test

--- a/src/test/java/dev/ethan/waypointer/progression/ProximityAdvanceTest.java
+++ b/src/test/java/dev/ethan/waypointer/progression/ProximityAdvanceTest.java
@@ -136,6 +136,18 @@ class ProximityAdvanceTest {
     }
 
     @Test
+    void static_progress_update_does_not_run_sequence_advancement() {
+        WaypointGroup g = line();
+        g.setLoadMode(WaypointGroup.LoadMode.STATIC);
+
+        ProximityTracker.updateGroupProgress(g, 20.5, 0.5, 0.5,
+                false, true, true);
+
+        assertEquals(0, g.currentIndex());
+        assertTrue(g.isStaticWaypointReached(2));
+    }
+
+    @Test
     void freshly_focused_static_waypoint_is_not_hidden_until_player_leaves_and_returns() {
         WaypointGroup g = line();
         g.setLoadMode(WaypointGroup.LoadMode.STATIC);


### PR DESCRIPTION
This PR is a final bug review to merge Beta to Main.

# In 1.5.2:
## Added
- Added waypoint editing (thanks amelia for suggestion)
- Added waypoint editing to api
- Added setting to put waypoints below player (thanks amelia for suggestion)
- Adding a waypoint in the Group GUI now adds the waypoint immediately after your selected waypoint, which allows you to put waypoints in the middle of a route for example.
- Improved some buttons in the GUIs and some of the descriptions

## Fixed
- Fixed compatibility with shaders, experimental, not pretty
- Fixed waypoint skip ahead setting not working (thanks amelia for finding this)

## Removed 
- Removed the Route Sorting button. It was literally useless.
- Colors no longer are exported by default.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core rendering and route progression/creation behavior (including new Iris shader fallback and per-route skip-ahead persistence), which could affect in-game visuals and waypoint flow across many paths.
> 
> **Overview**
> Adds a new `WaypointerApi.updateWaypoint` endpoint (and docs/tests) to allow mods to replace a waypoint in-place within saved routes.
> 
> Introduces configurable player-relative waypoint placement (defaulting to one block below the player) via `PlayerWaypointPlacement`, and applies it consistently across commands, keybinds, and add/insert GUI flows.
> 
> Improves route/group editing and persistence: per-group `skipAheadEnabled` is now serialized, group creation/auto-creation seeds skip-ahead from the global default, and the group editor adds coordinate editors plus a “move selected here” action while removing the route sort UI.
> 
> Adds rendering configurability and shader compatibility: new `tracerThickness`/`waypointOutlineThickness` settings, plus an experimental Iris-only HUD-projected fallback for waypoint boxes and tracers (with reflective Iris detection) that bypasses world-space rendering when shaders are active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ba10763c498d0d4b815a93ae305b3223cdd5cc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->