### PR TITLE
Add Diana waypoint support

### DIFF
--- a/src/client/java/dev/ethan/waypointer/WaypointerClient.java
+++ b/src/client/java/dev/ethan/waypointer/WaypointerClient.java
@@ -68,7 +68,7 @@ public final class WaypointerClient implements ClientModInitializer {
         storage.attach(manager);
         api = new DefaultWaypointerApi(manager);
 
-        new LocationTracker(manager, config).install();
+        new LocationTracker(manager).install();
         new ProximityTracker(manager, config).install();
         new TempWaypointCleaner(manager).install();
         new WorldJoinProgressReset(manager, config).install();

--- a/src/client/java/dev/ethan/waypointer/WaypointerClient.java
+++ b/src/client/java/dev/ethan/waypointer/WaypointerClient.java
@@ -17,6 +17,8 @@ import dev.ethan.waypointer.dungeon.DungeonStateTracker;
 import dev.ethan.waypointer.dungeon.DungeonTriggerDetector;
 import dev.ethan.waypointer.dungeon.config.DungeonConfig;
 import dev.ethan.waypointer.dungeon.data.DungeonRoomData;
+import dev.ethan.waypointer.diana.DianaBurrowDetector;
+import dev.ethan.waypointer.diana.DianaWaypointDetector;
 import dev.ethan.waypointer.input.WaypointRepositionMode;
 import dev.ethan.waypointer.input.WaypointerKeybinds;
 import dev.ethan.waypointer.location.LocationTracker;
@@ -84,6 +86,8 @@ public final class WaypointerClient implements ClientModInitializer {
         new WaypointerCommands(manager, storage, config, chatImportCache, WaypointerClient::openGui).install();
         new WaypointerKeybinds(WaypointerClient::openGui, manager, config).install();
         new ChatCoordDetector(config, manager).install();
+        new DianaBurrowDetector(config, manager).install();
+        new DianaWaypointDetector(config, manager).install();
         new ChatImportDetector(config, chatImportCache).install();
         int apiEntrypoints = WaypointerApiEntrypoints.invokeFabricEntrypoints(api);
         if (apiEntrypoints > 0) {

--- a/src/client/java/dev/ethan/waypointer/chat/ChatCoordDetector.java
+++ b/src/client/java/dev/ethan/waypointer/chat/ChatCoordDetector.java
@@ -227,9 +227,10 @@ public final class ChatCoordDetector {
                 .withStyle(Style.EMPTY
                         .withColor(ChatFormatting.RED)
                         .withBold(true)
-                        .withClickEvent(new ClickEvent.RunCommand("/waypointer blacklist add " + senderName))
+                        .withClickEvent(new ClickEvent.RunCommand("/waypointer blacklist toggle " + senderName))
                         .withHoverEvent(new HoverEvent.ShowText(Component.literal(
-                                "Click here to block " + senderName).withStyle(ChatFormatting.RED))));
+                                "Click to block/unblock chat waypoints from " + senderName)
+                                .withStyle(ChatFormatting.RED))));
     }
 
     private static Component tempWaypointHover(CoordScanner.Match m, boolean alreadyAdded,

--- a/src/client/java/dev/ethan/waypointer/commands/WaypointerCommands.java
+++ b/src/client/java/dev/ethan/waypointer/commands/WaypointerCommands.java
@@ -1034,18 +1034,11 @@ public final class WaypointerCommands {
     }
 
     /**
-     * Default exports keep every optional per-waypoint field off and preserve only
-     * group metadata. Users can still override per field with
-     * {@code /wp export names}, etc.
+     * Default exports follow persisted toggles; explicit {@code /wp export names}
+     * and friends still override per invocation.
      */
     private WaypointCodec.Options defaultExportOptions() {
-        return WaypointCodec.Options.builder()
-                .includeNames(false)
-                .includeColors(false)
-                .includeRadii(false)
-                .includeWaypointFlags(false)
-                .includeGroupMeta(true)
-                .build();
+        return config.exportCodecOptions();
     }
 
     private int runCreateGroup(FabricClientCommandSource src, String name) {

--- a/src/client/java/dev/ethan/waypointer/commands/WaypointerCommands.java
+++ b/src/client/java/dev/ethan/waypointer/commands/WaypointerCommands.java
@@ -175,8 +175,14 @@ public final class WaypointerCommands {
                                 .then(argument("name", StringArgumentType.word())
                                         .executes(ctx -> runChatCoordBlacklistAdd(ctx.getSource(),
                                                 StringArgumentType.getString(ctx, "name")))))
+                        .then(literal("toggle")
+                                .then(argument("name", StringArgumentType.word())
+                                        .suggests(suggestChatCoordBlacklistNames())
+                                        .executes(ctx -> runChatCoordBlacklistToggle(ctx.getSource(),
+                                                StringArgumentType.getString(ctx, "name")))))
                         .then(literal("remove")
                                 .then(argument("name", StringArgumentType.word())
+                                        .suggests(suggestChatCoordBlacklistNames())
                                         .executes(ctx -> runChatCoordBlacklistRemove(ctx.getSource(),
                                                 StringArgumentType.getString(ctx, "name"))))))
                 .then(literal("remove")
@@ -200,7 +206,7 @@ public final class WaypointerCommands {
                         .executes(ctx -> runClearZone(ctx.getSource(), false))
                         .then(literal("confirm").executes(ctx -> runClearZone(ctx.getSource(), true))))
                 .then(literal("export")
-                        .executes(ctx -> runExport(ctx.getSource(), exportOptionsFromConfig()))
+                        .executes(ctx -> runExport(ctx.getSource(), defaultExportOptions()))
                         .then(literal("names")
                                 .executes(ctx -> runExport(ctx.getSource(), WaypointCodec.Options.WITH_NAMES)))
                         .then(literal("nonames")
@@ -303,6 +309,18 @@ public final class WaypointerCommands {
             for (String h : handles) {
                 if (h.toLowerCase(Locale.ROOT).startsWith(token)) {
                     builder.suggest(h, Component.literal("cached import"));
+                }
+            }
+            return builder.buildFuture();
+        };
+    }
+
+    private SuggestionProvider<FabricClientCommandSource> suggestChatCoordBlacklistNames() {
+        return (ctx, builder) -> {
+            String token = builder.getRemainingLowerCase();
+            for (String name : config.chatCoordSenderBlacklist()) {
+                if (name.toLowerCase(Locale.ROOT).startsWith(token)) {
+                    builder.suggest(name, Component.literal("blacklisted sender"));
                 }
             }
             return builder.buildFuture();
@@ -734,6 +752,18 @@ public final class WaypointerCommands {
         return added ? 1 : 0;
     }
 
+    private int runChatCoordBlacklistToggle(FabricClientCommandSource src, String senderName) {
+        boolean nowBlocked = config.toggleChatCoordSenderBlacklist(senderName);
+        int removed = nowBlocked ? manager.removeTempWaypointsFromSender(senderName) : 0;
+        if (nowBlocked) {
+            success(src, "Blacklisted " + senderName + " for chat waypoints"
+                    + (removed > 0 ? " and removed " + removed + " temporary waypoint(s)" : ""));
+        } else {
+            success(src, "Removed " + senderName + " from the chat waypoint blacklist");
+        }
+        return 1;
+    }
+
     private int runChatCoordBlacklistRemove(FabricClientCommandSource src, String senderName) {
         if (config.removeChatCoordSenderBlacklist(senderName)) {
             success(src, "Removed " + senderName + " from the chat waypoint blacklist");
@@ -1004,21 +1034,17 @@ public final class WaypointerCommands {
     }
 
     /**
-     * Default export options reflect the user's persisted config (see Settings).
-     * Users can still override per field with {@code /wp export names}, etc.
-     *
-     * The label is intentionally omitted here: the CLI export path doesn't have a
-     * good way to prompt for a label, and silently attaching one from config would
-     * surprise users who set it once and forgot. Use {@link dev.ethan.waypointer.screen.ExportScreen}
-     * (the GUI export panel) to set a label on a per-export basis.
+     * Default exports keep every optional per-waypoint field off and preserve only
+     * group metadata. Users can still override per field with
+     * {@code /wp export names}, etc.
      */
-    private WaypointCodec.Options exportOptionsFromConfig() {
+    private WaypointCodec.Options defaultExportOptions() {
         return WaypointCodec.Options.builder()
-                .includeNames(config.exportIncludeNames())
-                .includeColors(config.exportIncludeColors())
-                .includeRadii(config.exportIncludeRadii())
-                .includeWaypointFlags(config.exportIncludeWaypointFlags())
-                .includeGroupMeta(config.exportIncludeGroupMeta())
+                .includeNames(false)
+                .includeColors(false)
+                .includeRadii(false)
+                .includeWaypointFlags(false)
+                .includeGroupMeta(true)
                 .build();
     }
 

--- a/src/client/java/dev/ethan/waypointer/diana/DianaBurrowDetector.java
+++ b/src/client/java/dev/ethan/waypointer/diana/DianaBurrowDetector.java
@@ -38,7 +38,6 @@ import java.util.regex.Pattern;
 
 public final class DianaBurrowDetector {
 
-    private static final String GROUP_ID = "diana::burrows";
     private static final String HUB_ZONE_ID = "hub";
     private static final int WARP_HELPFUL_COLOR = 0x3FA7FF;
     private static final int HUB_MIN_X = -296;
@@ -168,13 +167,13 @@ public final class DianaBurrowDetector {
         if (isBurrowDugMessage(clean)) {
             lastBurrowRelatedChatMillis = System.currentTimeMillis();
             BlockKey clicked = recentlyClickedBurrowBlock(lastBurrowRelatedChatMillis);
-            boolean removed = clicked != null
-                    ? removeNearby(clicked, 3.0)
-                    : removeNearestToPlayer(9.0);
-            boolean clearedStale = clearResolvedBurrowMarkers(clean);
-            boolean clearedGuess = !guesses.isEmpty();
+            if (clicked != null) {
+                removeNearby(clicked, 3.0);
+            } else {
+                removeNearestToPlayer(9.0);
+            }
+            clearResolvedBurrowMarkers(clean);
             guesses.clear();
-            removed = removed || clearedStale || clearedGuess;
             renderWaypoints();
         } else if (chainStateChanged) {
             renderWaypoints();
@@ -780,7 +779,7 @@ public final class DianaBurrowDetector {
 
         int navigationIndex = navigationIndex(waypoints, estimateWaypoints.size());
         String signature = signature(waypoints);
-        WaypointGroup existing = manager.get(GROUP_ID);
+        WaypointGroup existing = manager.get(DianaBurrowWaypointGroup.ID);
         if (Objects.equals(signature, lastRenderedSignature)) {
             if (existing != null && existing.currentIndex() != navigationIndex) {
                 existing.setCurrentIndex(navigationIndex);
@@ -791,7 +790,7 @@ public final class DianaBurrowDetector {
         lastRenderedSignature = signature;
 
         if (waypoints.isEmpty()) {
-            if (existing != null) manager.remove(GROUP_ID);
+            if (existing != null) manager.remove(DianaBurrowWaypointGroup.ID);
             return;
         }
 
@@ -838,10 +837,10 @@ public final class DianaBurrowDetector {
     }
 
     private WaypointGroup ensureGroup() {
-        WaypointGroup existing = manager.get(GROUP_ID);
+        WaypointGroup existing = manager.get(DianaBurrowWaypointGroup.ID);
         if (existing != null) return existing;
 
-        WaypointGroup group = new WaypointGroup(GROUP_ID, "Diana Burrows", HUB_ZONE_ID);
+        WaypointGroup group = new WaypointGroup(DianaBurrowWaypointGroup.ID, "Diana Burrows", HUB_ZONE_ID);
         group.setTemp(true);
         group.setLoadMode(WaypointGroup.LoadMode.STATIC);
         group.setGradientMode(WaypointGroup.GradientMode.MANUAL);
@@ -963,7 +962,7 @@ public final class DianaBurrowDetector {
         reportedArrowParticlesForSequence = false;
         currentChainComplete = true;
         spadeDebugLogTimes.clear();
-        if (manager.get(GROUP_ID) != null) manager.remove(GROUP_ID);
+        if (manager.get(DianaBurrowWaypointGroup.ID) != null) manager.remove(DianaBurrowWaypointGroup.ID);
     }
 
     private boolean isEnabledInHub() {

--- a/src/client/java/dev/ethan/waypointer/diana/DianaBurrowDetector.java
+++ b/src/client/java/dev/ethan/waypointer/diana/DianaBurrowDetector.java
@@ -3,6 +3,7 @@ package dev.ethan.waypointer.diana;
 import dev.ethan.waypointer.Waypointer;
 import dev.ethan.waypointer.config.WaypointerConfig;
 import dev.ethan.waypointer.core.ActiveGroupManager;
+import dev.ethan.waypointer.math.DistanceUtil;
 import dev.ethan.waypointer.core.Waypoint;
 import dev.ethan.waypointer.core.WaypointGroup;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
@@ -69,6 +70,13 @@ public final class DianaBurrowDetector {
     private static final int RESOLVED_BURROW_Y_TOLERANCE = 16;
     private static final double EPSILON = 1.0E-6;
     private static final Pattern CHAIN_PROGRESS_PATTERN = Pattern.compile("\\((\\d+)\\s*/\\s*(\\d+)\\)");
+
+    /**
+     * Second line on Diana estimate markers when warp-assist applies. Kept in this
+     * class with {@link #dianaEstimateNameWithWarpAssistLine} so keybind lookup
+     * stays aligned with the detector label.
+     */
+    public static final String DIANA_WARP_ASSIST_HINT = "Press warp key";
 
     private final WaypointerConfig config;
     private final ActiveGroupManager manager;
@@ -861,9 +869,12 @@ public final class DianaBurrowDetector {
         if (type != DianaBurrowType.GUESS) return type.label();
 
         String base = config.dianaEstimateWaypointName();
-        return hasHelpfulWarp(key)
-                ? base + "\nPress warp key"
-                : base;
+        return hasHelpfulWarp(key) ? dianaEstimateNameWithWarpAssistLine(base) : base;
+    }
+
+    /** Full waypoint name when the warp-assist hint row is shown under {@code baseName}. */
+    public static String dianaEstimateNameWithWarpAssistLine(String baseName) {
+        return baseName + "\n" + DIANA_WARP_ASSIST_HINT;
     }
 
     private int dianaColor(BlockKey key, DianaBurrowType type) {
@@ -897,14 +908,14 @@ public final class DianaBurrowDetector {
         double estimateX = key.x() + 0.5;
         double estimateY = key.y() + 0.5;
         double estimateZ = key.z() + 0.5;
-        double playerDistance = distance(
+        double playerDistance = DistanceUtil.euclidean(
                 player.getX(), player.getY(), player.getZ(),
                 estimateX, estimateY, estimateZ);
 
         for (DianaWarp warp : DianaWarp.values()) {
             if (!config.dianaWarpEnabled(warp)) continue;
 
-            double warpDistance = distance(
+            double warpDistance = DistanceUtil.euclidean(
                     warp.x(), warp.y(), warp.z(),
                     estimateX, estimateY, estimateZ);
             if (playerDistance - warpDistance > config.dianaWarpMinSavings()) {
@@ -1079,13 +1090,6 @@ public final class DianaBurrowDetector {
 
         spadeDebugLogTimes.put(key, now);
         Waypointer.LOGGER.info("[Diana spade] {}", message);
-    }
-
-    private static double distance(double ax, double ay, double az, double bx, double by, double bz) {
-        double dx = ax - bx;
-        double dy = ay - by;
-        double dz = az - bz;
-        return Math.sqrt(dx * dx + dy * dy + dz * dz);
     }
 
     private static double distanceToRay(Ray ray, Vec3 point) {

--- a/src/client/java/dev/ethan/waypointer/diana/DianaBurrowDetector.java
+++ b/src/client/java/dev/ethan/waypointer/diana/DianaBurrowDetector.java
@@ -1002,11 +1002,6 @@ public final class DianaBurrowDetector {
         return y >= MIN_BURROW_Y && y <= MAX_BURROW_Y;
     }
 
-    private static boolean isPlausibleHubBlock(BlockKey block) {
-        return isPlausibleHubColumn(block)
-                && isPlausibleBurrowY(block.y());
-    }
-
     private static boolean isPlausibleHubColumn(BlockKey block) {
         return block.x() >= HUB_MIN_X
                 && block.x() <= HUB_MAX_X
@@ -1100,8 +1095,6 @@ public final class DianaBurrowDetector {
         return originToPoint.subtract(projected).length();
     }
 
-    private record SightingState(BlockKey key, DianaBurrowType type) {}
-
     private static final class Sighting {
         private boolean hasEnchant;
         private DianaBurrowType type;
@@ -1133,7 +1126,7 @@ public final class DianaBurrowDetector {
 
     private record BlockKey(int x, int y, int z) implements Comparable<BlockKey> {
         double distanceSq(BlockKey other) {
-            return distanceSq(other.x, other.y, other.z);
+            return distanceSq(other.x + 0.5, other.y + 0.5, other.z + 0.5);
         }
 
         double distance(BlockKey other) {

--- a/src/client/java/dev/ethan/waypointer/diana/DianaBurrowDetector.java
+++ b/src/client/java/dev/ethan/waypointer/diana/DianaBurrowDetector.java
@@ -1,0 +1,1216 @@
+package dev.ethan.waypointer.diana;
+
+import dev.ethan.waypointer.Waypointer;
+import dev.ethan.waypointer.config.WaypointerConfig;
+import dev.ethan.waypointer.core.ActiveGroupManager;
+import dev.ethan.waypointer.core.Waypoint;
+import dev.ethan.waypointer.core.WaypointGroup;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
+import net.fabricmc.fabric.api.event.player.AttackBlockCallback;
+import net.fabricmc.fabric.api.event.player.UseBlockCallback;
+import net.fabricmc.fabric.api.event.player.UseItemCallback;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.particles.ParticleOptions;
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.network.protocol.game.ClientboundLevelParticlesPacket;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class DianaBurrowDetector {
+
+    private static final String GROUP_ID = "diana::burrows";
+    private static final String HUB_ZONE_ID = "hub";
+    private static final int WARP_HELPFUL_COLOR = 0x3FA7FF;
+    private static final int HUB_MIN_X = -296;
+    private static final int HUB_MAX_X = 207;
+    private static final int MIN_BURROW_Y = 45;
+    private static final int MAX_BURROW_Y = 140;
+    private static final int HUB_MIN_Z = -272;
+    private static final int HUB_MAX_Z = 223;
+    private static final long DETECTED_STALE_MS = 2_500L;
+    private static final long GUESS_EXPIRE_MS = 30L * 60L * 1000L;
+    private static final long ARROW_POINT_TTL_MS = 2_000L;
+    private static final long RECENT_ARROW_TTL_MS = 18_000L;
+    private static final long RECENT_BURROW_CLICK_MS = 5_000L;
+    private static final long RECENT_BURROW_ARROW_MS = 6_000L;
+    private static final long RECENT_ARROW_CLICK_SOURCE_MS = 12_000L;
+    private static final long RECENT_SPADE_SEARCH_ARROW_MS = 12_000L;
+    private static final long SPADE_SEARCH_DEBOUNCE_MS = 250L;
+    private static final long SPADE_ECHO_WINDOW_MS = 4_000L;
+    private static final long SPADE_CURVE_POINT_TTL_MS = 4_000L;
+    private static final int ARROW_SHAFT_POINTS = 20;
+    private static final int MAX_ARROW_POINTS = 96;
+    private static final int MAX_SPADE_CURVE_POINTS = 128;
+    private static final double ARROW_POINT_TOLERANCE = 0.12;
+    private static final double SPADE_CURVE_DUPLICATE_TOLERANCE = 0.01;
+    private static final double SPADE_CURVE_OUTLIER_DISTANCE = 8.0;
+    private static final int SPADE_CURVE_STABLE_ESTIMATE_COUNT = 3;
+    private static final int ESTIMATE_GROUND_SCAN_ABOVE = 6;
+    private static final double RESOLVED_BURROW_HORIZONTAL_RADIUS = 6.0;
+    private static final int RESOLVED_BURROW_Y_TOLERANCE = 16;
+    private static final double EPSILON = 1.0E-6;
+    private static final Pattern CHAIN_PROGRESS_PATTERN = Pattern.compile("\\((\\d+)\\s*/\\s*(\\d+)\\)");
+
+    private final WaypointerConfig config;
+    private final ActiveGroupManager manager;
+    private final Map<BlockKey, Sighting> sightings = new ConcurrentHashMap<>();
+    private final Map<BlockKey, Guess> guesses = new ConcurrentHashMap<>();
+    private final List<TimedPoint> arrowPoints = new ArrayList<>();
+    private final List<TimedPoint> spadeCurvePoints = new ArrayList<>();
+    private final List<BlockKey> recentSpadeCurveEstimates = new ArrayList<>();
+    private final List<TimedRay> recentArrows = new ArrayList<>();
+    private final Map<String, Long> spadeDebugLogTimes = new HashMap<>();
+    private String lastRenderedSignature = "";
+    private long lastBurrowRelatedChatMillis;
+    private BlockKey lastSpadeAttackBlock;
+    private long lastSpadeAttackMillis;
+    private long lastSpadeSearchMillis;
+    private int spadeEchoParticlesSinceClick;
+    private boolean reportedSpadeEchoForClick;
+    private boolean reportedArrowParticlesForSequence;
+    private boolean currentChainComplete = true;
+    private int tickCounter;
+
+    public DianaBurrowDetector(WaypointerConfig config, ActiveGroupManager manager) {
+        this.config = config;
+        this.manager = manager;
+    }
+
+    public void install() {
+        WaypointerParticleEvents.register(this::onParticle);
+        ClientTickEvents.END_CLIENT_TICK.register(client -> {
+            try {
+                onTick();
+            } catch (RuntimeException e) {
+                Waypointer.LOGGER.warn("Waypointer Diana detector tick failed; skipping this tick", e);
+            }
+        });
+        ClientReceiveMessageEvents.MODIFY_GAME.register(this::onMessage);
+        ClientPlayConnectionEvents.JOIN.register((handler, sender, client) -> reset());
+        ClientPlayConnectionEvents.DISCONNECT.register((handler, client) -> reset());
+        UseItemCallback.EVENT.register((player, world, hand) -> {
+            if (world.isClientSide()) {
+                onSpadeSearch(player.getItemInHand(hand), null);
+            }
+            return InteractionResult.PASS;
+        });
+        UseBlockCallback.EVENT.register((player, world, hand, hit) -> {
+            if (world.isClientSide()) {
+                onSpadeSearch(player.getItemInHand(hand), hit.getBlockPos());
+            }
+            return InteractionResult.PASS;
+        });
+        AttackBlockCallback.EVENT.register((player, world, hand, pos, direction) -> {
+            if (world.isClientSide()) {
+                onSpadeAttack(player.getItemInHand(hand), pos);
+            }
+            return InteractionResult.PASS;
+        });
+    }
+
+    private void onSpadeSearch(ItemStack item, BlockPos pos) {
+        if (!isEnabledInHub() || !isDianaSpade(item)) return;
+
+        long now = System.currentTimeMillis();
+        if (now - lastSpadeSearchMillis < SPADE_SEARCH_DEBOUNCE_MS) return;
+
+        lastSpadeSearchMillis = now;
+        spadeEchoParticlesSinceClick = 0;
+        reportedSpadeEchoForClick = false;
+        reportedArrowParticlesForSequence = false;
+        arrowPoints.clear();
+        spadeCurvePoints.clear();
+        recentSpadeCurveEstimates.clear();
+        // Keep the existing estimate visible while the new spade curve settles.
+        // It will be replaced atomically once the new estimate is stable.
+        debugSpade("search", 0L,
+                "search click registered"
+                        + (pos == null ? "" : " near " + format(pos.getX(), pos.getY(), pos.getZ()))
+                        + "; cleared samples, keeping current estimate until a new one stabilizes");
+    }
+
+    private void onSpadeAttack(ItemStack item, BlockPos pos) {
+        if (!isEnabledInHub() || !isDianaSpade(item) || pos == null) return;
+
+        lastSpadeAttackBlock = new BlockKey(pos.getX(), pos.getY(), pos.getZ());
+        lastSpadeAttackMillis = System.currentTimeMillis();
+        debugSpade("attack", 250L, "left-click burrow check at " + lastSpadeAttackBlock.format());
+    }
+
+    private Component onMessage(Component message, boolean overlay) {
+        if (overlay || !config.dianaBurrowWaypoints()) return message;
+        String clean = message.getString();
+        if (clean.contains("Poof!") && clean.contains("cleared your griffin burrows")) {
+            reset();
+            return message;
+        }
+        boolean chainStateChanged = updateChainState(clean);
+        if (isBurrowDugMessage(clean)) {
+            lastBurrowRelatedChatMillis = System.currentTimeMillis();
+            BlockKey clicked = recentlyClickedBurrowBlock(lastBurrowRelatedChatMillis);
+            boolean removed = clicked != null
+                    ? removeNearby(clicked, 3.0)
+                    : removeNearestToPlayer(9.0);
+            boolean clearedStale = clearResolvedBurrowMarkers(clean);
+            boolean clearedGuess = !guesses.isEmpty();
+            guesses.clear();
+            removed = removed || clearedStale || clearedGuess;
+            renderWaypoints();
+        } else if (chainStateChanged) {
+            renderWaypoints();
+        }
+        return message;
+    }
+
+    private void onParticle(ClientboundLevelParticlesPacket packet) {
+        if (!isEnabledInHub()) return;
+
+        long now = System.currentTimeMillis();
+        ParticleOptions particle = packet.getParticle();
+        if (particle.getType() == ParticleTypes.DUST) {
+            handleArrowParticle(packet, now);
+            return;
+        }
+        if (isSpadeEchoParticle(packet)) {
+            handleSpadeEchoParticle(packet, now);
+            return;
+        }
+
+        DianaBurrowType type = classifyBurrowParticle(packet);
+        if (type == null && particle.getType() != ParticleTypes.ENCHANT) return;
+
+        BlockKey key = burrowBlock(packet);
+        Sighting sighting = sightings.computeIfAbsent(key, ignored -> new Sighting());
+        if (particle.getType() == ParticleTypes.ENCHANT) {
+            sighting.hasEnchant = true;
+        } else {
+            sighting.type = type;
+        }
+        sighting.lastSeenMillis = now;
+
+        if (sighting.hasEnchant && sighting.type != null && sighting.confirmedType != sighting.type) {
+            sighting.confirmedType = sighting.type;
+            removeNearbyGuesses(key, 45.0);
+            renderWaypoints();
+        }
+    }
+
+    private void onTick() {
+        if (++tickCounter < 10) return;
+        tickCounter = 0;
+
+        if (!isEnabledInHub()) {
+            if (!sightings.isEmpty() || !guesses.isEmpty()) reset();
+            return;
+        }
+
+        long now = System.currentTimeMillis();
+        boolean changed = prune(now);
+        if (changed || (!guesses.isEmpty() && config.dianaWarpAssist())) {
+            renderWaypoints();
+        }
+    }
+
+    private boolean prune(long now) {
+        boolean changed = false;
+        Iterator<Map.Entry<BlockKey, Sighting>> sightingIt = sightings.entrySet().iterator();
+        while (sightingIt.hasNext()) {
+            Map.Entry<BlockKey, Sighting> entry = sightingIt.next();
+            Sighting sighting = entry.getValue();
+            long staleAfter = sighting.confirmedType == null
+                    ? DETECTED_STALE_MS
+                    : GUESS_EXPIRE_MS;
+            if (now - sighting.lastSeenMillis > staleAfter) {
+                sightingIt.remove();
+                changed = true;
+            }
+        }
+
+        Iterator<Map.Entry<BlockKey, Guess>> guessIt = guesses.entrySet().iterator();
+        while (guessIt.hasNext()) {
+            Map.Entry<BlockKey, Guess> entry = guessIt.next();
+            if (now - entry.getValue().createdAtMillis > GUESS_EXPIRE_MS) {
+                guessIt.remove();
+                changed = true;
+            }
+        }
+        if (normalizeLoadedGuesses()) changed = true;
+
+        arrowPoints.removeIf(point -> now - point.timeMillis() > ARROW_POINT_TTL_MS);
+        spadeCurvePoints.removeIf(point -> now - point.timeMillis() > SPADE_CURVE_POINT_TTL_MS);
+        recentArrows.removeIf(ray -> now - ray.timeMillis() > RECENT_ARROW_TTL_MS);
+        return changed;
+    }
+
+    private DianaBurrowType classifyBurrowParticle(ClientboundLevelParticlesPacket packet) {
+        ParticleOptions particle = packet.getParticle();
+        if (particle.getType() == ParticleTypes.ENCHANTED_HIT
+                && packet.getCount() == 4
+                && close(packet.getMaxSpeed(), 0.01)
+                && close(packet.getXDist(), 0.5)
+                && close(packet.getYDist(), 0.1)
+                && close(packet.getZDist(), 0.5)) {
+            return DianaBurrowType.START;
+        }
+        if (particle.getType() == ParticleTypes.CRIT
+                && packet.getCount() == 3
+                && close(packet.getMaxSpeed(), 0.01)
+                && close(packet.getXDist(), 0.5)
+                && close(packet.getYDist(), 0.1)
+                && close(packet.getZDist(), 0.5)) {
+            return DianaBurrowType.MOB;
+        }
+        if (particle.getType() == ParticleTypes.DRIPPING_LAVA
+                && packet.getCount() == 2
+                && close(packet.getMaxSpeed(), 0.01)
+                && close(packet.getXDist(), 0.35)
+                && close(packet.getYDist(), 0.1)
+                && close(packet.getZDist(), 0.35)) {
+            return DianaBurrowType.TREASURE;
+        }
+        return null;
+    }
+
+    private boolean isSpadeEchoParticle(ClientboundLevelParticlesPacket packet) {
+        return packet.getParticle().getType() == ParticleTypes.DRIPPING_LAVA
+                && ((packet.getCount() == 2 && close(packet.getMaxSpeed(), -0.5))
+                || (close(packet.getXDist(), 0.0)
+                && close(packet.getYDist(), 0.0)
+                && close(packet.getZDist(), 0.0)));
+    }
+
+    private void handleSpadeEchoParticle(ClientboundLevelParticlesPacket packet, long now) {
+        if (now - lastSpadeSearchMillis > SPADE_ECHO_WINDOW_MS) return;
+
+        spadeEchoParticlesSinceClick++;
+        if (isSpadeCurveParticle(packet) && addSpadeCurvePoint(packet, now)) {
+            refineGuessFromSpadeCurve(now);
+        }
+        if (!reportedSpadeEchoForClick) {
+            reportedSpadeEchoForClick = true;
+            debugSpade("echo-first", 0L,
+                    "first spade echo particle: type=" + packet.getParticle().getType()
+                            + " count=" + packet.getCount()
+                            + " speed=" + packet.getMaxSpeed()
+                            + " offset=(" + packet.getXDist() + ", "
+                            + packet.getYDist() + ", " + packet.getZDist() + ")");
+        }
+    }
+
+    private void handleArrowParticle(ClientboundLevelParticlesPacket packet, long now) {
+        if (packet.getCount() != 0 || !close(packet.getMaxSpeed(), 1.0)) return;
+        IntRange range = arrowRange(packet);
+        if (range == null) return;
+        if (distanceToPlayerSq(packet.getX(), packet.getY(), packet.getZ()) > 36.0) return;
+        if (!isArrowNearRecentBurrowClick(packet, now)) return;
+        if (hasActiveSpadeCurve(now)) return;
+
+        if (!reportedArrowParticlesForSequence) {
+            reportedArrowParticlesForSequence = true;
+            debugSpade("arrow-first", 0L,
+                    "arrow dust detected; range bucket " + range.min() + "-" + range.max());
+        }
+
+        arrowPoints.add(new TimedPoint(new Vec3(packet.getX(), packet.getY(), packet.getZ()), now));
+        arrowPoints.removeIf(point -> now - point.timeMillis() > ARROW_POINT_TTL_MS);
+        trimOldest(arrowPoints, MAX_ARROW_POINTS);
+
+        Ray ray = detectArrowRay();
+        if (ray == null) return;
+        if (markFirstArrowSighting(ray, now)) return;
+        arrowPoints.clear();
+
+        if (!hasRecentArrowContext(now)) {
+            debugSpade("arrow-no-context", 2_500L,
+                    "arrow ray ignored because no recent burrow dig or spade search context exists");
+            return;
+        }
+
+        BlockKey guess = guessFromArrow(ray, range);
+        if (guess == null) {
+            debugSpade("arrow-no-candidate", 2_500L,
+                    "arrow ray had no valid burrow block candidate for range "
+                            + range.min() + "-" + range.max());
+            return;
+        }
+        if (distanceToPlayerSq(guess.x() + 0.5, guess.y() + 0.5, guess.z() + 0.5) < 36.0) {
+            debugSpade("arrow-too-close", 2_500L,
+                    "arrow estimate rejected as too close at " + guess.format());
+            return;
+        }
+        setEstimateGuess(guess, now, EstimateSource.ARROW);
+    }
+
+    private IntRange arrowRange(ClientboundLevelParticlesPacket packet) {
+        int x = Math.round(packet.getXDist());
+        int y = Math.round(packet.getYDist());
+        int z = Math.round(packet.getZDist());
+        if (x == 0 && y == 128 && z == 0) return new IntRange(0, 117);
+        if (x == 255 && y == 255 && z == 0) return new IntRange(112, 282);
+        if (x == 255 && y == 0 && z == 0) return new IntRange(281, 600);
+        return null;
+    }
+
+    private Ray detectArrowRay() {
+        List<TimedPoint> snapshot = List.copyOf(arrowPoints);
+        List<Vec3> points = snapshot.stream().map(TimedPoint::point).toList();
+        List<Vec3> line = findLine(points);
+        if (line.isEmpty()) return null;
+
+        int count1 = countWithin(points, line.get(1), ARROW_POINT_TOLERANCE);
+        int count2 = countWithin(points, line.get(line.size() - 2), ARROW_POINT_TOLERANCE);
+        if (!((count1 == 2 && count2 == 4) || (count1 == 4 && count2 == 2))) return null;
+
+        Vec3 tip;
+        Vec3 base;
+        if (count1 == 4) {
+            tip = line.get(0);
+            base = line.get(line.size() - 1);
+        } else {
+            tip = line.get(line.size() - 1);
+            base = line.get(0);
+        }
+
+        Vec3 origin = base.add(0.0, -1.5, 0.0);
+        Vec3 direction = tip.add(0.0, -1.5, 0.0).subtract(origin).normalize();
+        if (direction.lengthSquared() < EPSILON) return null;
+        return new Ray(origin, direction);
+    }
+
+    private boolean markFirstArrowSighting(Ray ray, long now) {
+        for (TimedRay existing : recentArrows) {
+            if (existing.ray().sameRay(ray)) return false;
+        }
+        recentArrows.add(new TimedRay(ray, now));
+        return true;
+    }
+
+    private BlockKey guessFromArrow(Ray ray, IntRange range) {
+        Map<BlockKey, Candidate> candidates = new HashMap<>();
+        for (int distance = Math.max(1, range.min()); distance <= range.max(); distance++) {
+            Vec3 point = ray.origin().add(ray.direction().scale(distance));
+            BlockKey block = new BlockKey(blockCoord(point.x()), blockCoord(point.y()), blockCoord(point.z()));
+            if (!isValidBurrowBlock(block)) continue;
+
+            Vec3 center = new Vec3(block.x() + 0.5, block.y() + 0.5, block.z() + 0.5);
+            double distToRay = distanceToRay(ray, center);
+            double scaled = distToRay * 500_000.0 / Math.max(1.0, distance);
+            Candidate existing = candidates.get(block);
+            if (existing == null || scaled < existing.scaledDistance()) {
+                candidates.put(block, new Candidate(scaled, distance));
+            }
+        }
+
+        return candidates.entrySet().stream()
+                .min(Comparator
+                        .comparingDouble((Map.Entry<BlockKey, Candidate> entry) -> entry.getValue().scaledDistance())
+                        .thenComparingDouble(entry -> entry.getValue().distanceFromOrigin()))
+                .map(Map.Entry::getKey)
+                .orElse(null);
+    }
+
+    private List<Vec3> findLine(List<Vec3> points) {
+        for (Vec3 point : points) {
+            List<Vec3> line = new ArrayList<>();
+            List<Vec3> visited = new ArrayList<>();
+            line.add(point);
+            visited.add(point);
+            if (extendLine(line, visited, points)) return List.copyOf(line);
+        }
+        return List.of();
+    }
+
+    private boolean extendLine(List<Vec3> line, List<Vec3> visited, List<Vec3> points) {
+        if (line.size() == ARROW_SHAFT_POINTS) return true;
+
+        Vec3 next = null;
+        double minDist = Double.MAX_VALUE;
+        for (Vec3 point : points) {
+            if (visited.contains(point)) continue;
+            double dist = line.get(line.size() - 1).distance(point);
+            if (dist > ARROW_POINT_TOLERANCE) continue;
+
+            Vec3 second = line.size() > 1 ? line.get(1) : line.get(0);
+            if (!isCollinear(line.get(0), second, point)) continue;
+
+            if (dist < minDist) {
+                minDist = dist;
+                next = point;
+            }
+        }
+
+        if (next == null) return false;
+        line.add(next);
+        visited.add(next);
+        if (extendLine(line, visited, points)) return true;
+        line.remove(line.size() - 1);
+        visited.remove(next);
+        return false;
+    }
+
+    private static boolean isCollinear(Vec3 a, Vec3 b, Vec3 c) {
+        return b.subtract(a).cross(c.subtract(a)).lengthSquared() < EPSILON;
+    }
+
+    private static int countWithin(List<Vec3> points, Vec3 origin, double maxDist) {
+        double maxDistSq = maxDist * maxDist;
+        int count = 0;
+        for (Vec3 point : points) {
+            if (!point.equals(origin) && point.distanceSquared(origin) <= maxDistSq) count++;
+        }
+        return count;
+    }
+
+    private boolean isValidBurrowBlock(BlockKey block) {
+        if (!isPlausibleBurrowY(block.y())) return false;
+
+        Minecraft mc = Minecraft.getInstance();
+        Level level = mc.level;
+        if (level == null) return false;
+
+        BlockPos pos = new BlockPos(block.x(), block.y(), block.z());
+        if (!level.isLoaded(pos)) return true;
+
+        BlockState ground = level.getBlockState(pos);
+        if (!ground.is(Blocks.GRASS_BLOCK)) return false;
+
+        BlockState above = level.getBlockState(pos.above());
+        return above.isAir() || above.getCollisionShape(level, pos.above()).isEmpty();
+    }
+
+    private boolean isLoadedValidBurrowBlock(BlockKey block) {
+        if (!isPlausibleBurrowY(block.y())) return false;
+
+        Minecraft mc = Minecraft.getInstance();
+        Level level = mc.level;
+        if (level == null) return false;
+
+        BlockPos pos = new BlockPos(block.x(), block.y(), block.z());
+        return level.isLoaded(pos) && isValidBurrowBlock(block);
+    }
+
+    private boolean isReasonableEstimateBlock(BlockKey block) {
+        return normalizeEstimateBlock(block) != null;
+    }
+
+    private BlockKey normalizeEstimateBlock(BlockKey block) {
+        if (!isPlausibleHubColumn(block)) return null;
+
+        BlockKey loadedGround = loadedBurrowGround(block);
+        if (loadedGround != null) return loadedGround;
+        if (isColumnLoaded(block)) return null;
+
+        return isPlausibleBurrowY(block.y()) ? block : null;
+    }
+
+    private BlockKey loadedBurrowGround(BlockKey block) {
+        if (!isColumnLoaded(block)) return null;
+
+        int startY = Math.min(MAX_BURROW_Y, block.y() + ESTIMATE_GROUND_SCAN_ABOVE);
+        for (int y = startY; y >= MIN_BURROW_Y; y--) {
+            BlockKey candidate = new BlockKey(block.x(), y, block.z());
+            if (isValidBurrowBlock(candidate)) return candidate;
+        }
+        return null;
+    }
+
+    private boolean isColumnLoaded(BlockKey block) {
+        Minecraft mc = Minecraft.getInstance();
+        Level level = mc.level;
+        if (level == null) return false;
+
+        int y = Math.max(MIN_BURROW_Y, Math.min(MAX_BURROW_Y, block.y()));
+        return level.isLoaded(new BlockPos(block.x(), y, block.z()));
+    }
+
+    private boolean addSpadeCurvePoint(ClientboundLevelParticlesPacket packet, long now) {
+        Vec3 point = new Vec3(packet.getX(), packet.getY(), packet.getZ());
+        List<TimedPoint> snapshot = List.copyOf(spadeCurvePoints);
+        if (!snapshot.isEmpty()) {
+            Vec3 previous = snapshot.get(snapshot.size() - 1).point();
+            double distance = previous.distance(point);
+            if (distance < SPADE_CURVE_DUPLICATE_TOLERANCE) return false;
+            if (distance > SPADE_CURVE_OUTLIER_DISTANCE) {
+                spadeCurvePoints.clear();
+                recentSpadeCurveEstimates.clear();
+                debugSpade("curve-outlier", 1_000L,
+                        "curve sample jumped " + formatDistance(distance)
+                                + " blocks; reset curve fit at "
+                                + formatPoint(point));
+            }
+        }
+
+        spadeCurvePoints.add(new TimedPoint(point, now));
+        spadeCurvePoints.removeIf(sample -> now - sample.timeMillis() > SPADE_CURVE_POINT_TTL_MS);
+        trimOldest(spadeCurvePoints, MAX_SPADE_CURVE_POINTS);
+        int sampleCount = spadeCurvePoints.size();
+        if (sampleCount == 1 || sampleCount % 8 == 0) {
+            debugSpade("curve-samples", 750L,
+                    "collected " + sampleCount + " spade curve sample(s); latest "
+                            + formatPoint(point));
+        }
+        return true;
+    }
+
+    private void refineGuessFromSpadeCurve(long now) {
+        List<DianaSpadeCurveSolver.Sample> samples = List.copyOf(spadeCurvePoints).stream()
+                .map(point -> new DianaSpadeCurveSolver.Sample(
+                        point.point().x(),
+                        point.point().y(),
+                        point.point().z()))
+                .toList();
+        var estimateOpt = DianaSpadeCurveSolver.estimate(samples);
+        if (estimateOpt.isEmpty()) {
+            debugSpade("curve-no-estimate", 1_000L,
+                    "curve solver has no estimate yet from " + samples.size() + " sample(s)");
+            return;
+        }
+
+        DianaSpadeCurveSolver.Estimate estimate = estimateOpt.get();
+        BlockKey rawGuess = new BlockKey(
+                blockCoord(estimate.x()),
+                blockCoord(estimate.y() - 0.5),
+                blockCoord(estimate.z()));
+        BlockKey guess = normalizeEstimateBlock(rawGuess);
+        if (guess == null) {
+            debugSpade("curve-invalid", 1_500L,
+                    "curve estimate rejected outside valid Hub burrow space at " + rawGuess.format()
+                            + " from " + estimate.sampleCount() + " sample(s)");
+            return;
+        }
+        if (distanceToPlayerSq(guess.x() + 0.5, guess.y() + 0.5, guess.z() + 0.5) < 9.0) {
+            debugSpade("curve-too-close", 1_500L,
+                    "curve estimate rejected as too close at " + guess.format());
+            return;
+        }
+        if (!isStableSpadeCurveEstimate(guess, estimate.sampleCount())) {
+            debugSpade("curve-unstable", 750L,
+                    "curve estimate still stabilizing at " + guess.format()
+                            + " from " + estimate.sampleCount() + " sample(s)");
+            return;
+        }
+
+        debugSpade("curve-accepted", 0L,
+                "curve estimate accepted at " + guess.format()
+                        + " from " + estimate.sampleCount() + " sample(s)");
+        setEstimateGuess(guess, now, EstimateSource.SPADE_CURVE);
+    }
+
+    private void setEstimateGuess(BlockKey guess, long now, EstimateSource source) {
+        if (!config.dianaSpadeEstimateWaypoints()) {
+            debugSpade("estimate-disabled", 1_500L, "estimate ignored because estimate waypoints are disabled");
+            return;
+        }
+        if (source == EstimateSource.ARROW && currentEstimateSource() == EstimateSource.SPADE_CURVE) {
+            debugSpade("arrow-ignored-curve-active", 1_500L,
+                    "arrow estimate ignored because a spade-curve estimate is active");
+            return;
+        }
+        guess = normalizeEstimateBlock(guess);
+        if (guess == null) {
+            debugSpade("estimate-normalize-null", 1_500L,
+                    "estimate ignored because ground normalization failed");
+            return;
+        }
+        guesses.clear();
+        guesses.put(guess, new Guess(now, source));
+        renderWaypoints();
+    }
+
+    private boolean isStableSpadeCurveEstimate(BlockKey guess, int sampleCount) {
+        recentSpadeCurveEstimates.add(guess);
+        while (recentSpadeCurveEstimates.size() > SPADE_CURVE_STABLE_ESTIMATE_COUNT) {
+            recentSpadeCurveEstimates.remove(0);
+        }
+
+        if (sampleCount < config.dianaEstimateMinSamples()
+                || recentSpadeCurveEstimates.size() < SPADE_CURVE_STABLE_ESTIMATE_COUNT) {
+            return false;
+        }
+
+        double stableRadius = config.dianaEstimateStabilityRadius();
+        double stableRadiusSq = stableRadius * stableRadius;
+        for (BlockKey candidate : recentSpadeCurveEstimates) {
+            if (candidate.distanceSq(guess) > stableRadiusSq) return false;
+        }
+        return true;
+    }
+
+    private EstimateSource currentEstimateSource() {
+        return guesses.values().stream()
+                .findFirst()
+                .map(Guess::source)
+                .orElse(null);
+    }
+
+    private boolean normalizeLoadedGuesses() {
+        boolean changed = false;
+        for (Map.Entry<BlockKey, Guess> entry : List.copyOf(guesses.entrySet())) {
+            BlockKey key = entry.getKey();
+            Guess guess = entry.getValue();
+            BlockKey normalized = normalizeEstimateBlock(key);
+            if (normalized == null) {
+                if (guesses.remove(key, guess)) changed = true;
+                continue;
+            }
+            if (!normalized.equals(key) && guesses.remove(key, guess)) {
+                guesses.put(normalized, guess);
+                changed = true;
+            }
+        }
+        return changed;
+    }
+
+    private boolean isArrowNearRecentBurrowClick(ClientboundLevelParticlesPacket packet, long now) {
+        if (lastSpadeAttackBlock == null || now - lastSpadeAttackMillis > RECENT_ARROW_CLICK_SOURCE_MS) {
+            return false;
+        }
+        return lastSpadeAttackBlock.distanceSq(packet.getX(), packet.getY() - 2.0, packet.getZ()) <= 64.0;
+    }
+
+    private boolean hasActiveSpadeCurve(long now) {
+        return !spadeCurvePoints.isEmpty()
+                && now - spadeCurvePoints.get(spadeCurvePoints.size() - 1).timeMillis() <= SPADE_CURVE_POINT_TTL_MS;
+    }
+
+    private void removeNearbyGuesses(BlockKey key, double radius) {
+        guesses.keySet().removeIf(guess -> sameBurrowColumnArea(guess, key, radius));
+    }
+
+    private BlockKey recentlyClickedBurrowBlock(long now) {
+        if (lastSpadeAttackBlock == null) return null;
+        return now - lastSpadeAttackMillis <= RECENT_BURROW_CLICK_MS ? lastSpadeAttackBlock : null;
+    }
+
+    private boolean removeNearby(BlockKey key, double radius) {
+        boolean removedSighting = sightings.keySet().removeIf(candidate -> sameBurrowColumnArea(candidate, key, radius));
+        boolean removedGuess = guesses.keySet().removeIf(candidate -> sameBurrowColumnArea(candidate, key, radius));
+        return removedSighting || removedGuess;
+    }
+
+    private boolean clearResolvedBurrowMarkers(String message) {
+        String lower = message.toLowerCase(Locale.ROOT);
+        boolean progress = lower.contains("griffin burrow") || lower.contains("finished the griffin burrow chain");
+        boolean dugMob = isMobDugMessage(lower);
+        boolean dugTreasure = isTreasureDugMessage(lower);
+
+        if (!progress && !dugMob && !dugTreasure) return false;
+
+        boolean removed = false;
+        if (progress || dugMob) removed |= removeSightingsOfType(DianaBurrowType.MOB);
+        if (progress || dugTreasure) removed |= removeSightingsOfType(DianaBurrowType.TREASURE);
+        return removed;
+    }
+
+    private boolean removeSightingsOfType(DianaBurrowType type) {
+        return sightings.entrySet().removeIf(entry -> entry.getValue().confirmedType == type);
+    }
+
+    private static boolean sameBurrowColumnArea(BlockKey candidate, BlockKey target, double horizontalRadius) {
+        double dx = candidate.x() - target.x();
+        double dz = candidate.z() - target.z();
+        return dx * dx + dz * dz <= horizontalRadius * horizontalRadius
+                && Math.abs(candidate.y() - target.y()) <= RESOLVED_BURROW_Y_TOLERANCE;
+    }
+
+    private boolean removeNearestToPlayer(double radius) {
+        LocalPlayer player = Minecraft.getInstance().player;
+        if (player == null) return false;
+        double radiusSq = radius * radius;
+        BlockKey nearest = null;
+        double best = Double.MAX_VALUE;
+        for (BlockKey key : allKnownKeys()) {
+            double dist = key.distanceSq(player.getX(), player.getY(), player.getZ());
+            if (dist <= radiusSq && dist < best) {
+                best = dist;
+                nearest = key;
+            }
+        }
+        if (nearest != null) {
+            sightings.remove(nearest);
+            guesses.remove(nearest);
+            return true;
+        }
+        return false;
+    }
+
+    private List<BlockKey> allKnownKeys() {
+        List<BlockKey> out = new ArrayList<>(sightings.keySet());
+        out.addAll(guesses.keySet());
+        return out;
+    }
+
+    private void renderWaypoints() {
+        if (!config.dianaBurrowWaypoints()) return;
+
+        List<Waypoint> estimateWaypoints = new ArrayList<>();
+        if (config.dianaSpadeEstimateWaypoints()) {
+            guesses.keySet().stream()
+                    .filter(key -> !sightings.containsKey(key))
+                    .sorted()
+                    .forEach(key -> estimateWaypoints.add(waypoint(key, DianaBurrowType.GUESS)));
+        }
+
+        List<Waypoint> waypoints = new ArrayList<>(estimateWaypoints);
+        sightings.entrySet().stream()
+                .filter(entry -> entry.getValue().confirmedType != null)
+                .filter(entry -> shouldRenderDianaType(entry.getValue().confirmedType))
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(entry -> waypoints.add(waypoint(entry.getKey(), entry.getValue().confirmedType)));
+
+        int navigationIndex = navigationIndex(waypoints, estimateWaypoints.size());
+        String signature = signature(waypoints);
+        WaypointGroup existing = manager.get(GROUP_ID);
+        if (Objects.equals(signature, lastRenderedSignature)) {
+            if (existing != null && existing.currentIndex() != navigationIndex) {
+                existing.setCurrentIndex(navigationIndex);
+                manager.fireDataChanged();
+            }
+            return;
+        }
+        lastRenderedSignature = signature;
+
+        if (waypoints.isEmpty()) {
+            if (existing != null) manager.remove(GROUP_ID);
+            return;
+        }
+
+        WaypointGroup group = ensureGroup();
+        group.replaceWaypoints(waypoints);
+        group.setCurrentIndex(navigationIndex);
+        manager.fireDataChanged();
+    }
+
+    private int navigationIndex(List<Waypoint> waypoints, int estimateCount) {
+        if (estimateCount > 0) return 0;
+        if (!currentChainComplete) return waypoints.size();
+
+        LocalPlayer player = Minecraft.getInstance().player;
+        if (player == null) return firstStartBurrowIndex(waypoints);
+
+        int bestIndex = waypoints.size();
+        double bestDistanceSq = Double.MAX_VALUE;
+        for (int i = 0; i < waypoints.size(); i++) {
+            Waypoint waypoint = waypoints.get(i);
+            if (!DianaBurrowType.START.label().equals(waypoint.name())) continue;
+
+            double distanceSq = waypointDistanceSq(waypoint, player.getX(), player.getY(), player.getZ());
+            if (distanceSq < bestDistanceSq) {
+                bestDistanceSq = distanceSq;
+                bestIndex = i;
+            }
+        }
+        return bestIndex;
+    }
+
+    private static int firstStartBurrowIndex(List<Waypoint> waypoints) {
+        for (int i = 0; i < waypoints.size(); i++) {
+            if (DianaBurrowType.START.label().equals(waypoints.get(i).name())) return i;
+        }
+        return waypoints.size();
+    }
+
+    private static double waypointDistanceSq(Waypoint waypoint, double x, double y, double z) {
+        double dx = waypoint.x() + 0.5 - x;
+        double dy = waypoint.y() + 0.5 - y;
+        double dz = waypoint.z() + 0.5 - z;
+        return dx * dx + dy * dy + dz * dz;
+    }
+
+    private WaypointGroup ensureGroup() {
+        WaypointGroup existing = manager.get(GROUP_ID);
+        if (existing != null) return existing;
+
+        WaypointGroup group = new WaypointGroup(GROUP_ID, "Diana Burrows", HUB_ZONE_ID);
+        group.setTemp(true);
+        group.setLoadMode(WaypointGroup.LoadMode.STATIC);
+        group.setGradientMode(WaypointGroup.GradientMode.MANUAL);
+        group.setSkipAheadEnabled(false);
+        manager.add(group);
+        return group;
+    }
+
+    private Waypoint waypoint(BlockKey key, DianaBurrowType type) {
+        return Waypoint.at(key.x(), key.y(), key.z())
+                .withName(dianaLabel(key, type))
+                .withColor(dianaColor(key, type))
+                .withFlags(Waypoint.FLAG_LOCKED_COLOR)
+                .withTemp(Waypoint.TEMP_UNTIL_LEAVE, 0L);
+    }
+
+    private String dianaLabel(BlockKey key, DianaBurrowType type) {
+        if (type != DianaBurrowType.GUESS) return type.label();
+
+        String base = config.dianaEstimateWaypointName();
+        return hasHelpfulWarp(key)
+                ? base + "\nPress warp key"
+                : base;
+    }
+
+    private int dianaColor(BlockKey key, DianaBurrowType type) {
+        if (type == DianaBurrowType.GUESS && hasHelpfulWarp(key)) {
+            return WARP_HELPFUL_COLOR;
+        }
+        return switch (type) {
+            case START -> config.dianaStartBurrowColor();
+            case MOB -> config.dianaMobBurrowColor();
+            case TREASURE -> config.dianaTreasureBurrowColor();
+            case GUESS -> config.dianaEstimateWaypointColor();
+        };
+    }
+
+    private static String signature(List<Waypoint> waypoints) {
+        StringBuilder out = new StringBuilder();
+        for (Waypoint waypoint : waypoints) {
+            out.append(waypoint.x()).append(',')
+                    .append(waypoint.y()).append(',')
+                    .append(waypoint.z()).append(',')
+                    .append(waypoint.name()).append(',')
+                    .append(waypoint.color()).append(';');
+        }
+        return out.toString();
+    }
+
+    private boolean hasHelpfulWarp(BlockKey key) {
+        LocalPlayer player = Minecraft.getInstance().player;
+        if (player == null || !config.dianaWarpAssist()) return false;
+
+        double estimateX = key.x() + 0.5;
+        double estimateY = key.y() + 0.5;
+        double estimateZ = key.z() + 0.5;
+        double playerDistance = distance(
+                player.getX(), player.getY(), player.getZ(),
+                estimateX, estimateY, estimateZ);
+
+        for (DianaWarp warp : DianaWarp.values()) {
+            if (!config.dianaWarpEnabled(warp)) continue;
+
+            double warpDistance = distance(
+                    warp.x(), warp.y(), warp.z(),
+                    estimateX, estimateY, estimateZ);
+            if (playerDistance - warpDistance > config.dianaWarpMinSavings()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean shouldRenderDianaType(DianaBurrowType type) {
+        if (type == DianaBurrowType.START && !config.dianaShowStartBurrows()) return false;
+        if (type == DianaBurrowType.MOB && !config.dianaShowMobBurrows()) return false;
+        if (type == DianaBurrowType.TREASURE && !config.dianaShowTreasureBurrows()) return false;
+        return type != DianaBurrowType.START
+                || !config.dianaHideStartBurrowsUntilChainComplete()
+                || currentChainComplete;
+    }
+
+    private boolean updateChainState(String text) {
+        String lower = text.toLowerCase(Locale.ROOT);
+        boolean previous = currentChainComplete;
+
+        if (lower.contains("finished the griffin burrow chain")) {
+            currentChainComplete = true;
+            return previous != currentChainComplete;
+        }
+
+        if (!lower.contains("griffin burrow")) return false;
+
+        Matcher matcher = CHAIN_PROGRESS_PATTERN.matcher(text);
+        if (!matcher.find()) return false;
+
+        int current = parsePositiveInt(matcher.group(1));
+        int total = parsePositiveInt(matcher.group(2));
+        if (current <= 0 || total <= 0) return false;
+
+        currentChainComplete = current >= total;
+        return previous != currentChainComplete;
+    }
+
+    private void reset() {
+        sightings.clear();
+        guesses.clear();
+        arrowPoints.clear();
+        spadeCurvePoints.clear();
+        recentSpadeCurveEstimates.clear();
+        recentArrows.clear();
+        lastRenderedSignature = "";
+        lastBurrowRelatedChatMillis = 0L;
+        lastSpadeAttackBlock = null;
+        lastSpadeAttackMillis = 0L;
+        lastSpadeSearchMillis = 0L;
+        spadeEchoParticlesSinceClick = 0;
+        reportedSpadeEchoForClick = false;
+        reportedArrowParticlesForSequence = false;
+        currentChainComplete = true;
+        spadeDebugLogTimes.clear();
+        if (manager.get(GROUP_ID) != null) manager.remove(GROUP_ID);
+    }
+
+    private boolean isEnabledInHub() {
+        return config.dianaBurrowWaypoints()
+                && manager.currentZone() != null
+                && HUB_ZONE_ID.equals(manager.currentZone().id());
+    }
+
+    private double distanceToPlayerSq(double x, double y, double z) {
+        LocalPlayer player = Minecraft.getInstance().player;
+        if (player == null) return Double.MAX_VALUE;
+        double dx = player.getX() - x;
+        double dy = player.getY() - y;
+        double dz = player.getZ() - z;
+        return dx * dx + dy * dy + dz * dz;
+    }
+
+    private static BlockKey burrowBlock(ClientboundLevelParticlesPacket packet) {
+        return new BlockKey(blockCoord(packet.getX()), blockCoord(packet.getY() - 1.0), blockCoord(packet.getZ()));
+    }
+
+    private static int blockCoord(double value) {
+        return (int) Math.floor(value);
+    }
+
+    private static boolean close(double value, double expected) {
+        return Math.abs(value - expected) < 0.0001;
+    }
+
+    private static <T> void trimOldest(List<T> values, int maxSize) {
+        int over = values.size() - maxSize;
+        if (over > 0) values.subList(0, over).clear();
+    }
+
+    private static boolean isPlausibleBurrowY(int y) {
+        return y >= MIN_BURROW_Y && y <= MAX_BURROW_Y;
+    }
+
+    private static boolean isPlausibleHubBlock(BlockKey block) {
+        return isPlausibleHubColumn(block)
+                && isPlausibleBurrowY(block.y());
+    }
+
+    private static boolean isPlausibleHubColumn(BlockKey block) {
+        return block.x() >= HUB_MIN_X
+                && block.x() <= HUB_MAX_X
+                && block.z() >= HUB_MIN_Z
+                && block.z() <= HUB_MAX_Z;
+    }
+
+    private static boolean isSpadeCurveParticle(ClientboundLevelParticlesPacket packet) {
+        return packet.getParticle().getType() == ParticleTypes.DRIPPING_LAVA
+                && packet.getCount() == 2
+                && close(packet.getMaxSpeed(), -0.5);
+    }
+
+    private static boolean isDianaSpade(ItemStack item) {
+        if (item == null || item.isEmpty()) return false;
+        String name = item.getHoverName().getString().toLowerCase(Locale.ROOT);
+        return name.contains("ancestral spade")
+                || name.contains("archaic spade")
+                || name.contains("deific spade");
+    }
+
+    private boolean hasRecentArrowContext(long now) {
+        return now - lastBurrowRelatedChatMillis <= RECENT_BURROW_ARROW_MS
+                || now - lastSpadeSearchMillis <= RECENT_SPADE_SEARCH_ARROW_MS;
+    }
+
+    private static boolean isBurrowDugMessage(String text) {
+        String lower = text.toLowerCase(Locale.ROOT);
+        return lower.contains("you dug out")
+                || lower.contains("finished the griffin burrow chain")
+                || lower.contains("defeat all the burrow defenders");
+    }
+
+    private static boolean isMobDugMessage(String lower) {
+        return lower.contains("you dug out")
+                && !lower.contains("griffin burrow")
+                && !isTreasureDugMessage(lower);
+    }
+
+    private static boolean isTreasureDugMessage(String lower) {
+        return lower.contains("rare drop")
+                || lower.contains("coins")
+                || lower.contains("griffin feather")
+                || lower.contains("crown of greed")
+                || lower.contains("washed-up souvenir")
+                || lower.contains("minos relic")
+                || lower.contains("chimera");
+    }
+
+    private static int parsePositiveInt(String text) {
+        try {
+            return Integer.parseInt(text);
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+
+    private static String format(int x, int y, int z) {
+        return x + ", " + y + ", " + z;
+    }
+
+    private static String formatDistance(double distance) {
+        return String.format(Locale.ROOT, "%.1f", distance);
+    }
+
+    private static String formatPoint(Vec3 point) {
+        return String.format(Locale.ROOT, "%.2f, %.2f, %.2f", point.x(), point.y(), point.z());
+    }
+
+    private void debugSpade(String key, long minIntervalMillis, String message) {
+        if (!config.dianaSpadeDebugLogging()) return;
+
+        long now = System.currentTimeMillis();
+        Long last = spadeDebugLogTimes.get(key);
+        if (last != null && now - last < minIntervalMillis) return;
+
+        spadeDebugLogTimes.put(key, now);
+        Waypointer.LOGGER.info("[Diana spade] {}", message);
+    }
+
+    private static double distance(double ax, double ay, double az, double bx, double by, double bz) {
+        double dx = ax - bx;
+        double dy = ay - by;
+        double dz = az - bz;
+        return Math.sqrt(dx * dx + dy * dy + dz * dz);
+    }
+
+    private static double distanceToRay(Ray ray, Vec3 point) {
+        Vec3 originToPoint = point.subtract(ray.origin());
+        Vec3 projected = ray.direction().scale(originToPoint.dot(ray.direction()));
+        return originToPoint.subtract(projected).length();
+    }
+
+    private record SightingState(BlockKey key, DianaBurrowType type) {}
+
+    private static final class Sighting {
+        private boolean hasEnchant;
+        private DianaBurrowType type;
+        private DianaBurrowType confirmedType;
+        private long lastSeenMillis;
+    }
+
+    private record Guess(long createdAtMillis, EstimateSource source) {}
+
+    private enum EstimateSource {
+        ARROW,
+        SPADE_CURVE
+    }
+
+    private record TimedPoint(Vec3 point, long timeMillis) {}
+
+    private record TimedRay(Ray ray, long timeMillis) {}
+
+    private record Candidate(double scaledDistance, double distanceFromOrigin) {}
+
+    private record IntRange(int min, int max) {}
+
+    private record Ray(Vec3 origin, Vec3 direction) {
+        boolean sameRay(Ray other) {
+            return origin.distanceSquared(other.origin) < 0.01
+                    && direction.distanceSquared(other.direction) < 0.0001;
+        }
+    }
+
+    private record BlockKey(int x, int y, int z) implements Comparable<BlockKey> {
+        double distanceSq(BlockKey other) {
+            return distanceSq(other.x, other.y, other.z);
+        }
+
+        double distance(BlockKey other) {
+            return Math.sqrt(distanceSq(other));
+        }
+
+        double distanceSq(double ox, double oy, double oz) {
+            double dx = x + 0.5 - ox;
+            double dy = y + 0.5 - oy;
+            double dz = z + 0.5 - oz;
+            return dx * dx + dy * dy + dz * dz;
+        }
+
+        String format() {
+            return DianaBurrowDetector.format(x, y, z);
+        }
+
+        @Override
+        public int compareTo(BlockKey other) {
+            int byX = Integer.compare(x, other.x);
+            if (byX != 0) return byX;
+            int byY = Integer.compare(y, other.y);
+            if (byY != 0) return byY;
+            return Integer.compare(z, other.z);
+        }
+    }
+
+    private record Vec3(double x, double y, double z) {
+        Vec3 add(double ox, double oy, double oz) {
+            return new Vec3(x + ox, y + oy, z + oz);
+        }
+
+        Vec3 add(Vec3 other) {
+            return add(other.x, other.y, other.z);
+        }
+
+        Vec3 subtract(Vec3 other) {
+            return new Vec3(x - other.x, y - other.y, z - other.z);
+        }
+
+        Vec3 scale(double amount) {
+            return new Vec3(x * amount, y * amount, z * amount);
+        }
+
+        Vec3 normalize() {
+            double length = length();
+            return length < EPSILON ? this : scale(1.0 / length);
+        }
+
+        Vec3 cross(Vec3 other) {
+            return new Vec3(
+                    y * other.z - z * other.y,
+                    z * other.x - x * other.z,
+                    x * other.y - y * other.x);
+        }
+
+        double dot(Vec3 other) {
+            return x * other.x + y * other.y + z * other.z;
+        }
+
+        double length() {
+            return Math.sqrt(lengthSquared());
+        }
+
+        double lengthSquared() {
+            return x * x + y * y + z * z;
+        }
+
+        double distance(Vec3 other) {
+            return Math.sqrt(distanceSquared(other));
+        }
+
+        double distanceSquared(Vec3 other) {
+            double dx = x - other.x;
+            double dy = y - other.y;
+            double dz = z - other.z;
+            return dx * dx + dy * dy + dz * dz;
+        }
+    }
+}

--- a/src/client/java/dev/ethan/waypointer/diana/DianaWaypointDetector.java
+++ b/src/client/java/dev/ethan/waypointer/diana/DianaWaypointDetector.java
@@ -96,6 +96,11 @@ public final class DianaWaypointDetector {
     }
 
     public static boolean isRareMobWaypoint(Waypoint waypoint) {
-        return waypoint != null && waypoint.name().contains(RARE_MOB_LABEL_MARKER);
+        if (waypoint == null) return false;
+        String name = waypoint.name();
+        // Diana chat labels use LIGHT_PURPLE for the mob + YELLOW before " from ".
+        // Require those codes so plain user text like "Start from North" does not match.
+        return name.contains(String.valueOf(ChatFormatting.LIGHT_PURPLE))
+                && name.contains(String.valueOf(ChatFormatting.YELLOW) + RARE_MOB_LABEL_MARKER);
     }
 }

--- a/src/client/java/dev/ethan/waypointer/diana/DianaWaypointDetector.java
+++ b/src/client/java/dev/ethan/waypointer/diana/DianaWaypointDetector.java
@@ -1,0 +1,101 @@
+package dev.ethan.waypointer.diana;
+
+import dev.ethan.waypointer.config.WaypointerConfig;
+import dev.ethan.waypointer.core.ActiveGroupManager;
+import dev.ethan.waypointer.core.Waypoint;
+import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+
+import java.util.EnumMap;
+import java.util.Locale;
+import java.util.Map;
+
+public final class DianaWaypointDetector {
+
+    private static final long OUTGOING_SHARE_COOLDOWN_MS = 5_000L;
+    private static final String RARE_MOB_LABEL_MARKER = " from ";
+
+    private final WaypointerConfig config;
+    private final ActiveGroupManager manager;
+    private final Map<DianaRareMob, Long> lastSharedMillis = new EnumMap<>(DianaRareMob.class);
+
+    public DianaWaypointDetector(WaypointerConfig config, ActiveGroupManager manager) {
+        this.config = config;
+        this.manager = manager;
+    }
+
+    public void install() {
+        ClientReceiveMessageEvents.MODIFY_GAME.register(this::onMessage);
+    }
+
+    private Component onMessage(Component message, boolean overlay) {
+        if (overlay) return message;
+        if (manager.currentZone() == null || !"hub".equals(manager.currentZone().id())) return message;
+
+        String text = message.getString();
+        maybeShareOwnRareMob(text);
+
+        if (config.dianaRareMobWaypoints()) {
+            DianaRareMobShareParser.parse(text).ifPresent(share -> {
+                long now = System.currentTimeMillis();
+                var group = manager.addTempWaypoint(share.x(), share.y(), share.z(),
+                        tempLabel(share),
+                        config.tempDefaultMode(),
+                        config.defaultTempExpiresAtMillis(now));
+                if (config.focusTempWaypoints()) {
+                    manager.focusTempWaypoint(group, group.size() - 1);
+                }
+            });
+        }
+        return message;
+    }
+
+    private void maybeShareOwnRareMob(String text) {
+        if (!config.dianaRareMobPartySharing()) return;
+
+        DianaRareMob mob = dugRareMob(text);
+        if (mob == null || !config.dianaRareMobShareEnabled(mob)) return;
+
+        long now = System.currentTimeMillis();
+        Long last = lastSharedMillis.get(mob);
+        if (last != null && now - last < OUTGOING_SHARE_COOLDOWN_MS) return;
+
+        LocalPlayer player = Minecraft.getInstance().player;
+        if (player == null || player.connection == null) return;
+
+        BlockPos pos = player.blockPosition();
+        player.connection.sendCommand("pc x: " + pos.getX()
+                + ", y: " + pos.getY()
+                + ", z: " + pos.getZ()
+                + " | " + mob.label() + " spawned!");
+        lastSharedMillis.put(mob, now);
+    }
+
+    private static DianaRareMob dugRareMob(String text) {
+        if (text == null || text.isBlank()) return null;
+
+        String lower = text.toLowerCase(Locale.ROOT).trim();
+        boolean ownDugMessage = lower.startsWith("you dug out")
+                || lower.startsWith("oh! you dug out")
+                || lower.startsWith("oi! you dug out");
+        if (!ownDugMessage) return null;
+
+        for (DianaRareMob mob : DianaRareMob.values()) {
+            if (mob.matches(lower)) return mob;
+        }
+        return null;
+    }
+
+    private static String tempLabel(DianaRareMobShareParser.Share share) {
+        return ChatFormatting.LIGHT_PURPLE + share.mobName()
+                + ChatFormatting.YELLOW + RARE_MOB_LABEL_MARKER + share.playerName();
+    }
+
+    public static boolean isRareMobWaypoint(Waypoint waypoint) {
+        return waypoint != null && waypoint.name().contains(RARE_MOB_LABEL_MARKER);
+    }
+}

--- a/src/client/java/dev/ethan/waypointer/diana/WaypointerParticleEvents.java
+++ b/src/client/java/dev/ethan/waypointer/diana/WaypointerParticleEvents.java
@@ -1,0 +1,32 @@
+package dev.ethan.waypointer.diana;
+
+import dev.ethan.waypointer.Waypointer;
+import net.minecraft.network.protocol.game.ClientboundLevelParticlesPacket;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public final class WaypointerParticleEvents {
+
+    public interface Listener {
+        void onParticle(ClientboundLevelParticlesPacket packet);
+    }
+
+    private static final List<Listener> LISTENERS = new CopyOnWriteArrayList<>();
+
+    private WaypointerParticleEvents() {}
+
+    public static void register(Listener listener) {
+        LISTENERS.add(listener);
+    }
+
+    public static void emit(ClientboundLevelParticlesPacket packet) {
+        for (Listener listener : LISTENERS) {
+            try {
+                listener.onParticle(packet);
+            } catch (RuntimeException e) {
+                Waypointer.LOGGER.warn("Waypointer particle listener failed; skipping this particle packet", e);
+            }
+        }
+    }
+}

--- a/src/client/java/dev/ethan/waypointer/input/WaypointerKeybinds.java
+++ b/src/client/java/dev/ethan/waypointer/input/WaypointerKeybinds.java
@@ -6,7 +6,9 @@ import dev.ethan.waypointer.config.WaypointerConfig;
 import dev.ethan.waypointer.core.ActiveGroupManager;
 import dev.ethan.waypointer.core.Waypoint;
 import dev.ethan.waypointer.core.WaypointGroup;
+import dev.ethan.waypointer.diana.DianaBurrowDetector;
 import dev.ethan.waypointer.diana.DianaWarp;
+import dev.ethan.waypointer.math.DistanceUtil;
 import dev.ethan.waypointer.placement.PlayerWaypointPlacement;
 import dev.ethan.waypointer.screen.AddNamedWaypointScreen;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
@@ -289,14 +291,14 @@ public final class WaypointerKeybinds {
         double estimateX = estimate.x() + 0.5;
         double estimateY = estimate.y() + 0.5;
         double estimateZ = estimate.z() + 0.5;
-        double playerDistance = distance(player.getX(), player.getY(), player.getZ(),
+        double playerDistance = DistanceUtil.euclidean(player.getX(), player.getY(), player.getZ(),
                 estimateX, estimateY, estimateZ);
 
         DianaWarpCandidate best = null;
         for (DianaWarp warp : DianaWarp.values()) {
             if (!config.dianaWarpEnabled(warp)) continue;
 
-            double warpDistance = distance(warp.x(), warp.y(), warp.z(), estimateX, estimateY, estimateZ);
+            double warpDistance = DistanceUtil.euclidean(warp.x(), warp.y(), warp.z(), estimateX, estimateY, estimateZ);
             double savings = playerDistance - warpDistance;
             if (savings <= config.dianaWarpMinSavings()) continue;
             if (best == null || warpDistance < best.warpDistance()) {
@@ -308,23 +310,17 @@ public final class WaypointerKeybinds {
 
     private Waypoint currentDianaEstimate() {
         String estimateName = config.dianaEstimateWaypointName();
+        String withWarpAssistLine = DianaBurrowDetector.dianaEstimateNameWithWarpAssistLine(estimateName);
         for (WaypointGroup group : manager.activeGroups()) {
             if (!group.id().startsWith("diana::")) continue;
             for (Waypoint waypoint : group.waypoints()) {
                 if (estimateName.equals(waypoint.name())
-                        || waypoint.name().startsWith(estimateName + "\n")) {
+                        || withWarpAssistLine.equals(waypoint.name())) {
                     return waypoint;
                 }
             }
         }
         return null;
-    }
-
-    private static double distance(double ax, double ay, double az, double bx, double by, double bz) {
-        double dx = ax - bx;
-        double dy = ay - by;
-        double dz = az - bz;
-        return Math.sqrt(dx * dx + dy * dy + dz * dz);
     }
 
     private PlayerWaypointPlacement.BlockPosition playerWaypointPosition(LocalPlayer player) {

--- a/src/client/java/dev/ethan/waypointer/input/WaypointerKeybinds.java
+++ b/src/client/java/dev/ethan/waypointer/input/WaypointerKeybinds.java
@@ -6,6 +6,7 @@ import dev.ethan.waypointer.config.WaypointerConfig;
 import dev.ethan.waypointer.core.ActiveGroupManager;
 import dev.ethan.waypointer.core.Waypoint;
 import dev.ethan.waypointer.core.WaypointGroup;
+import dev.ethan.waypointer.diana.DianaWarp;
 import dev.ethan.waypointer.placement.PlayerWaypointPlacement;
 import dev.ethan.waypointer.screen.AddNamedWaypointScreen;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
@@ -40,6 +41,8 @@ import org.lwjgl.glfw.GLFW;
  *     the waypoint before adding it.
  *   - Add Temp Waypoint Here -- drops a temporary waypoint using the user's
  *     default expiry mode and duration.
+ *   - Diana Warp Assist -- warps to the enabled Hub warp that saves meaningful
+ *     travel distance to the active Diana estimate waypoint.
  *
  * All bindings are registered under a single Waypointer category via the
  * identifier-based API so the vanilla controls screen groups them together.
@@ -58,6 +61,7 @@ public final class WaypointerKeybinds {
     private final KeyMapping repositionAddWaypoint;
     private final KeyMapping repositionAddNamedWaypoint;
     private final KeyMapping addTempWaypointHere;
+    private final KeyMapping dianaWarpAssist;
     private final Runnable openGui;
     private final ActiveGroupManager manager;
     private final WaypointerConfig config;
@@ -113,6 +117,11 @@ public final class WaypointerKeybinds {
                 InputConstants.Type.KEYSYM,
                 InputConstants.UNKNOWN.getValue(),
                 CATEGORY));
+        this.dianaWarpAssist = KeyBindingHelper.registerKeyBinding(new KeyMapping(
+                "key.waypointer.diana_warp_assist",
+                InputConstants.Type.KEYSYM,
+                InputConstants.UNKNOWN.getValue(),
+                CATEGORY));
     }
 
     public void install() {
@@ -150,6 +159,7 @@ public final class WaypointerKeybinds {
             return;
         }
         while (addTempWaypointHere.consumeClick()) addTempWaypointAtPlayer(mc);
+        while (dianaWarpAssist.consumeClick()) runDianaWarpAssist(mc);
     }
 
     /**
@@ -164,6 +174,7 @@ public final class WaypointerKeybinds {
         while (repositionAddWaypoint.consumeClick()) {}
         while (repositionAddNamedWaypoint.consumeClick()) {}
         while (addTempWaypointHere.consumeClick()) {}
+        while (dianaWarpAssist.consumeClick()) {}
     }
 
     /**
@@ -256,6 +267,66 @@ public final class WaypointerKeybinds {
                 + pos.x() + ", " + pos.y() + ", " + pos.z()).withStyle(ChatFormatting.AQUA));
     }
 
+    private void runDianaWarpAssist(Minecraft mc) {
+        DianaWarpCandidate candidate = currentDianaWarpCandidate(mc);
+        if (candidate == null) return;
+
+        LocalPlayer player = mc.player;
+        if (player == null || player.connection == null) return;
+        player.connection.sendCommand(candidate.warp().command());
+        showFeedback(mc, Component.literal("Warping to " + candidate.warp().label() + "...")
+                .withStyle(ChatFormatting.DARK_GREEN));
+    }
+
+    private DianaWarpCandidate currentDianaWarpCandidate(Minecraft mc) {
+        if (!config.dianaWarpAssist()) return null;
+        LocalPlayer player = mc.player;
+        if (player == null) return null;
+
+        Waypoint estimate = currentDianaEstimate();
+        if (estimate == null) return null;
+
+        double estimateX = estimate.x() + 0.5;
+        double estimateY = estimate.y() + 0.5;
+        double estimateZ = estimate.z() + 0.5;
+        double playerDistance = distance(player.getX(), player.getY(), player.getZ(),
+                estimateX, estimateY, estimateZ);
+
+        DianaWarpCandidate best = null;
+        for (DianaWarp warp : DianaWarp.values()) {
+            if (!config.dianaWarpEnabled(warp)) continue;
+
+            double warpDistance = distance(warp.x(), warp.y(), warp.z(), estimateX, estimateY, estimateZ);
+            double savings = playerDistance - warpDistance;
+            if (savings <= config.dianaWarpMinSavings()) continue;
+            if (best == null || warpDistance < best.warpDistance()) {
+                best = new DianaWarpCandidate(warp, warpDistance, savings);
+            }
+        }
+        return best;
+    }
+
+    private Waypoint currentDianaEstimate() {
+        String estimateName = config.dianaEstimateWaypointName();
+        for (WaypointGroup group : manager.activeGroups()) {
+            if (!group.id().startsWith("diana::")) continue;
+            for (Waypoint waypoint : group.waypoints()) {
+                if (estimateName.equals(waypoint.name())
+                        || waypoint.name().startsWith(estimateName + "\n")) {
+                    return waypoint;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static double distance(double ax, double ay, double az, double bx, double by, double bz) {
+        double dx = ax - bx;
+        double dy = ay - by;
+        double dz = az - bz;
+        return Math.sqrt(dx * dx + dy * dy + dz * dz);
+    }
+
     private PlayerWaypointPlacement.BlockPosition playerWaypointPosition(LocalPlayer player) {
         return PlayerWaypointPlacement.fromPlayer(
                 player.getX(), player.getY(), player.getZ(), config);
@@ -271,4 +342,6 @@ public final class WaypointerKeybinds {
         if (mc.gui == null) return;
         mc.gui.setOverlayMessage(msg, false);
     }
+
+    private record DianaWarpCandidate(DianaWarp warp, double warpDistance, double savings) {}
 }

--- a/src/client/java/dev/ethan/waypointer/location/LocationTracker.java
+++ b/src/client/java/dev/ethan/waypointer/location/LocationTracker.java
@@ -4,42 +4,26 @@ import dev.ethan.waypointer.Waypointer;
 import dev.ethan.waypointer.config.WaypointerConfig;
 import dev.ethan.waypointer.core.ActiveGroupManager;
 import dev.ethan.waypointer.core.Zone;
-import net.fabricmc.loader.api.FabricLoader;
 
 /**
  * Picks the best available {@link ZoneSource} at boot and routes its signals into
  * {@link ActiveGroupManager#onZoneChanged(Zone)}.
  *
- * Resolution order:
- *
- *   1. {@code hypixel-mod-api} installed -- use {@link HypixelApiZoneSource}
- *      (authoritative, event-driven).
- *   2. Otherwise -- use {@link ScoreboardZoneResolver} (polls sidebar each tick).
- *
- * This keeps the mod useful standalone but automatically upgrades when the API mod is present.
+ * Zone detection is backed by hypixel-mod-api. The older scoreboard source was
+ * too noisy for reliable route activation, so the API mod is now required.
  */
 public final class LocationTracker {
 
     private final ActiveGroupManager manager;
-    private final WaypointerConfig config;
     private ZoneSource source;
 
     public LocationTracker(ActiveGroupManager manager, WaypointerConfig config) {
         this.manager = manager;
-        this.config = config;
     }
 
     public void install() {
-        boolean hypixelApi = !config.preferScoreboardFallback()
-                && FabricLoader.getInstance().isModLoaded("hypixel-mod-api");
-        if (hypixelApi) {
-            source = new HypixelApiZoneSource();
-            Waypointer.LOGGER.info("Location: using Hypixel Mod API source");
-        } else {
-            source = new ScoreboardZoneResolver();
-            Waypointer.LOGGER.info("Location: using scoreboard fallback"
-                    + (config.preferScoreboardFallback() ? " (forced by config)" : " (install hypixel-mod-api for better accuracy)"));
-        }
+        source = new HypixelApiZoneSource();
+        Waypointer.LOGGER.info("Location: using Hypixel Mod API source");
         source.register(manager::onZoneChanged);
     }
 

--- a/src/client/java/dev/ethan/waypointer/location/LocationTracker.java
+++ b/src/client/java/dev/ethan/waypointer/location/LocationTracker.java
@@ -1,7 +1,6 @@
 package dev.ethan.waypointer.location;
 
 import dev.ethan.waypointer.Waypointer;
-import dev.ethan.waypointer.config.WaypointerConfig;
 import dev.ethan.waypointer.core.ActiveGroupManager;
 import dev.ethan.waypointer.core.Zone;
 
@@ -17,7 +16,7 @@ public final class LocationTracker {
     private final ActiveGroupManager manager;
     private ZoneSource source;
 
-    public LocationTracker(ActiveGroupManager manager, WaypointerConfig config) {
+    public LocationTracker(ActiveGroupManager manager) {
         this.manager = manager;
     }
 

--- a/src/client/java/dev/ethan/waypointer/location/ZoneSource.java
+++ b/src/client/java/dev/ethan/waypointer/location/ZoneSource.java
@@ -5,9 +5,7 @@ import dev.ethan.waypointer.core.Zone;
 import java.util.function.Consumer;
 
 /**
- * A source that can emit Zone change signals. Swappable so we can pick the best
- * available source at runtime -- the Hypixel Mod API when installed, scoreboard
- * scraping otherwise.
+ * A source that can emit Zone change signals.
  */
 public interface ZoneSource {
 

--- a/src/client/java/dev/ethan/waypointer/math/DistanceUtil.java
+++ b/src/client/java/dev/ethan/waypointer/math/DistanceUtil.java
@@ -1,0 +1,17 @@
+package dev.ethan.waypointer.math;
+
+/**
+ * Small geometric helpers shared by client-only features (Diana warp assist, etc.).
+ */
+public final class DistanceUtil {
+
+    private DistanceUtil() {}
+
+    /** Euclidean distance between two points in world space. */
+    public static double euclidean(double ax, double ay, double az, double bx, double by, double bz) {
+        double dx = ax - bx;
+        double dy = ay - by;
+        double dz = az - bz;
+        return Math.sqrt(dx * dx + dy * dy + dz * dz);
+    }
+}

--- a/src/client/java/dev/ethan/waypointer/mixin/client/ClientPacketListenerMixin.java
+++ b/src/client/java/dev/ethan/waypointer/mixin/client/ClientPacketListenerMixin.java
@@ -1,0 +1,18 @@
+package dev.ethan.waypointer.mixin.client;
+
+import dev.ethan.waypointer.diana.WaypointerParticleEvents;
+import net.minecraft.client.multiplayer.ClientPacketListener;
+import net.minecraft.network.protocol.game.ClientboundLevelParticlesPacket;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ClientPacketListener.class)
+public abstract class ClientPacketListenerMixin {
+
+    @Inject(method = "handleParticleEvent", at = @At("HEAD"))
+    private void waypointer$onParticlePacket(ClientboundLevelParticlesPacket packet, CallbackInfo ci) {
+        WaypointerParticleEvents.emit(packet);
+    }
+}

--- a/src/client/java/dev/ethan/waypointer/progression/ProximityTracker.java
+++ b/src/client/java/dev/ethan/waypointer/progression/ProximityTracker.java
@@ -4,6 +4,7 @@ import dev.ethan.waypointer.config.WaypointerConfig;
 import dev.ethan.waypointer.core.ActiveGroupManager;
 import dev.ethan.waypointer.core.Waypoint;
 import dev.ethan.waypointer.core.WaypointGroup;
+import dev.ethan.waypointer.diana.DianaWaypointDetector;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
@@ -51,6 +52,11 @@ public final class ProximityTracker {
         boolean hideReachedStatic = config.hideReachedStaticWaypointsUntilCycleComplete();
         for (WaypointGroup group : manager.activeGroups()) {
             updateGroupProgress(group, px, py, pz, loop, globalSkipAhead, hideReachedStatic);
+        }
+        if (config.deleteTempWaypointsWhenReached()) {
+            manager.removeReachedTempWaypoints(px, py, pz);
+        } else {
+            manager.removeReachedTempWaypoints(px, py, pz, DianaWaypointDetector::isRareMobWaypoint);
         }
     }
 

--- a/src/client/java/dev/ethan/waypointer/progression/TempWaypointCleaner.java
+++ b/src/client/java/dev/ethan/waypointer/progression/TempWaypointCleaner.java
@@ -22,8 +22,10 @@ import net.minecraft.client.Minecraft;
  *       a hard boundary too.</li>
  * </ul>
  *
- * {@code TEMP_UNTIL_REACHED} cleanup is handled inside {@link ProximityTracker}
- * at the moment of advance, where the "reached" signal actually lives.
+ * Reach cleanup is handled inside {@link ProximityTracker} at the moment the
+ * player enters a marker's radius. Route-owned {@code TEMP_UNTIL_REACHED}
+ * waypoints are removed as progression advances; temp bucket markers can also
+ * opt into the same behavior through the user's settings.
  */
 public final class TempWaypointCleaner {
 

--- a/src/client/java/dev/ethan/waypointer/render/TracerRenderer.java
+++ b/src/client/java/dev/ethan/waypointer/render/TracerRenderer.java
@@ -80,7 +80,7 @@ public final class TracerRenderer implements HudElement {
         if (IrisShaderFallback.shouldUse(config)) return;
 
         var groups = manager.activeGroups();
-        if (groups.isEmpty()) return;
+        if (groups == null || groups.isEmpty()) return;
         boolean tempFocus = manager.tempWaypointFocusActive();
         if (!tempFocus && !config.showTracer()) return;
 
@@ -145,7 +145,7 @@ public final class TracerRenderer implements HudElement {
         if (!IrisShaderFallback.shouldUse(config)) return;
 
         var groups = manager.activeGroups();
-        if (groups.isEmpty()) return;
+        if (groups == null || groups.isEmpty()) return;
         boolean tempFocus = manager.tempWaypointFocusActive();
         if (!tempFocus && !config.showTracer()) return;
 

--- a/src/client/java/dev/ethan/waypointer/render/WaypointRenderer.java
+++ b/src/client/java/dev/ethan/waypointer/render/WaypointRenderer.java
@@ -78,7 +78,7 @@ public final class WaypointRenderer implements HudElement {
     private static final int NAME_ARGB = 0xFFAAAAAA;
 
     /** Slightly dimmer than the name so the distance row reads as secondary info. */
-    private static final int DISTANCE_ARGB = 0xFFCCCCCC;
+    private static final int DISTANCE_ARGB = 0xFF888888;
 
     /**
      * ~70% black backdrop drawn behind each label. Vanilla nametags use ~25%

--- a/src/client/java/dev/ethan/waypointer/render/WaypointRenderer.java
+++ b/src/client/java/dev/ethan/waypointer/render/WaypointRenderer.java
@@ -676,7 +676,11 @@ public final class WaypointRenderer implements HudElement {
 
     private static float colorOpacity(int color) {
         int alpha = (color >>> 24) & 0xFF;
-        return alpha == 0 ? 1.0f : alpha / 255.0f;
+        // Alpha 0: legacy 24-bit RGB (no high byte) — treat as fully opaque.
+        if (alpha == 0) return 1.0f;
+        // Alpha 1: ConfigScreen encodes "opacity 0" this way to avoid colliding with legacy A=0.
+        if (alpha == 1) return 1.0f / 255.0f;
+        return alpha / 255.0f;
     }
 
     private static double labelRowAdvance(Font font, float scale) {

--- a/src/client/java/dev/ethan/waypointer/render/WaypointRenderer.java
+++ b/src/client/java/dev/ethan/waypointer/render/WaypointRenderer.java
@@ -74,8 +74,8 @@ public final class WaypointRenderer implements HudElement {
      */
     private static final double LABEL_ANCHOR_LIFT = 1.6;
 
-    /** Opaque ARGB for the waypoint name -- readable against every biome. */
-    private static final int NAME_ARGB = 0xFFFFFFFF;
+    /** Default label colour, matching Minecraft's &7 gray. */
+    private static final int NAME_ARGB = 0xFFAAAAAA;
 
     /** Slightly dimmer than the name so the distance row reads as secondary info. */
     private static final int DISTANCE_ARGB = 0xFFCCCCCC;
@@ -187,7 +187,7 @@ public final class WaypointRenderer implements HudElement {
         if (IrisShaderFallback.shouldUse(config)) return;
 
         var groups = manager.activeGroups();
-        if (groups.isEmpty()) return;
+        if (groups == null || groups.isEmpty()) return;
 
         WaypointerConfig.BoxStyle style = config.boxStyle();
         boolean drawLines = style != WaypointerConfig.BoxStyle.FILLED;
@@ -269,7 +269,7 @@ public final class WaypointRenderer implements HudElement {
             State state = stateFor(g, i, currentIdx);
             if (shouldHideCompletedSequenceWaypoint(g, i, currentIdx, state, showCompleted, w)) return;
 
-            float alpha = alphaFor(g, state) * beaconOpacity;
+            float alpha = alphaFor(g, state) * beaconOpacity * colorOpacity(w.color());
             float x = w.x(), y = w.y(), z = w.z();
             RenderHelpers.emitLineBox(lines, ps, x, y, z, x + 1f, y + 1f, z + 1f,
                     w.color(), alpha, outlineThickness);
@@ -293,7 +293,7 @@ public final class WaypointRenderer implements HudElement {
             State state = stateFor(g, i, currentIdx);
             if (shouldHideCompletedSequenceWaypoint(g, i, currentIdx, state, showCompleted, w)) return;
 
-            float alpha = alphaFor(g, state) * beaconOpacity;
+            float alpha = alphaFor(g, state) * beaconOpacity * colorOpacity(w.color());
             float x = w.x(), y = w.y(), z = w.z();
             RenderHelpers.emitFilledBox(quads, ps, x, y, z, x + 1f, y + 1f, z + 1f,
                     w.color(), alpha * FILLED_ALPHA_SCALE);
@@ -338,7 +338,8 @@ public final class WaypointRenderer implements HudElement {
         State state = stateFor(g, i, currentIdx);
         if (shouldHideCompletedSequenceWaypoint(g, i, currentIdx, state, showCompleted, w)) return;
 
-        float alpha = alphaFor(g, state) * (float) config.beaconOpacity() * BEAM_ALPHA_SCALE;
+        float alpha = alphaFor(g, state) * (float) config.beaconOpacity()
+                * colorOpacity(w.color()) * BEAM_ALPHA_SCALE;
         if (alpha <= 0.0f) return;
 
         float y1 = config.beaconBeamExtendsBelowWaypoint() ? minY : w.y();
@@ -372,7 +373,7 @@ public final class WaypointRenderer implements HudElement {
         if (!showNames && !showDistances && !drawHudFallback) return;
 
         var groups = manager.activeGroups();
-        if (groups.isEmpty()) return;
+        if (groups == null || groups.isEmpty()) return;
 
         Minecraft mc = Minecraft.getInstance();
         GameRenderer renderer = mc.gameRenderer;
@@ -446,7 +447,7 @@ public final class WaypointRenderer implements HudElement {
                 return;
             }
 
-            float alpha = alphaFor(group, state) * beaconOpacity;
+            float alpha = alphaFor(group, state) * beaconOpacity * colorOpacity(waypoint.color());
             int argb = RenderHelpers.withAlpha(0xFF000000 | (waypoint.color() & 0xFFFFFF), alpha);
             if (!projectBoxCorners(waypoint, screenW, screenH)) return;
 
@@ -556,7 +557,7 @@ public final class WaypointRenderer implements HudElement {
             String distanceText = showDistances
                     ? distanceString((int) distance)
                     : null;
-            float alpha = alphaFor(group, state);
+            float alpha = alphaFor(group, state) * colorOpacity(w.color());
             int nameColor = colorizeNames && showNames
                     ? 0xFF000000 | (w.color() & 0xFFFFFF)
                     : NAME_ARGB;
@@ -569,9 +570,8 @@ public final class WaypointRenderer implements HudElement {
 
             double rowY = sy;
             if (showNames) {
-                drawCenteredLabel(g, font, name, sx, rowY,
+                rowY = drawCenteredLabelRows(g, font, name, sx, rowY,
                         RenderHelpers.withAlpha(nameColor, alpha), alpha, labelScale);
-                rowY += labelRowAdvance(font, labelScale);
             }
             if (showDistances) {
                 drawCenteredLabel(g, font, distanceText, sx, rowY,
@@ -592,10 +592,9 @@ public final class WaypointRenderer implements HudElement {
             LabelCandidate candidate = labelCandidates.get(i);
             double rowY = candidate.screenY;
             if (candidate.name != null) {
-                drawCenteredLabel(g, font, candidate.name, candidate.screenX, rowY,
+                rowY = drawCenteredLabelRows(g, font, candidate.name, candidate.screenX, rowY,
                         RenderHelpers.withAlpha(candidate.nameColor, candidate.alpha),
                         candidate.alpha, candidate.scale);
-                rowY += labelRowAdvance(font, candidate.scale);
             }
             if (candidate.distance != null) {
                 drawCenteredLabel(g, font, candidate.distance, candidate.screenX, rowY,
@@ -675,6 +674,11 @@ public final class WaypointRenderer implements HudElement {
         return (float) Math.max(LABEL_SCALE_MIN, Math.min(LABEL_SCALE_MAX, scale));
     }
 
+    private static float colorOpacity(int color) {
+        int alpha = (color >>> 24) & 0xFF;
+        return alpha == 0 ? 1.0f : alpha / 255.0f;
+    }
+
     private static double labelRowAdvance(Font font, float scale) {
         return (font.lineHeight + DISTANCE_ROW_GAP) * scale;
     }
@@ -716,6 +720,26 @@ public final class WaypointRenderer implements HudElement {
         // drop shadow is doing all the work keeping text readable against bright biomes.
         g.drawString(font, text, 0, 0, argb, true);
         g.pose().popMatrix();
+    }
+
+    private double drawCenteredLabelRows(GuiGraphics g, Font font, String text,
+                                         double cx, double top, int argb,
+                                         float alpha, float scale) {
+        if (text == null || text.isEmpty()) return top;
+
+        double rowY = top;
+        int start = 0;
+        while (start <= text.length()) {
+            int next = text.indexOf('\n', start);
+            String row = next < 0 ? text.substring(start) : text.substring(start, next);
+            if (!row.isEmpty()) {
+                drawCenteredLabel(g, font, row, cx, rowY, argb, alpha, scale);
+                rowY += labelRowAdvance(font, scale);
+            }
+            if (next < 0) break;
+            start = next + 1;
+        }
+        return rowY;
     }
 
     private String labelFor(WaypointGroup g, int i, Waypoint w, State state,

--- a/src/client/java/dev/ethan/waypointer/screen/ColorPickerScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/ColorPickerScreen.java
@@ -14,6 +14,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.DoubleConsumer;
 import java.util.function.IntConsumer;
 
 import static dev.ethan.waypointer.screen.GuiTokens.*;
@@ -46,9 +47,10 @@ public final class ColorPickerScreen extends Screen {
     // footer buttons (top=192 rel) to overlap by ~8px. Bumped so there is a clean
     // gap between the hex row and the footer.
     private static final int PANEL_W = 280;
-    private static final int PANEL_H = 252;
+    private static final int PANEL_H = 276;
     private static final int SV_SIZE = 140;
     private static final int HUE_W   = 18;
+    private static final int OPACITY_W = 18;
 
     // ResourceLocations for the picker's two dynamic textures. A per-instance
     // suffix keeps two simultaneous pickers (e.g. a quickly swapped-open one)
@@ -59,15 +61,17 @@ public final class ColorPickerScreen extends Screen {
     private final Screen parent;
     private final String title;
     private final IntConsumer onPicked;
+    private final DoubleConsumer onOpacityPicked;
 
     // Working HSV state. Kept in floats so mid-drag updates are smooth even when
     // the resulting RGB would snap the SV position back into the visible box.
     private float hue;       // [0, 360)
     private float sat;       // [0, 1]
     private float value;     // [0, 1]
+    private float opacity;   // [0, 1]
 
     private EditBox hexBox;
-    private int svX, svY, hueX, hueY, swatchX, swatchY;
+    private int svX, svY, hueX, hueY, opacityX, opacityY, swatchX, swatchY;
 
     private DynamicTexture svTex;
     private DynamicTexture hueTex;
@@ -78,23 +82,36 @@ public final class ColorPickerScreen extends Screen {
     // Whether a drag started on the SV square vs the hue slider. Without this, a
     // drag that starts on the SV box and wanders out would silently switch to
     // editing the hue, which feels broken.
-    private enum Drag { NONE, SV, HUE }
+    private enum Drag { NONE, SV, HUE, OPACITY }
     private Drag drag = Drag.NONE;
 
     public ColorPickerScreen(Screen parent, String title, int initialRgb, IntConsumer onPicked) {
+        this(parent, title, initialRgb, 1.0, onPicked, null);
+    }
+
+    public ColorPickerScreen(Screen parent, String title, int initialRgb, double initialOpacity,
+                             IntConsumer onPicked, DoubleConsumer onOpacityPicked) {
         super(Component.literal(title));
         this.parent = parent;
         this.title = title;
         this.onPicked = onPicked;
+        this.onOpacityPicked = onOpacityPicked;
         float[] hsv = rgbToHsv(initialRgb & 0xFFFFFF);
         this.hue = hsv[0];
         this.sat = hsv[1];
         this.value = hsv[2];
+        this.opacity = (float) clamp01(initialOpacity);
     }
 
     /** Convenience opener so call sites read like "pick a colour → here's what to do". */
     public static void open(Screen parent, String title, int initialRgb, IntConsumer onPicked) {
         Minecraft.getInstance().setScreen(new ColorPickerScreen(parent, title, initialRgb, onPicked));
+    }
+
+    public static void open(Screen parent, String title, int initialRgb, double initialOpacity,
+                            IntConsumer onPicked, DoubleConsumer onOpacityPicked) {
+        Minecraft.getInstance().setScreen(new ColorPickerScreen(parent, title, initialRgb,
+                initialOpacity, onPicked, onOpacityPicked));
     }
 
     @Override
@@ -106,7 +123,9 @@ public final class ColorPickerScreen extends Screen {
         svY = panelY + 32;
         hueX = svX + SV_SIZE + GAP;
         hueY = svY;
-        swatchX = hueX + HUE_W + GAP;
+        opacityX = hueX + HUE_W + GAP;
+        opacityY = svY;
+        swatchX = (onOpacityPicked != null ? opacityX + OPACITY_W + GAP : opacityX);
         swatchY = svY;
 
         int hexY = svY + SV_SIZE + GAP;
@@ -137,6 +156,7 @@ public final class ColorPickerScreen extends Screen {
                 .bounds(panelX + PANEL_W - PAD_OUTER - btnW * 2 - GAP, footerY, btnW, BTN_H).build());
         addRenderableWidget(Button.builder(Component.literal("Save"), b -> {
             onPicked.accept(currentRgb());
+            if (onOpacityPicked != null) onOpacityPicked.accept(opacity);
             onClose();
         }).bounds(panelX + PANEL_W - PAD_OUTER - btnW, footerY, btnW, BTN_H).build());
 
@@ -157,6 +177,7 @@ public final class ColorPickerScreen extends Screen {
 
         drawSvSquare(g);
         drawHueSlider(g);
+        if (onOpacityPicked != null) drawOpacitySlider(g);
         drawSwatch(g);
 
         super.render(g, mouseX, mouseY, partial);
@@ -192,6 +213,25 @@ public final class ColorPickerScreen extends Screen {
         int hy = hueY + Math.round(hue / 360f * (SV_SIZE - 1));
         g.fill(hueX - 2, hy,     hueX + HUE_W + 2, hy + 1, 0xFF000000);
         g.fill(hueX - 2, hy + 1, hueX + HUE_W + 2, hy + 2, 0xFFFFFFFF);
+    }
+
+    private void drawOpacitySlider(GuiGraphics g) {
+        int rgb = currentRgb();
+        g.fill(opacityX - 1, opacityY - 1, opacityX + OPACITY_W + 1, opacityY + SV_SIZE + 1, 0xFF000000);
+        for (int py = 0; py < SV_SIZE; py++) {
+            int baseY = opacityY + py;
+            int alpha = Math.round((1f - (float) py / (SV_SIZE - 1)) * 255f);
+            for (int px = 0; px < OPACITY_W; px++) {
+                boolean light = (((px / 4) + (py / 4)) & 1) == 0;
+                int checker = light ? 0xFF5A5A5A : 0xFF242424;
+                g.fill(opacityX + px, baseY, opacityX + px + 1, baseY + 1, checker);
+            }
+            g.fill(opacityX, baseY, opacityX + OPACITY_W, baseY + 1, (alpha << 24) | rgb);
+        }
+
+        int oy = opacityY + Math.round((1f - opacity) * (SV_SIZE - 1));
+        g.fill(opacityX - 2, oy,     opacityX + OPACITY_W + 2, oy + 1, 0xFF000000);
+        g.fill(opacityX - 2, oy + 1, opacityX + OPACITY_W + 2, oy + 2, 0xFFFFFFFF);
     }
 
     private void drawSwatch(GuiGraphics g) {
@@ -293,6 +333,11 @@ public final class ColorPickerScreen extends Screen {
                 updateHue(my);
                 return true;
             }
+            if (onOpacityPicked != null && inside(mx, my, opacityX, opacityY, OPACITY_W, SV_SIZE)) {
+                drag = Drag.OPACITY;
+                updateOpacity(my);
+                return true;
+            }
         }
         return super.mouseClicked(event, doubleClick);
     }
@@ -300,8 +345,9 @@ public final class ColorPickerScreen extends Screen {
     @Override
     public boolean mouseDragged(MouseButtonEvent event, double dx, double dy) {
         double mx = event.x(), my = event.y();
-        if (drag == Drag.SV)  { updateSv(mx, my); return true; }
-        if (drag == Drag.HUE) { updateHue(my);    return true; }
+        if (drag == Drag.SV)      { updateSv(mx, my);  return true; }
+        if (drag == Drag.HUE)     { updateHue(my);     return true; }
+        if (drag == Drag.OPACITY) { updateOpacity(my); return true; }
         return super.mouseDragged(event, dx, dy);
     }
 
@@ -323,6 +369,10 @@ public final class ColorPickerScreen extends Screen {
         hue = 360f * (float) clamp01((my - hueY) / (double) (SV_SIZE - 1));
         if (hue >= 360f) hue = 359.9999f;
         syncHex();
+    }
+
+    private void updateOpacity(double my) {
+        opacity = 1f - (float) clamp01((my - opacityY) / (double) (SV_SIZE - 1));
     }
 
     private void syncHex() {

--- a/src/client/java/dev/ethan/waypointer/screen/ConfigScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/ConfigScreen.java
@@ -1,12 +1,15 @@
 package dev.ethan.waypointer.screen;
 
 import dev.ethan.waypointer.config.WaypointerConfig;
+import dev.ethan.waypointer.diana.DianaRareMob;
+import dev.ethan.waypointer.diana.DianaWarp;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.Checkbox;
 import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.gui.components.Tooltip;
+import net.minecraft.client.gui.screens.ConfirmScreen;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
@@ -15,6 +18,7 @@ import net.minecraft.network.chat.MutableComponent;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.function.BooleanSupplier;
 
 import static dev.ethan.waypointer.screen.GuiTokens.*;
@@ -38,7 +42,9 @@ public final class ConfigScreen extends Screen {
         PERFORMANCE("Performance"),
         ROUTES("Routes"),
         CHAT("Chat"),
-        SYSTEM("System");
+        DIANA("Diana"),
+        SYSTEM("System"),
+        TEMP_WPS("Temp WPs");
 
         final String label;
 
@@ -51,16 +57,142 @@ public final class ConfigScreen extends Screen {
     private final WaypointerConfig config;
     private final Page page;
     private final List<DependentControl> dependentControls = new ArrayList<>();
+    private String searchQuery;
+    private boolean rebuildRequested;
+    private boolean restoreSearchFocus;
+    private EditBox searchBox;
+    private static final List<SearchEntry> SEARCH_INDEX = List.of(
+            entry(Page.VISUALS, "Markers", "Waypoint box opacity (0-1)",
+                    "Opacity of each waypoint's world-space box."),
+            entry(Page.VISUALS, "Markers", "Box style",
+                    "Outlined, filled, or filled plus outline waypoint boxes."),
+            entry(Page.VISUALS, "Markers", "Outline thickness (px)",
+                    "Width of waypoint outlines."),
+            entry(Page.VISUALS, "Markers", "Beacon beams",
+                    "Optional vertical guide beams for current or all visible waypoints."),
+            entry(Page.VISUALS, "Markers", "Beam extends below waypoint",
+                    "Start beacon beams at the world's bottom instead of the waypoint Y level."),
+            entry(Page.VISUALS, "Markers", "Show completed waypoints",
+                    "Keep waypoints visible after they have been reached."),
+            entry(Page.VISUALS, "Maintenance", "Disable all features",
+                    "Turn off every Waypointer feature toggle after confirmation."),
+            entry(Page.VISUALS, "Labels & Tracers", "Show waypoint names",
+                    "Floating name labels at each rendered waypoint."),
+            entry(Page.VISUALS, "Labels & Tracers", "Show waypoint distances",
+                    "Distance text below each waypoint label."),
+            entry(Page.VISUALS, "Labels & Tracers", "Waypoint text inherits color",
+                    "Waypoint labels use each waypoint's color."),
+            entry(Page.VISUALS, "Labels & Tracers", "Show label backdrop",
+                    "Dark rectangle behind floating waypoint names."),
+            entry(Page.VISUALS, "Labels & Tracers", "Scale text with distance",
+                    "Waypoint labels shrink as their anchor gets farther from the camera."),
+            entry(Page.VISUALS, "Labels & Tracers", "Label height offset (blocks)",
+                    "Extra blocks to push each waypoint label above its marker."),
+            entry(Page.VISUALS, "Labels & Tracers", "Show tracers",
+                    "Master switch for crosshair tracer lines."),
+            entry(Page.VISUALS, "Labels & Tracers", "Tracer opacity (0-1)",
+                    "Opacity of the line drawn from the crosshair to the active waypoint."),
+            entry(Page.VISUALS, "Labels & Tracers", "Tracer thickness (px)",
+                    "Pixel width of the crosshair tracer line."),
+            entry(Page.VISUALS, "Labels & Tracers", "Tracer color (hex RRGGBB)",
+                    "Fixed tracer color used when tracer color inheritance is off."),
+            entry(Page.VISUALS, "Labels & Tracers", "Tracer inherits waypoint color",
+                    "Tracer uses each waypoint's rendered color."),
+
+            entry(Page.PERFORMANCE, "Budgets", "Max waypoint labels (0 = unlimited)",
+                    "Keep only the nearest N floating labels on screen."),
+            entry(Page.PERFORMANCE, "Budgets", "Static marker distance (0 = unlimited)",
+                    "Skip static waypoint rendering beyond this many blocks."),
+            entry(Page.PERFORMANCE, "Label Performance", "Show waypoint names",
+                    "Every visible name submits text to the HUD."),
+            entry(Page.PERFORMANCE, "Label Performance", "Show waypoint distances",
+                    "Each visible distance is another text draw."),
+            entry(Page.PERFORMANCE, "Label Performance", "Show label backdrop",
+                    "Remove dark rectangles behind label rows."),
+
+            entry(Page.ROUTES, "Progression", "Default reach radius (blocks)",
+                    "How close you must stand to mark a waypoint reached."),
+            entry(Page.ROUTES, "Progression", "Enable waypoint skip-ahead mechanic",
+                    "Skip waypoints by walking to a later waypoint in a sequenced route."),
+            entry(Page.ROUTES, "Progression", "Reset progress when joining a world",
+                    "Reset every group's current waypoint on world load or multiplayer join."),
+            entry(Page.ROUTES, "Progression", "Restart route after last waypoint",
+                    "Wrap progress to the first point after completing the final waypoint."),
+            entry(Page.ROUTES, "Progression", "Add new waypoints below player",
+                    "Place new player-position waypoints one block below your feet."),
+            entry(Page.ROUTES, "Route Display", "Dim sequence context waypoints",
+                    "Dim waypoints around the current point in a sequenced route."),
+            entry(Page.ROUTES, "Route Display", "Hide tracer on static routes",
+                    "Disable waypoint tracer lines on static routes."),
+            entry(Page.ROUTES, "Route Display", "Hide waypoints when near",
+                    "Hide waypoint boxes, labels, beams, and tracers while near them."),
+            entry(Page.ROUTES, "Route Display", "Near hide radius (blocks)",
+                    "Distance from the waypoint where near-hide starts."),
+            entry(Page.ROUTES, "Route Display", "Hide reached static waypoints",
+                    "For static groups, hide each waypoint after it is reached until the cycle resets."),
+
+            entry(Page.CHAT, "Chat Detection", "Chat coord detection",
+                    "Scan incoming chat for coordinates and offer waypoint quick-add flows."),
+            entry(Page.CHAT, "Chat Detection", "Chat codec detection (imports)",
+                    "Detect Waypointer share codes pasted in chat."),
+            entry(Page.DIANA, "Burrows", "Diana burrow waypoints",
+                    "Detect Diana burrow particles in the Hub and create temporary waypoints."),
+        entry(Page.DIANA, "Burrows", "Hide start burrows during active chain",
+                "Do not target fresh start burrows while chat says the current Griffin chain is still active."),
+        entry(Page.DIANA, "Burrows", "Diana spade debug logging",
+                "Writes Ancestral Spade solver milestones and rejection reasons to latest.log."),
+        entry(Page.DIANA, "Warp Assist", "Diana warp assist",
+                "Suggest and execute enabled Hub warps that save travel distance to the estimate."),
+            entry(Page.DIANA, "Warp Assist", "Diana warp savings threshold",
+                    "Minimum distance saved before a warp is suggested."),
+            entry(Page.DIANA, "Warp Assist", "Enabled Diana warps",
+                    "Choose which Hub warp commands the assist may use."),
+            entry(Page.DIANA, "Appearance", "Diana estimate color",
+                    "Color used for the spade estimate waypoint."),
+            entry(Page.DIANA, "Appearance", "Diana start color",
+                    "Color used for start burrow waypoints."),
+            entry(Page.DIANA, "Appearance", "Diana mob color",
+                    "Color used for mob burrow waypoints."),
+            entry(Page.DIANA, "Appearance", "Diana treasure color",
+                    "Color used for treasure burrow waypoints."),
+            entry(Page.DIANA, "Chat Shares", "Diana rare mob waypoints",
+                    "Detect Diana rare mob coordinate shares in Hub chat."),
+            entry(Page.DIANA, "Chat Shares", "Diana rare mob party sharing",
+                    "Share selected Diana mob coordinates in party chat when you dig them up."),
+            entry(Page.DIANA, "Chat Shares", "Shared Diana rare mobs",
+                    "Choose which Diana mobs Waypointer shares to party chat."),
+
+            entry(Page.SYSTEM, "Maintenance", "Check for updates on startup",
+                    "Check GitHub once at startup for a newer Waypointer release."),
+            entry(Page.SYSTEM, "Maintenance", "Experimental Iris HUD fallback",
+                    "Render waypoints through a HUD fallback when Iris shaders interfere."),
+
+            entry(Page.TEMP_WPS, "Creation", "Auto-add chat temp waypoints",
+                    "Immediately create temporary waypoints from detected chat coordinates."),
+            entry(Page.TEMP_WPS, "Creation", "Focus mode for temp waypoints",
+                    "Hide other active-zone waypoints and trace to the newest temp marker."),
+            entry(Page.TEMP_WPS, "Cleanup", "Delete temp waypoints when reached",
+                    "Remove temporary waypoints when you enter their reach radius."),
+            entry(Page.TEMP_WPS, "Cleanup", "Temp waypoints expire",
+                    "Use time-based expiry for newly-created temporary waypoints."),
+            entry(Page.TEMP_WPS, "Cleanup", "Temp duration (mins)",
+                    "Default lifetime for time-based temporary waypoints.")
+    );
 
     public ConfigScreen(Screen parent, WaypointerConfig config) {
-        this(parent, config, Page.VISUALS);
+        this(parent, config, Page.VISUALS, "");
     }
 
     private ConfigScreen(Screen parent, WaypointerConfig config, Page page) {
+        this(parent, config, page, "");
+    }
+
+    private ConfigScreen(Screen parent, WaypointerConfig config, Page page, String searchQuery) {
         super(Component.literal("Waypointer Settings"));
         this.parent = parent;
         this.config = config;
         this.page = page == null ? Page.VISUALS : page;
+        this.searchQuery = searchQuery == null ? "" : searchQuery;
     }
 
     @Override
@@ -78,47 +210,124 @@ public final class ConfigScreen extends Screen {
         int headerY = top;
         int rowsY = top + 16;
 
-        addPageTabs(navY);
+        int searchX = addPageTabs(navY);
+        addSearchBox(searchX, navY);
 
-        switch (page) {
+        if (searchActive()) {
+            addSearchResultsPage(col1, col2, colW, rowsY, rowH);
+        } else switch (page) {
             case VISUALS -> addVisualsPage(col1, col2, colW, rowsY, rowH);
             case PERFORMANCE -> addPerformancePage(col1, col2, colW, rowsY, rowH);
             case ROUTES -> addRoutesPage(col1, col2, colW, rowsY, rowH);
             case CHAT -> addChatPage(col1, col2, colW, rowsY, rowH);
+            case DIANA -> addDianaPage(col1, col2, colW, rowsY, rowH);
             case SYSTEM -> addSystemPage(col1, col2, colW, rowsY, rowH);
+            case TEMP_WPS -> addTempWaypointsPage(col1, col2, colW, rowsY, rowH);
         }
 
         int footerY = height - FOOTER_H;
         List<GuiTokens.ButtonSpec> empty = new ArrayList<>();
         GuiTokens.ButtonSpec done = new GuiTokens.ButtonSpec("Done", -1, this::onClose,
-                Tooltip.create(Component.literal(
-                        "Return to the previous screen.\n"
-                      + "Every change on this page is saved as you type or click.")));
+                tip("Return to the previous screen.\nChanges save automatically."));
         GuiTokens.layoutFooter(width, footerY, empty, done, this::addRenderableWidget, font);
+        if (!searchActive() && page == Page.VISUALS) {
+            addVisualsMaintenanceControls(colW);
+        }
 
         this.leftHeaderX = col1;
         this.rightHeaderX = col2;
         this.sectionHeaderY = headerY;
     }
 
-    private void addPageTabs(int y) {
+    @Override
+    public void tick() {
+        super.tick();
+        if (!rebuildRequested) return;
+
+        rebuildRequested = false;
+        clearWidgets();
+        init();
+    }
+
+    private boolean searchActive() {
+        return !searchQuery.trim().isEmpty();
+    }
+
+    private static SearchEntry entry(Page page, String section, String label, String description) {
+        return new SearchEntry(page, section, label, description);
+    }
+
+    private static List<SearchEntry> searchEntries(String query) {
+        String[] terms = normalizeSearch(query).split("\\s+");
+        List<SearchEntry> matches = new ArrayList<>();
+        for (SearchEntry entry : SEARCH_INDEX) {
+            String haystack = normalizeSearch(entry.page().label + " "
+                    + entry.section() + " "
+                    + entry.label() + " "
+                    + entry.description());
+            boolean matched = true;
+            for (String term : terms) {
+                if (term.isEmpty()) continue;
+                if (!haystack.contains(term)) {
+                    matched = false;
+                    break;
+                }
+            }
+            if (matched) matches.add(entry);
+        }
+        return matches;
+    }
+
+    private static String normalizeSearch(String text) {
+        return (text == null ? "" : text)
+                .toLowerCase(Locale.ROOT)
+                .replace("wps", "waypoints")
+                .replace("wp", "waypoint");
+    }
+
+    private int addPageTabs(int y) {
         int x = PAD_OUTER;
         for (Page target : Page.values()) {
             int tabW = Math.max(64, font.width(target.label) + 18);
             Button btn = Button.builder(Component.literal(target.label), b -> {
-                if (target != page) {
-                    minecraft.setScreen(new ConfigScreen(parent, config, target));
+                if (searchActive() || target != page) {
+                    minecraft.setScreen(new ConfigScreen(parent, config, target, ""));
                 }
             }).bounds(x, y, tabW, BTN_H).build();
-            btn.active = target != page;
+            btn.active = searchActive() || target != page;
             addRenderableWidget(btn);
             x += tabW + GAP;
+        }
+        return x;
+    }
+
+    private void addSearchBox(int x, int y) {
+        int available = width - PAD_OUTER - x;
+        if (available < 86) return;
+
+        int searchW = Math.min(180, available);
+        searchBox = new EditBox(font, x, y, searchW, BTN_H, Component.literal("Search settings"));
+        searchBox.setMaxLength(64);
+        searchBox.setValue(searchQuery);
+        searchBox.setHint(Component.literal("Search settings"));
+        searchBox.setResponder(v -> {
+            String next = v == null ? "" : v;
+            if (Objects.equals(next, searchQuery)) return;
+            searchQuery = next;
+            rebuildRequested = true;
+            restoreSearchFocus = true;
+        });
+        addRenderableWidget(searchBox);
+        if (restoreSearchFocus) {
+            setFocused(searchBox);
+            searchBox.setFocused(true);
+            restoreSearchFocus = false;
         }
     }
 
     private void addVisualsPage(int col1, int col2, int colW, int rowsY, int rowH) {
         leftHeader = "Markers";
-        rightHeader = "Labels & Tracers";
+        rightHeader = "Labels";
 
         int y = rowsY;
         addNumberRow(col1, y, colW, "Waypoint box opacity (0-1)",
@@ -131,7 +340,9 @@ public final class ConfigScreen extends Screen {
         addNumberRow(col1, y, colW, "Outline thickness (px)",
                 config.waypointOutlineThickness(), config::setWaypointOutlineThickness,
                 "Width of waypoint outlines.");
-        y += rowH;
+        y += rowH + GAP;
+        addSectionHeader(col1, y, "Beacon Beams", colW);
+        y += font.lineHeight + GAP;
         addBeamModeRow(col1, y, colW);
         y += rowH;
         addBoolRow(col1, y, "Beam extends below waypoint",
@@ -178,7 +389,9 @@ public final class ConfigScreen extends Screen {
                 "Extra blocks to push each waypoint label above its marker. 0 keeps the\n"
               + "default placement. Use large values if distant labels still cover the\n"
               + "box; finite numbers only, no arbitrary clamp.");
-        y2 += rowH;
+        y2 += rowH + GAP;
+        addSectionHeader(col2, y2, "Tracers", colW);
+        y2 += font.lineHeight + GAP;
         addBoolRow(col2, y2, "Show tracers", config.showTracer(), config::setShowTracer,
                 "Master switch for crosshair tracers. When off, no tracer lines are drawn\n"
               + "for any group (other waypoint rendering is unchanged).");
@@ -307,59 +520,100 @@ public final class ConfigScreen extends Screen {
                 config::setHideReachedStaticWaypointsUntilCycleComplete,
                 "For STATIC groups, hide each waypoint when you enter its reach radius.\n"
               + "After every waypoint in the group has been reached, all of them show again.");
-        y2 += rowH;
-        addBoolRow(col2, y2, "Focus mode for temp waypoints",
-                config.focusTempWaypoints(), config::setFocusTempWaypoints,
-                "When on, adding a temporary waypoint hides other waypoints in the\n"
-              + "active zone and forces a tracer to the temp until you leave the server.");
-        y2 += rowH;
-        addBoolRow(col2, y2, "Temp waypoints expire",
-                config.tempWaypointsExpireByDefault(), config::setTempWaypointsExpireByDefault,
-                "When on, newly-created temp waypoints use TIME mode by default.\n"
-              + "When off, they last until you leave the server unless changed in\n"
-              + "the Add Temp dialog.");
-        y2 += rowH;
-        addNumberRow(col2, y2, colW, "Temp duration (min)",
-                config.tempDefaultDurationMin(), this::setTempDefaultDuration,
-                config::tempWaypointsExpireByDefault,
-                "Default lifetime for TIME-mode temporary waypoints.");
     }
 
     private void addChatPage(int col1, int col2, int colW, int rowsY, int rowH) {
         leftHeader = "Chat Detection";
-        rightHeader = "Export Defaults";
+        rightHeader = "";
 
         int y = rowsY;
         addBoolRow(col1, y, "Chat coord detection", config.chatCoordDetection(), config::setChatCoordDetection,
                 "Scans incoming chat for coordinates and can offer quick-add flows for\n"
               + "temporary or permanent waypoints (no effect when chat has no coords).");
         y += rowH;
-        addBoolRow(col1, y, "Auto-add chat temp waypoints",
-                config.autoAddChatTempWaypoints(), config::setAutoAddChatTempWaypoints,
-                config::chatCoordDetection,
-                "When chat coord detection finds a coordinate, immediately creates a\n"
-              + "temporary waypoint using your default expiry. Off keeps click-to-add only.");
-        y += rowH;
         addBoolRow(col1, y, "Chat codec detection (imports)",
                 config.chatCodecDetection(), config::setChatCodecDetection,
                 "Detects Waypointer share codes pasted in chat so you can import routes\n"
               + "without opening the main menu.");
 
+    }
+
+    private void addDianaPage(int col1, int col2, int colW, int rowsY, int rowH) {
+        leftHeader = "Burrows & Travel";
+        rightHeader = "Colors & Shares";
+
+        int y = rowsY;
+        addBoolRow(col1, y, "Diana burrow waypoints",
+                config.dianaBurrowWaypoints(), config::setDianaBurrowWaypoints,
+                "Detects real Diana burrow particles in the Hub and creates temporary\n"
+                + "waypoints for confirmed burrows plus conservative Ancestral Spade\n"
+                + "spade-curve estimates.");
+        y += rowH;
+        addBoolRow(col1, y, "Hide start burrows during active chain",
+                config.dianaHideStartBurrowsUntilChainComplete(),
+                config::setDianaHideStartBurrowsUntilChainComplete,
+                config::dianaBurrowWaypoints,
+                "When on, start burrow waypoints are withheld while chat progress says\n"
+              + "your current Griffin chain is incomplete, so the tracer cannot pick\n"
+              + "a fresh start before the chain is done.");
+        y += rowH;
+        addBoolRow(col1, y, "Diana spade debug logging",
+                config.dianaSpadeDebugLogging(), config::setDianaSpadeDebugLogging,
+                config::dianaBurrowWaypoints,
+                "Writes focused Ancestral Spade solver milestones to latest.log.\n"
+              + "Use when estimates stop appearing or seem inconsistent.");
+        y += rowH;
+        addBoolRow(col1, y, "Diana warp assist",
+                config.dianaWarpAssist(), config::setDianaWarpAssist,
+                config::dianaBurrowWaypoints,
+                "Suggests and executes enabled Hub warps when they save travel\n"
+                + "distance to the current Diana estimate waypoint.");
+        y += rowH;
+        addNumberRow(col1, y, colW, "Diana warp savings threshold",
+                config.dianaWarpMinSavings(), config::setDianaWarpMinSavings,
+                () -> config.dianaBurrowWaypoints() && config.dianaWarpAssist(),
+                "Minimum distance a warp must save before it is suggested.\n"
+                + "Default is 45 blocks.");
+        y += rowH;
+        addDianaWarpsRow(col1, y, colW);
+
         int y2 = rowsY;
-        addBoolRow(col2, y2, "Include names in default export",
-                config.exportIncludeNames(), config::setExportIncludeNames,
-                "When exporting, include waypoint names in the payload. Makes shared codes\n"
-              + "longer but preserves labels for the recipient.");
+        addColorRow(col2, y2, colW, "Diana estimate color",
+                config.dianaEstimateWaypointColor(), config::setDianaEstimateWaypointColor,
+                config::dianaBurrowWaypoints,
+                "Color used for the spade estimate waypoint.");
+        y2 += rowH;
+        addColorRow(col2, y2, colW, "Diana start color",
+                config.dianaStartBurrowColor(), config::setDianaStartBurrowColor,
+                config::dianaBurrowWaypoints,
+                "Color used for start burrow waypoints.");
+        y2 += rowH;
+        addColorRow(col2, y2, colW, "Diana mob color",
+                config.dianaMobBurrowColor(), config::setDianaMobBurrowColor,
+                config::dianaBurrowWaypoints,
+                "Color used for mob burrow waypoints.");
+        y2 += rowH;
+        addColorRow(col2, y2, colW, "Diana treasure color",
+                config.dianaTreasureBurrowColor(), config::setDianaTreasureBurrowColor,
+                config::dianaBurrowWaypoints,
+                "Color used for treasure burrow waypoints.");
+        y2 += rowH;
+        addBoolRow(col2, y2, "Diana rare mob waypoints",
+                config.dianaRareMobWaypoints(), config::setDianaRareMobWaypoints,
+                "Detects SkyHanni-style Diana rare mob coordinate shares in Hub chat\n"
+                + "and creates temporary waypoints for them.");
+        y2 += rowH;
+        addBoolRow(col2, y2, "Diana rare mob party sharing",
+                config.dianaRareMobPartySharing(), config::setDianaRareMobPartySharing,
+                "Shares selected Diana mob coordinates to party chat when you dig\n"
+                + "one up. Uses /pc so it stays in party chat.");
+        y2 += rowH;
+        addDianaRareMobSharesRow(col2, y2, colW);
     }
 
     private void addSystemPage(int col1, int col2, int colW, int rowsY, int rowH) {
-        leftHeader = "Location";
+        leftHeader = "";
         rightHeader = "Maintenance";
-
-        addBoolRow(col1, rowsY, "Always use scoreboard for zone detection",
-                config.preferScoreboardFallback(), config::setPreferScoreboardFallback,
-                "Prefer Hypixel-style scoreboard hints when resolving the current zone ID,\n"
-              + "even when other signals exist. Use if tab/location detection misbehaves.");
 
         int y2 = rowsY;
         addBoolRow(col2, y2, "Check for updates on startup",
@@ -373,6 +627,350 @@ public final class ConfigScreen extends Screen {
               + "The appearance will be degraded.");
     }
 
+    private void addTempWaypointsPage(int col1, int col2, int colW, int rowsY, int rowH) {
+        leftHeader = "Creation";
+        rightHeader = "Cleanup";
+
+        int y = rowsY;
+        addBoolRow(col1, y, "Auto-add chat temp waypoints",
+                config.autoAddChatTempWaypoints(), config::setAutoAddChatTempWaypoints,
+                config::chatCoordDetection,
+                "When chat coord detection finds a coordinate, immediately creates a\n"
+              + "temporary waypoint using your default expiry. Off keeps click-to-add only.");
+        y += rowH;
+        addBoolRow(col1, y, "Focus mode for temp waypoints",
+                config.focusTempWaypoints(), config::setFocusTempWaypoints,
+                "When on, adding a temporary waypoint hides other waypoints in the\n"
+              + "active zone and forces a tracer to the temp until you leave the server.");
+
+        int y2 = rowsY;
+        addBoolRow(col2, y2, "Delete temp waypoints when reached",
+                config.deleteTempWaypointsWhenReached(), config::setDeleteTempWaypointsWhenReached,
+                "When on, temporary waypoints disappear as soon as you enter their\n"
+              + "reach radius. Time-based temporary waypoints can still expire first.");
+        y2 += rowH;
+        addBoolRow(col2, y2, "Temp waypoints expire",
+                config.tempWaypointsExpireByDefault(), config::setTempWaypointsExpireByDefault,
+                "When on, newly-created temp waypoints use TIME mode by default.\n"
+              + "When off, they last until you leave the server unless changed in\n"
+              + "the Add Temp dialog.");
+        y2 += rowH;
+        addNumberRow(col2, y2, colW, "Temp duration (mins)",
+                config.tempDefaultDurationMin(), this::setTempDefaultDuration,
+                config::tempWaypointsExpireByDefault,
+                "Default lifetime for TIME-mode temporary waypoints.");
+    }
+
+    private void addSearchResultsPage(int col1, int col2, int colW, int rowsY, int rowH) {
+        leftHeader = "Search results";
+        rightHeader = "";
+
+        List<SearchEntry> matches = searchEntries(searchQuery);
+        if (matches.isEmpty()) {
+            addRenderableOnly(new LabelWidget(col1, rowsY + 6,
+                    "No matching settings.", colW * 2 + GAP_SECTION, () -> true));
+            return;
+        }
+
+        int bottom = height - FOOTER_H - GAP;
+        int[] y = { rowsY, rowsY };
+        int shown = 0;
+        for (SearchEntry entry : matches) {
+            int col = y[0] <= y[1] ? 0 : 1;
+            int x = col == 0 ? col1 : col2;
+            if (y[col] + BTN_H > bottom) break;
+
+            addSearchResultControl(x, y[col], colW, entry);
+            y[col] += rowH;
+            shown++;
+        }
+
+        if (shown < matches.size()) {
+            int col = y[0] <= y[1] ? 0 : 1;
+            int x = col == 0 ? col1 : col2;
+            if (y[col] + font.lineHeight <= bottom) {
+                addRenderableOnly(new LabelWidget(x, y[col] + 6,
+                        (matches.size() - shown) + " more matches. Narrow the search.",
+                        colW, () -> true));
+            }
+        }
+    }
+
+    private void addSearchResultControl(int x, int y, int colW, SearchEntry entry) {
+        switch (entry.label()) {
+            case "Waypoint box opacity (0-1)" -> addNumberRow(x, y, colW, "Waypoint box opacity (0-1)",
+                    config.beaconOpacity(), config::setBeaconOpacity,
+                    "Opacity of each waypoint's world-space box. 0 hides the volume,\n"
+                  + "1 is the strongest fill; labels can still show separately.");
+            case "Box style" -> addBoxStyleRow(x, y, colW);
+            case "Outline thickness (px)" -> addNumberRow(x, y, colW, "Outline thickness (px)",
+                    config.waypointOutlineThickness(), config::setWaypointOutlineThickness,
+                    "Width of waypoint outlines.");
+            case "Beacon beams" -> addBeamModeRow(x, y, colW);
+            case "Beam extends below waypoint" -> addBoolRow(x, y, "Beam extends below waypoint",
+                    config.beaconBeamExtendsBelowWaypoint(), config::setBeaconBeamExtendsBelowWaypoint,
+                    () -> config.beaconBeamMode() != WaypointerConfig.BeaconBeamMode.OFF,
+                    "When beacon beams are enabled, start each beam at the world's bottom\n"
+                  + "instead of at the waypoint's Y level. Useful for finding targets\n"
+                  + "above or below you through terrain.");
+            case "Show completed waypoints" -> addBoolRow(x, y, "Show completed waypoints",
+                    config.showCompleted(), config::setShowCompleted,
+                    "When on, waypoints you have already reached still draw (usually faded).\n"
+                  + "When off, completed stops disappear from the world HUD.");
+            case "Disable all features" -> addDisableAllFeaturesButton(x, y, colW);
+            case "Show waypoint names" -> addBoolRow(x, y, "Show waypoint names",
+                    config.showWaypointNames(), config::setShowWaypointNames,
+                    entry.description());
+            case "Show waypoint distances" -> addBoolRow(x, y, "Show waypoint distances",
+                    config.showWaypointDistances(), config::setShowWaypointDistances,
+                    entry.description());
+            case "Waypoint text inherits color" -> addBoolRow(x, y, "Waypoint text inherits color",
+                    config.matchWaypointTextToWaypointColor(), config::setMatchWaypointTextToWaypointColor,
+                    config::showWaypointNames,
+                    "When on, each floating waypoint name uses that waypoint's color.\n"
+                  + "When off, names stay white for maximum contrast.");
+            case "Show label backdrop" -> addBoolRow(x, y, "Show label backdrop",
+                    config.showLabelBackdrop(), config::setShowLabelBackdrop,
+                    () -> config.showWaypointNames() || config.showWaypointDistances(),
+                    entry.description());
+            case "Scale text with distance" -> addBoolRow(x, y, "Scale text with distance",
+                    config.scaleWaypointTextWithDistance(), config::setScaleWaypointTextWithDistance,
+                    () -> config.showWaypointNames() || config.showWaypointDistances(),
+                    "When on, waypoint labels use camera-depth scaling like a small\n"
+                  + "world-space label, while still drawing through the 2D HUD path.\n"
+                  + "Off preserves fixed-size labels.");
+            case "Label height offset (blocks)" -> addNumberRow(x, y, colW, "Label height offset (blocks)",
+                    config.labelHeightOffset(), config::setLabelHeightOffset,
+                    () -> config.showWaypointNames() || config.showWaypointDistances(),
+                    "Extra blocks to push each waypoint label above its marker. 0 keeps the\n"
+                  + "default placement. Use large values if distant labels still cover the\n"
+                  + "box; finite numbers only, no arbitrary clamp.");
+            case "Show tracers" -> addBoolRow(x, y, "Show tracers",
+                    config.showTracer(), config::setShowTracer,
+                    "Master switch for crosshair tracers. When off, no tracer lines are drawn\n"
+                  + "for any group (other waypoint rendering is unchanged).");
+            case "Tracer opacity (0-1)" -> addNumberRow(x, y, colW, "Tracer opacity (0-1)",
+                    config.tracerOpacity(), config::setTracerOpacity,
+                    config::showTracer,
+                    "Opacity of the line drawn from the crosshair to the active waypoint.\n"
+                  + "0 is fully transparent, 1 is solid.");
+            case "Tracer thickness (px)" -> addNumberRow(x, y, colW, "Tracer thickness (px)",
+                    config.tracerThickness(), config::setTracerThickness,
+                    config::showTracer,
+                    "Pixel width of the crosshair tracer line. Values are clamped\n"
+                  + "from 1 to 12 so it stays visible without flooding the screen.");
+            case "Tracer color (hex RRGGBB)" -> addTracerColorRow(x, y, colW,
+                    () -> config.showTracer() && !config.matchTracerToWaypointColor(),
+                    "Fixed tracer color as hex RRGGBB (e.g. 4FE05A). Only used when\n"
+                  + "\"Tracer inherits waypoint color\" is off.");
+            case "Tracer inherits waypoint color" -> addBoolRow(x, y, "Tracer inherits waypoint color",
+                    config.matchTracerToWaypointColor(), config::setMatchTracerToWaypointColor,
+                    config::showTracer,
+                    "When on, the tracer uses each waypoint's rendered color (gradient routes\n"
+                  + "shift hue as you progress). When off, every tracer uses the hex color above.");
+            case "Max waypoint labels (0 = unlimited)" -> addNumberRow(x, y, colW,
+                    "Max waypoint labels (0 = unlimited)",
+                    config.maxWaypointLabels(), this::setMaxWaypointLabels,
+                    performanceTooltip(entry.description(), Impact.HIGH));
+            case "Static marker distance (0 = unlimited)" -> addNumberRow(x, y, colW,
+                    "Static marker distance (0 = unlimited)",
+                    config.maxStaticWaypointRenderDistance(), config::setMaxStaticWaypointRenderDistance,
+                    performanceTooltip(entry.description(), Impact.HIGH));
+            case "Default reach radius (blocks)" -> addNumberRow(x, y, colW, "Default reach radius (blocks)",
+                    config.defaultReachRadius(), config::setDefaultReachRadius,
+                    "How close you must stand (in blocks) to mark the current waypoint reached,\n"
+                  + "when a waypoint does not set its own radius. Group default radius can\n"
+                  + "override this in the group editor.");
+            case "Enable waypoint skip-ahead mechanic" -> addBoolRow(x, y, "Enable waypoint skip-ahead mechanic",
+                    config.skipAheadMechanicEnabled(), config::setSkipAheadMechanicEnabled,
+                    entry.description());
+            case "Reset progress when joining a world" -> addBoolRow(x, y, "Reset progress when joining a world",
+                    config.resetProgressOnWorldJoin(), config::setResetProgressOnWorldJoin,
+                    "On world load or multiplayer join, every group's \"current\" waypoint resets\n"
+                  + "to the start. Off keeps saved progress across reconnects.");
+            case "Restart route after last waypoint" -> addBoolRow(x, y, "Restart route after last waypoint",
+                    config.restartRouteWhenComplete(), config::setRestartRouteWhenComplete,
+                    "After you complete the final waypoint, progress wraps to the first point\n"
+                  + "so loop and farm routes do not sit in a \"finished\" state.");
+            case "Add new waypoints below player" -> addBoolRow(x, y, "Add new waypoints below player",
+                    config.placeNewWaypointsBelowPlayer(), config::setPlaceNewWaypointsBelowPlayer,
+                    "When adding at your position, place the marker one block below your feet.\n"
+                  + "Turn off to use your exact standing block. Typed coordinates stay exact.");
+            case "Dim sequence context waypoints" -> addBoolRow(x, y, "Dim sequence context waypoints",
+                    config.dimSequenceContextWaypoints(), config::setDimSequenceContextWaypoints,
+                    entry.description());
+            case "Hide tracer on static routes" -> addBoolRow(x, y, "Hide tracer on static routes",
+                    config.hideTracerOnStaticRoutes(), config::setHideTracerOnStaticRoutes,
+                    config::showTracer,
+                    entry.description());
+            case "Hide waypoints when near" -> addBoolRow(x, y, "Hide waypoints when near",
+                    config.hideWaypointsNearPlayer(), config::setHideWaypointsNearPlayer,
+                    "When on, waypoint boxes, labels, beams, and tracers hide while\n"
+                  + "you stand near the waypoint, then reappear after you move away.");
+            case "Near hide radius (blocks)" -> addNumberRow(x, y, colW, "Near hide radius (blocks)",
+                    config.hideWaypointsNearRadius(), config::setHideWaypointsNearRadius,
+                    config::hideWaypointsNearPlayer,
+                    entry.description());
+            case "Hide reached static waypoints" -> addBoolRow(x, y, "Hide reached static waypoints",
+                    config.hideReachedStaticWaypointsUntilCycleComplete(),
+                    config::setHideReachedStaticWaypointsUntilCycleComplete,
+                    "For STATIC groups, hide each waypoint when you enter its reach radius.\n"
+                  + "After every waypoint in the group has been reached, all of them show again.");
+            case "Chat coord detection" -> addBoolRow(x, y, "Chat coord detection",
+                    config.chatCoordDetection(), config::setChatCoordDetection,
+                    "Scans incoming chat for coordinates and can offer quick-add flows for\n"
+                  + "temporary or permanent waypoints (no effect when chat has no coords).");
+            case "Chat codec detection (imports)" -> addBoolRow(x, y, "Chat codec detection (imports)",
+                    config.chatCodecDetection(), config::setChatCodecDetection,
+                    "Detects Waypointer share codes pasted in chat so you can import routes\n"
+                  + "without opening the main menu.");
+            case "Diana burrow waypoints" -> addBoolRow(x, y, "Diana burrow waypoints",
+                    config.dianaBurrowWaypoints(), config::setDianaBurrowWaypoints,
+                    "Detects real Diana burrow particles in the Hub and creates temporary\n"
+                  + "waypoints for confirmed burrows plus conservative Ancestral Spade\n"
+                  + "arrow guesses.");
+            case "Hide start burrows during active chain" -> addBoolRow(x, y,
+                    "Hide start burrows during active chain",
+                    config.dianaHideStartBurrowsUntilChainComplete(),
+                    config::setDianaHideStartBurrowsUntilChainComplete,
+                    config::dianaBurrowWaypoints,
+                    "When on, start burrow waypoints are withheld while chat progress says\n"
+                  + "your current Griffin chain is incomplete, so the tracer cannot pick\n"
+                  + "a fresh start before the chain is done.");
+            case "Diana spade debug logging" -> addBoolRow(x, y, "Diana spade debug logging",
+                    config.dianaSpadeDebugLogging(), config::setDianaSpadeDebugLogging,
+                    config::dianaBurrowWaypoints,
+                    entry.description());
+            case "Diana estimate color" -> addColorRow(x, y, colW, "Diana estimate color",
+                    config.dianaEstimateWaypointColor(), config::setDianaEstimateWaypointColor,
+                    config::dianaBurrowWaypoints,
+                    entry.description());
+            case "Diana start color" -> addColorRow(x, y, colW, "Diana start color",
+                    config.dianaStartBurrowColor(), config::setDianaStartBurrowColor,
+                    config::dianaBurrowWaypoints,
+                    entry.description());
+            case "Diana mob color" -> addColorRow(x, y, colW, "Diana mob color",
+                    config.dianaMobBurrowColor(), config::setDianaMobBurrowColor,
+                    config::dianaBurrowWaypoints,
+                    entry.description());
+            case "Diana treasure color" -> addColorRow(x, y, colW, "Diana treasure color",
+                    config.dianaTreasureBurrowColor(), config::setDianaTreasureBurrowColor,
+                    config::dianaBurrowWaypoints,
+                    entry.description());
+            case "Diana warp assist" -> addBoolRow(x, y, "Diana warp assist",
+                    config.dianaWarpAssist(), config::setDianaWarpAssist,
+                    config::dianaBurrowWaypoints,
+                    entry.description());
+            case "Diana warp savings threshold" -> addNumberRow(x, y, colW,
+                    "Diana warp savings threshold",
+                    config.dianaWarpMinSavings(), config::setDianaWarpMinSavings,
+                    () -> config.dianaBurrowWaypoints() && config.dianaWarpAssist(),
+                    entry.description());
+            case "Enabled Diana warps" -> addDianaWarpsRow(x, y, colW);
+            case "Diana rare mob waypoints" -> addBoolRow(x, y, "Diana rare mob waypoints",
+                    config.dianaRareMobWaypoints(), config::setDianaRareMobWaypoints,
+                    entry.description());
+            case "Diana rare mob party sharing" -> addBoolRow(x, y, "Diana rare mob party sharing",
+                    config.dianaRareMobPartySharing(), config::setDianaRareMobPartySharing,
+                    entry.description());
+            case "Shared Diana rare mobs" -> addDianaRareMobSharesRow(x, y, colW);
+            case "Check for updates on startup" -> addBoolRow(x, y, "Check for updates on startup",
+                    config.checkForUpdates(), config::setCheckForUpdates,
+                    "On client start, checks GitHub once for a newer Waypointer release.\n"
+                  + "Off avoids any update HTTP request.");
+            case "Experimental Iris HUD fallback" -> addBoolRow(x, y, "Experimental Iris HUD fallback",
+                    config.irisShaderHudFallback(), config::setIrisShaderHudFallback,
+                    entry.description());
+            case "Auto-add chat temp waypoints" -> addBoolRow(x, y, "Auto-add chat temp waypoints",
+                    config.autoAddChatTempWaypoints(), config::setAutoAddChatTempWaypoints,
+                    config::chatCoordDetection,
+                    "When chat coord detection finds a coordinate, immediately creates a\n"
+                  + "temporary waypoint using your default expiry. Off keeps click-to-add only.");
+            case "Focus mode for temp waypoints" -> addBoolRow(x, y, "Focus mode for temp waypoints",
+                    config.focusTempWaypoints(), config::setFocusTempWaypoints,
+                    "When on, adding a temporary waypoint hides other waypoints in the\n"
+                  + "active zone and forces a tracer to the temp until you leave the server.");
+            case "Delete temp waypoints when reached" -> addBoolRow(x, y,
+                    "Delete temp waypoints when reached",
+                    config.deleteTempWaypointsWhenReached(), config::setDeleteTempWaypointsWhenReached,
+                    "When on, temporary waypoints disappear as soon as you enter their\n"
+                  + "reach radius. Time-based temporary waypoints can still expire first.");
+            case "Temp waypoints expire" -> addBoolRow(x, y, "Temp waypoints expire",
+                    config.tempWaypointsExpireByDefault(), config::setTempWaypointsExpireByDefault,
+                    "When on, newly-created temp waypoints use TIME mode by default.\n"
+                  + "When off, they last until you leave the server unless changed in\n"
+                  + "the Add Temp dialog.");
+            case "Temp duration (mins)" -> addNumberRow(x, y, colW, "Temp duration (mins)",
+                    config.tempDefaultDurationMin(), this::setTempDefaultDuration,
+                    config::tempWaypointsExpireByDefault,
+                    entry.description());
+            default -> addRenderableOnly(new LabelWidget(x, y + 6, entry.label(), colW, () -> true));
+        }
+    }
+
+    private void addDisableAllFeaturesButton(int x, int y, int colW) {
+        Button btn = Button.builder(Component.literal("Disable all features"), b -> confirmDisableAllFeatures())
+                .bounds(x, y, Math.min(180, colW), BTN_H)
+                .tooltip(tip("Turn off every Waypointer feature toggle.\nShows a confirmation first."))
+                .build();
+        addRenderableWidget(btn);
+    }
+
+    private void addVisualsMaintenanceControls(int colW) {
+        int buttonY = height - FOOTER_H - BTN_H - GAP;
+        int headerY = buttonY - font.lineHeight - GAP;
+        addSectionHeader(PAD_OUTER, headerY, "Maintenance", colW);
+        addDisableAllFeaturesButton(PAD_OUTER, buttonY, colW);
+    }
+
+    private void addSectionHeader(int x, int y, String text, int colW) {
+        addRenderableOnly(new SectionHeaderWidget(x, y, text, colW));
+    }
+
+    private void addDianaWarpsRow(int x, int y, int colW) {
+        BooleanSupplier enabled = () -> config.dianaBurrowWaypoints() && config.dianaWarpAssist();
+        Button btn = Button.builder(Component.literal(dianaWarpsButtonLabel()),
+                        b -> minecraft.setScreen(new DianaWarpSettingsScreen(this, config)))
+                .bounds(x, y, Math.min(190, colW), BTN_H)
+                .tooltip(tip("Choose warp commands for Diana assist.\nDark Auction and Crypt start off."))
+                .build();
+        trackDependent(btn, enabled);
+        addRenderableWidget(btn);
+    }
+
+    private String dianaWarpsButtonLabel() {
+        return "Enabled Diana warps: " + config.dianaEnabledWarpCount()
+                + "/" + DianaWarp.values().length;
+    }
+
+    private void addDianaRareMobSharesRow(int x, int y, int colW) {
+        BooleanSupplier enabled = config::dianaRareMobPartySharing;
+        Button btn = Button.builder(Component.literal(dianaRareMobSharesButtonLabel()),
+                        b -> minecraft.setScreen(new DianaRareMobShareSettingsScreen(this, config)))
+                .bounds(x, y, Math.min(210, colW), BTN_H)
+                .tooltip(tip("Choose which Diana mobs Waypointer shares to party chat."))
+                .build();
+        trackDependent(btn, enabled);
+        addRenderableWidget(btn);
+    }
+
+    private String dianaRareMobSharesButtonLabel() {
+        return "Shared Diana mobs: " + config.dianaRareMobShareEnabledCount()
+                + "/" + DianaRareMob.values().length;
+    }
+
+    private void confirmDisableAllFeatures() {
+        minecraft.setScreen(new ConfirmScreen(confirmed -> {
+            if (confirmed) {
+                config.disableAllFeatures();
+            }
+            minecraft.setScreen(new ConfigScreen(parent, config, page));
+        }, Component.literal("Disable all Waypointer features?"),
+                Component.literal("This turns off every feature toggle in settings. You can re-enable features later."),
+                Component.literal("Disable all"),
+                Component.literal("Cancel")));
+    }
+
     private int leftHeaderX;
     private int rightHeaderX;
     private int sectionHeaderY;
@@ -380,6 +978,8 @@ public final class ConfigScreen extends Screen {
     private String rightHeader = "";
 
     private interface DoubleSetter { void accept(double value); }
+    private interface IntSetter { void accept(int value); }
+    private interface StringSetter { void accept(String value); }
 
     private enum Impact {
         HIGH("HIGH", ChatFormatting.RED),
@@ -396,15 +996,60 @@ public final class ConfigScreen extends Screen {
     }
 
     private static Component performanceTooltip(String description, Impact impact) {
-        MutableComponent out = Component.literal(description).withStyle(ChatFormatting.GRAY);
+        MutableComponent out = Component.literal(wrapTooltip(description)).withStyle(ChatFormatting.GRAY);
         out.append(Component.literal("\n\nImpact: ").withStyle(ChatFormatting.GRAY));
         out.append(Component.literal(impact.label).withStyle(impact.color));
         return out;
     }
 
+    private static Tooltip tip(String text) {
+        return Tooltip.create(tooltipText(text));
+    }
+
+    private static Component tooltipText(String text) {
+        return Component.literal(wrapTooltip(text)).withStyle(ChatFormatting.GRAY);
+    }
+
+    private static String wrapTooltip(String text) {
+        String cleaned = (text == null ? "" : text)
+                .replace('—', ':')
+                .replace('–', '-')
+                .replace("â€”", ":")
+                .replace(" -- ", ": ")
+                .trim();
+        StringBuilder out = new StringBuilder();
+        for (String paragraph : cleaned.split("\\n", -1)) {
+            appendWrapped(out, paragraph.trim(), 30);
+        }
+        return out.toString();
+    }
+
+    private static void appendWrapped(StringBuilder out, String text, int maxChars) {
+        if (text.isEmpty()) {
+            if (!out.isEmpty()) out.append('\n');
+            return;
+        }
+        String[] words = text.split("\\s+");
+        int lineLen = 0;
+        for (String word : words) {
+            if (lineLen > 0 && lineLen + 1 + word.length() > maxChars) {
+                out.append('\n');
+                lineLen = 0;
+            } else if (!out.isEmpty() && lineLen == 0) {
+                out.append('\n');
+            }
+            if (lineLen > 0) {
+                out.append(' ');
+                lineLen++;
+            }
+            out.append(word);
+            lineLen += word.length();
+        }
+    }
+
     private void addNumberRow(int x, int y, int colW, String label, double initial, DoubleSetter setter,
                               String tooltip) {
-        addNumberRow(x, y, colW, label, initial, setter, Component.literal(tooltip));
+        addNumberRow(x, y, colW, label, initial, setter, tooltipText(tooltip));
     }
 
     private void addNumberRow(int x, int y, int colW, String label, double initial, DoubleSetter setter,
@@ -414,7 +1059,7 @@ public final class ConfigScreen extends Screen {
 
     private void addNumberRow(int x, int y, int colW, String label, double initial, DoubleSetter setter,
                               BooleanSupplier enabled, String tooltip) {
-        addNumberRow(x, y, colW, label, initial, setter, enabled, Component.literal(tooltip));
+        addNumberRow(x, y, colW, label, initial, setter, enabled, tooltipText(tooltip));
     }
 
     private void addNumberRow(int x, int y, int colW, String label, double initial, DoubleSetter setter,
@@ -424,7 +1069,7 @@ public final class ConfigScreen extends Screen {
 
     private void addNumberRow(int x, int y, int colW, String label, double initial, DoubleSetter setter,
                               boolean hex, String tooltip) {
-        addNumberRow(x, y, colW, label, initial, setter, hex, () -> true, Component.literal(tooltip));
+        addNumberRow(x, y, colW, label, initial, setter, hex, () -> true, tooltipText(tooltip));
     }
 
     /**
@@ -454,53 +1099,77 @@ public final class ConfigScreen extends Screen {
         addRenderableWidget(box);
     }
 
+    private void addTextRow(int x, int y, int colW, String label, String initial,
+                            StringSetter setter, BooleanSupplier enabled,
+                            int maxLength, String tooltip) {
+        int boxW = 112;
+        int labelW = colW - boxW - GAP;
+        addRenderableOnly(new LabelWidget(x, y + 6, label, labelW, enabled));
+        EditBox box = new EditBox(font, x + labelW + GAP, y + 2, boxW, BTN_H, Component.literal(label));
+        box.setMaxLength(maxLength);
+        box.setValue(initial == null ? "" : initial);
+        box.setResponder(setter::accept);
+        box.setTooltip(tip(tooltip));
+        trackDependent(box, enabled);
+        addRenderableWidget(box);
+    }
+
+    private void addColorRow(int x, int y, int colW, String label, int initial,
+                             IntSetter setter, BooleanSupplier enabled,
+                             String tooltip) {
+        int swatchW = 90;
+        int labelW = colW - swatchW - GAP;
+        addRenderableOnly(new LabelWidget(x, y + 6, label, labelW, enabled));
+
+        int[] currentColor = { initial };
+
+        ColorSwatchButton[] swatchRef = new ColorSwatchButton[1];
+        ColorSwatchButton swatch = new ColorSwatchButton(
+                x + labelW + GAP, y + 2, swatchW, BTN_H,
+                "Pick color", currentColor[0] & 0xFFFFFF, () -> ColorPickerScreen.open(this,
+                label, currentColor[0] & 0xFFFFFF, opacityFromColor(currentColor[0]), picked -> {
+                    currentColor[0] = withOpacity(picked, opacityFromColor(currentColor[0]));
+                    setter.accept(currentColor[0]);
+                    swatchRef[0].setColor(picked);
+                }, opacity -> {
+                    currentColor[0] = withOpacity(currentColor[0], opacity);
+                    setter.accept(currentColor[0]);
+                }));
+        swatchRef[0] = swatch;
+        swatch.setTooltip(tip(tooltip));
+
+        trackDependent(swatch, enabled);
+        addRenderableWidget(swatch);
+    }
+
     private void addTracerColorRow(int x, int y, int colW, BooleanSupplier enabled,
                                    String tooltip) {
-        int swatchW = 72;
-        int boxW = 76;
-        int labelW = colW - boxW - swatchW - GAP * 2;
+        int swatchW = 90;
+        int labelW = colW - swatchW - GAP;
         addRenderableOnly(new LabelWidget(x, y + 6,
-                "Tracer color (hex RRGGBB)", labelW, enabled));
+                "Tracer color", labelW, enabled));
 
-        EditBox box = new EditBox(font, x + labelW + GAP, y + 2, boxW, BTN_H,
-                Component.literal("Tracer color"));
-        box.setMaxLength(6);
-        box.setValue(String.format("%06X", config.tracerColor() & 0xFFFFFF));
-        box.setTooltip(Tooltip.create(Component.literal(tooltip)));
-
+        ColorSwatchButton[] swatchRef = new ColorSwatchButton[1];
         ColorSwatchButton swatch = new ColorSwatchButton(
-                x + labelW + GAP + boxW + GAP, y + 2, swatchW, BTN_H,
+                x + labelW + GAP, y + 2, swatchW, BTN_H,
                 "Pick color", config.tracerColor(), () -> ColorPickerScreen.open(this,
-                "Tracer Colour", config.tracerColor(), picked -> {
+                "Tracer Color", config.tracerColor(), config.tracerOpacity(), picked -> {
                     config.setTracerColor(picked);
-                    box.setValue(String.format("%06X", picked & 0xFFFFFF));
-                }));
-        swatch.setTooltip(Tooltip.create(Component.literal(
-                "Open the color picker for the fixed tracer color.")));
+                    swatchRef[0].setColor(picked);
+                }, config::setTracerOpacity));
+        swatchRef[0] = swatch;
+        swatch.setTooltip(tip(tooltip));
 
-        box.setResponder(v -> {
-            if (v.isEmpty()) return;
-            try {
-                int parsed = Integer.parseInt(v.trim(), 16) & 0xFFFFFF;
-                config.setTracerColor(parsed);
-                swatch.setColor(parsed);
-            } catch (NumberFormatException ignored) {
-                // Partial edits are expected while typing; keep the last valid color.
-            }
-        });
-
-        trackDependent(box, enabled);
         trackDependent(swatch, enabled);
-        addRenderableWidget(box);
         addRenderableWidget(swatch);
     }
 
     private void addBoxStyleRow(int x, int y, int colW) {
         addBoxStyleRow(x, y, colW,
                 "How each waypoint is drawn in the world:\n"
-              + "Outlined — edge lines only.\n"
-              + "Filled — translucent faces (easier to see at distance).\n"
-              + "Filled + Outline — both for maximum contrast.");
+              + "Outlined: edge lines only.\n"
+              + "Filled: translucent faces.\n"
+              + "Filled + Outline: both.");
     }
 
     private void addBoxStyleRow(int x, int y, int colW, String tooltip) {
@@ -512,7 +1181,7 @@ public final class ConfigScreen extends Screen {
             config.setBoxStyle(next);
             b.setMessage(Component.literal(boxStyleLabel(next)));
         }).bounds(x + labelW + GAP, y, 140, BTN_H)
-                .tooltip(Tooltip.create(Component.literal(tooltip)))
+                .tooltip(tip(tooltip))
                 .build();
         addRenderableWidget(btn);
     }
@@ -520,9 +1189,9 @@ public final class ConfigScreen extends Screen {
     private void addBeamModeRow(int x, int y, int colW) {
         addBeamModeRow(x, y, colW,
                 "Optional vertical guide beams:\n"
-              + "Off — no beams.\n"
-              + "Current — only each active group's target.\n"
-              + "All visible — every rendered waypoint.");
+              + "Off: no beams.\n"
+              + "Current: active targets only.\n"
+              + "All visible: every waypoint.");
     }
 
     private void addBeamModeRow(int x, int y, int colW, String tooltip) {
@@ -535,7 +1204,7 @@ public final class ConfigScreen extends Screen {
             config.setBeaconBeamMode(next);
             b.setMessage(Component.literal(beamModeLabel(next)));
         }).bounds(x + labelW + GAP, y, 140, BTN_H)
-                .tooltip(Tooltip.create(Component.literal(tooltip)))
+                .tooltip(tip(tooltip))
                 .build();
         addRenderableWidget(btn);
     }
@@ -576,9 +1245,19 @@ public final class ConfigScreen extends Screen {
         config.setTempDefaultDurationMin(clamped);
     }
 
+    private static double opacityFromColor(int color) {
+        int alpha = (color >>> 24) & 0xFF;
+        return alpha == 0 ? 1.0 : alpha / 255.0;
+    }
+
+    private static int withOpacity(int color, double opacity) {
+        int alpha = Math.max(0, Math.min(255, (int) Math.round(opacity * 255.0)));
+        return (alpha << 24) | (color & 0xFFFFFF);
+    }
+
     private void addBoolRow(int x, int y, String label, boolean initial,
                             java.util.function.Consumer<Boolean> setter, String tooltip) {
-        addBoolRow(x, y, label, initial, setter, Component.literal(tooltip));
+        addBoolRow(x, y, label, initial, setter, tooltipText(tooltip));
     }
 
     private void addBoolRow(int x, int y, String label, boolean initial,
@@ -589,7 +1268,7 @@ public final class ConfigScreen extends Screen {
     private void addBoolRow(int x, int y, String label, boolean initial,
                             java.util.function.Consumer<Boolean> setter,
                             BooleanSupplier enabled, String tooltip) {
-        addBoolRow(x, y, label, initial, setter, enabled, Component.literal(tooltip));
+        addBoolRow(x, y, label, initial, setter, enabled, tooltipText(tooltip));
     }
 
     private void addBoolRow(int x, int y, String label, boolean initial,
@@ -639,6 +1318,8 @@ public final class ConfigScreen extends Screen {
     /** Right-padded label with an explicit width so long labels truncate at column bounds. */
     private record DependentControl(AbstractWidget widget, BooleanSupplier enabled) {}
 
+    private record SearchEntry(Page page, String section, String label, String description) {}
+
     private record LabelWidget(int x, int y, String text, int maxW, BooleanSupplier enabled)
             implements net.minecraft.client.gui.components.Renderable {
         @Override
@@ -646,6 +1327,16 @@ public final class ConfigScreen extends Screen {
             var font = net.minecraft.client.Minecraft.getInstance().font;
             String clipped = font.plainSubstrByWidth(text, maxW);
             g.drawString(font, clipped, x, y, enabled.getAsBoolean() ? TEXT : TEXT_DIM, false);
+        }
+    }
+
+    private record SectionHeaderWidget(int x, int y, String text, int maxW)
+            implements net.minecraft.client.gui.components.Renderable {
+        @Override
+        public void render(GuiGraphics g, int mouseX, int mouseY, float partial) {
+            var font = net.minecraft.client.Minecraft.getInstance().font;
+            String clipped = font.plainSubstrByWidth(text, maxW);
+            g.drawString(font, clipped, x, y, TEXT_DIM, false);
         }
     }
 

--- a/src/client/java/dev/ethan/waypointer/screen/ConfigScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/ConfigScreen.java
@@ -1247,11 +1247,14 @@ public final class ConfigScreen extends Screen {
 
     private static double opacityFromColor(int color) {
         int alpha = (color >>> 24) & 0xFF;
-        return alpha == 0 ? 1.0 : alpha / 255.0;
+        if (alpha == 0) return 1.0;
+        if (alpha == 1) return 0.0;
+        return alpha / 255.0;
     }
 
     private static int withOpacity(int color, double opacity) {
         int alpha = Math.max(0, Math.min(255, (int) Math.round(opacity * 255.0)));
+        if (alpha == 0) alpha = 1;
         return (alpha << 24) | (color & 0xFFFFFF);
     }
 

--- a/src/client/java/dev/ethan/waypointer/screen/DianaRareMobShareSettingsScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/DianaRareMobShareSettingsScreen.java
@@ -1,0 +1,74 @@
+package dev.ethan.waypointer.screen;
+
+import dev.ethan.waypointer.config.WaypointerConfig;
+import dev.ethan.waypointer.diana.DianaRareMob;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.Checkbox;
+import net.minecraft.client.gui.components.Tooltip;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static dev.ethan.waypointer.screen.GuiTokens.*;
+
+public final class DianaRareMobShareSettingsScreen extends Screen {
+
+    private final Screen parent;
+    private final WaypointerConfig config;
+
+    public DianaRareMobShareSettingsScreen(Screen parent, WaypointerConfig config) {
+        super(Component.literal("Diana Mob Sharing"));
+        this.parent = parent;
+        this.config = config;
+    }
+
+    @Override
+    protected void init() {
+        int footerY = height - FOOTER_H;
+        List<GuiTokens.ButtonSpec> left = new ArrayList<>();
+        GuiTokens.ButtonSpec done = new GuiTokens.ButtonSpec("Done", -1, this::onClose,
+                Tooltip.create(Component.literal("Return to Diana settings.")));
+        GuiTokens.layoutFooter(width, footerY, left, done, this::addRenderableWidget, font);
+
+        int top = PAD_OUTER + font.lineHeight + GAP_SECTION;
+        int colGap = GAP_SECTION;
+        int colW = (width - PAD_OUTER * 2 - colGap) / 2;
+        int col1 = PAD_OUTER;
+        int col2 = col1 + colW + colGap;
+        int rowH = 24;
+
+        DianaRareMob[] mobs = DianaRareMob.values();
+        for (int i = 0; i < mobs.length; i++) {
+            DianaRareMob mob = mobs[i];
+            int col = i < 5 ? col1 : col2;
+            int y = top + (i % 5) * rowH;
+            addMobCheckbox(col, y, mob);
+        }
+    }
+
+    private void addMobCheckbox(int x, int y, DianaRareMob mob) {
+        Checkbox checkbox = Checkbox.builder(Component.literal(mob.label()), font)
+                .pos(x, y)
+                .selected(config.dianaRareMobShareEnabled(mob))
+                .onValueChange((b, enabled) -> config.setDianaRareMobShareEnabled(mob, enabled))
+                .build();
+        checkbox.setTooltip(Tooltip.create(Component.literal(
+                "Share " + mob.label() + " coordinates in party chat when you dig one up.")));
+        addRenderableWidget(checkbox);
+    }
+
+    @Override
+    public void render(GuiGraphics g, int mouseX, int mouseY, float partial) {
+        super.render(g, mouseX, mouseY, partial);
+        g.drawString(font, getTitle(), PAD_OUTER, PAD_OUTER, TEXT, false);
+        String enabled = config.dianaRareMobShareEnabledCount() + "/" + DianaRareMob.values().length + " selected";
+        g.drawString(font, enabled, width - PAD_OUTER - font.width(enabled), PAD_OUTER, TEXT_DIM, false);
+    }
+
+    @Override
+    public void onClose() {
+        minecraft.setScreen(parent);
+    }
+}

--- a/src/client/java/dev/ethan/waypointer/screen/DianaWarpSettingsScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/DianaWarpSettingsScreen.java
@@ -1,0 +1,76 @@
+package dev.ethan.waypointer.screen;
+
+import dev.ethan.waypointer.config.WaypointerConfig;
+import dev.ethan.waypointer.diana.DianaWarp;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.Checkbox;
+import net.minecraft.client.gui.components.Tooltip;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static dev.ethan.waypointer.screen.GuiTokens.*;
+
+public final class DianaWarpSettingsScreen extends Screen {
+
+    private final Screen parent;
+    private final WaypointerConfig config;
+
+    public DianaWarpSettingsScreen(Screen parent, WaypointerConfig config) {
+        super(Component.literal("Diana Warps"));
+        this.parent = parent;
+        this.config = config;
+    }
+
+    @Override
+    protected void init() {
+        int footerY = height - FOOTER_H;
+        List<GuiTokens.ButtonSpec> left = new ArrayList<>();
+        GuiTokens.ButtonSpec done = new GuiTokens.ButtonSpec("Done", -1, this::onClose,
+                Tooltip.create(Component.literal("Return to Diana settings.")));
+        GuiTokens.layoutFooter(width, footerY, left, done, this::addRenderableWidget, font);
+
+        int top = PAD_OUTER + font.lineHeight + GAP_SECTION;
+        int colGap = GAP_SECTION;
+        int colW = (width - PAD_OUTER * 2 - colGap) / 2;
+        int col1 = PAD_OUTER;
+        int col2 = col1 + colW + colGap;
+        int rowH = 24;
+
+        DianaWarp[] warps = DianaWarp.values();
+        for (int i = 0; i < warps.length; i++) {
+            DianaWarp warp = warps[i];
+            int col = i < 4 ? col1 : col2;
+            int y = top + (i % 4) * rowH;
+            addWarpCheckbox(col, y, warp);
+        }
+    }
+
+    private void addWarpCheckbox(int x, int y, DianaWarp warp) {
+        Checkbox checkbox = Checkbox.builder(Component.literal(warp.label()), font)
+                .pos(x, y)
+                .selected(config.dianaWarpEnabled(warp))
+                .onValueChange((b, enabled) -> config.setDianaWarpEnabled(warp, enabled))
+                .build();
+        checkbox.setTooltip(Tooltip.create(Component.literal(
+                "/" + warp.command() + "  ->  "
+                        + warp.x() + ", " + warp.y() + ", " + warp.z())));
+        addRenderableWidget(checkbox);
+    }
+
+    @Override
+    public void render(GuiGraphics g, int mouseX, int mouseY, float partial) {
+        super.render(g, mouseX, mouseY, partial);
+        g.drawString(font, getTitle(), PAD_OUTER, PAD_OUTER, TEXT, false);
+        String enabled = config.dianaEnabledWarpCount() + "/" + DianaWarp.values().length + " enabled";
+        g.drawString(font, enabled, width - PAD_OUTER - font.width(enabled), PAD_OUTER, TEXT_DIM, false);
+    }
+
+    @Override
+    public void onClose() {
+        minecraft.setScreen(parent);
+    }
+}

--- a/src/client/java/dev/ethan/waypointer/screen/ExportScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/ExportScreen.java
@@ -38,9 +38,9 @@ import static dev.ethan.waypointer.screen.GuiTokens.SURFACE_SUBTLE;
  * the wire format -- exports always carried colors, radii, group metadata, and a
  * fixed-format header regardless of what the user picked. The recipient had no
  * way to opt out, and a sender who wanted a small "just the path" payload had no
- * choice. Granular toggles let the sender pay only for what's worth sharing;
- * defaults are preserved so the common case still produces a sensible mid-size
- * export with names dropped.
+ * choice. Granular toggles let the sender pay only for what's worth sharing.
+ * New export screens start with only Group Meta enabled so route behaviour
+ * survives while the payload stays clean by default.
  *
  * Layout, top to bottom:
  *
@@ -49,7 +49,7 @@ import static dev.ethan.waypointer.screen.GuiTokens.SURFACE_SUBTLE;
  *   3. Toggle row per export option (Names, Colors, Radii, Waypoint Flags,
  *      Group Meta). Each carries a tooltip explaining the trade-off.
  *   4. Reset-to-defaults button so users who experimented can recover the
- *      sensible config preset without leaving the screen.
+ *      short, predictable export preset without leaving the screen.
  *   5. Size summary: char count + paste-fit indicator.
  *   6. Preview box labelled "Encoded preview (this is what gets copied)".
  */
@@ -102,7 +102,6 @@ public final class ExportScreen extends Screen {
     private static final int ROUTE_TOGGLE_W = 148;
 
     private final Screen parent;
-    private final WaypointerConfig config;
     private final List<WaypointGroup> groups;
     private final boolean[] selectedGroups;
     private final String subtitle;
@@ -128,12 +127,11 @@ public final class ExportScreen extends Screen {
     public ExportScreen(Screen parent, WaypointerConfig config, List<WaypointGroup> groups, String subtitle) {
         super(Component.literal("Export Waypoints"));
         this.parent = parent;
-        this.config = config;
         this.groups = groups;
         this.selectedGroups = new boolean[groups.size()];
         Arrays.fill(this.selectedGroups, true);
         this.subtitle = subtitle;
-        this.optsBuilder = builderFromConfig(config);
+        this.optsBuilder = defaultExportBuilder();
     }
 
     /** Entry point for a single-group export; wraps the group in a list with a title. */
@@ -352,7 +350,7 @@ public final class ExportScreen extends Screen {
     }
 
     private void resetToConfigDefaults() {
-        optsBuilder = builderFromConfig(config);
+        optsBuilder = defaultExportBuilder();
         currentLabel = "";
         labelInput.setValue("");
         // Re-apply each toggle's value from the freshly-built options and
@@ -623,13 +621,13 @@ public final class ExportScreen extends Screen {
 
     // --- helpers ------------------------------------------------------------------------------
 
-    private static WaypointCodec.Options.Builder builderFromConfig(WaypointerConfig config) {
+    private static WaypointCodec.Options.Builder defaultExportBuilder() {
         return WaypointCodec.Options.builder()
-                .includeNames(config.exportIncludeNames())
-                .includeColors(config.exportIncludeColors())
-                .includeRadii(config.exportIncludeRadii())
-                .includeWaypointFlags(config.exportIncludeWaypointFlags())
-                .includeGroupMeta(config.exportIncludeGroupMeta());
+                .includeNames(false)
+                .includeColors(false)
+                .includeRadii(false)
+                .includeWaypointFlags(false)
+                .includeGroupMeta(true);
     }
 
     @Override

--- a/src/client/java/dev/ethan/waypointer/screen/ExportScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/ExportScreen.java
@@ -102,6 +102,7 @@ public final class ExportScreen extends Screen {
     private static final int ROUTE_TOGGLE_W = 148;
 
     private final Screen parent;
+    private final WaypointerConfig config;
     private final List<WaypointGroup> groups;
     private final boolean[] selectedGroups;
     private final String subtitle;
@@ -127,11 +128,12 @@ public final class ExportScreen extends Screen {
     public ExportScreen(Screen parent, WaypointerConfig config, List<WaypointGroup> groups, String subtitle) {
         super(Component.literal("Export Waypoints"));
         this.parent = parent;
+        this.config = config;
         this.groups = groups;
         this.selectedGroups = new boolean[groups.size()];
         Arrays.fill(this.selectedGroups, true);
         this.subtitle = subtitle;
-        this.optsBuilder = defaultExportBuilder();
+        this.optsBuilder = config.exportCodecOptionsBuilder();
     }
 
     /** Entry point for a single-group export; wraps the group in a list with a title. */
@@ -350,7 +352,7 @@ public final class ExportScreen extends Screen {
     }
 
     private void resetToConfigDefaults() {
-        optsBuilder = defaultExportBuilder();
+        optsBuilder = config.exportCodecOptionsBuilder();
         currentLabel = "";
         labelInput.setValue("");
         // Re-apply each toggle's value from the freshly-built options and
@@ -620,15 +622,6 @@ public final class ExportScreen extends Screen {
     }
 
     // --- helpers ------------------------------------------------------------------------------
-
-    private static WaypointCodec.Options.Builder defaultExportBuilder() {
-        return WaypointCodec.Options.builder()
-                .includeNames(false)
-                .includeColors(false)
-                .includeRadii(false)
-                .includeWaypointFlags(false)
-                .includeGroupMeta(true);
-    }
 
     @Override
     public boolean isPauseScreen() { return false; }

--- a/src/client/java/dev/ethan/waypointer/screen/WaypointerScreen.java
+++ b/src/client/java/dev/ethan/waypointer/screen/WaypointerScreen.java
@@ -50,6 +50,11 @@ public final class WaypointerScreen extends Screen {
     private static final String TEMPORARY_ZONE_ID = "__temporary__";
     private static final String TEMPORARY_ZONE_LABEL = "Temporary";
     private static final int TEMPORARY_ACCENT = 0xFF58C878;
+    private static final String DIANA_ZONE_ID = "__diana__";
+    private static final String DIANA_ZONE_LABEL = "Diana";
+    private static final String DIANA_GROUP_PREFIX = "diana::";
+    private static final String HUB_ZONE_ID = "hub";
+    private static final int DIANA_ACCENT = 0xFF1E5E32;
 
     private final ActiveGroupManager manager;
     private final WaypointerConfig config;
@@ -127,7 +132,9 @@ public final class WaypointerScreen extends Screen {
             // visibleGroups() are fragile when groups added mid-list shift
             // indices. The init() pass will resolve the id to a current
             // selectedIndex after it knows the list ordering for the zone.
-            screen.selectedZoneId = focus.temp() ? TEMPORARY_ZONE_ID : focus.zoneId();
+            screen.selectedZoneId = isDianaGroup(focus) ? DIANA_ZONE_ID
+                    : focus.temp() ? TEMPORARY_ZONE_ID
+                    : focus.zoneId();
             screen.pendingFocusGroupId = focus.id();
         }
         Minecraft.getInstance().setScreen(screen);
@@ -198,6 +205,7 @@ public final class WaypointerScreen extends Screen {
     private List<String> zoneIds() {
         List<String> zones = new ArrayList<>();
         zones.add(TEMPORARY_ZONE_ID);
+        if (dianaWaypointCount() > 0) zones.add(DIANA_ZONE_ID);
         for (String zoneId : manager.knownZoneIds()) {
             if (normalGroupCountForZone(zoneId) > 0 && !zones.contains(zoneId)) {
                 zones.add(zoneId);
@@ -211,10 +219,11 @@ public final class WaypointerScreen extends Screen {
 
     private List<WaypointGroup> visibleGroups() {
         if (isTemporaryZone(selectedZoneId)) return temporaryGroups();
+        if (isDianaZone(selectedZoneId)) return dianaGroups();
 
         List<WaypointGroup> out = new ArrayList<>();
         for (WaypointGroup group : manager.groupsForZone(selectedZoneId)) {
-            if (!group.temp()) out.add(group);
+            if (!group.temp() && !isDianaGroup(group)) out.add(group);
         }
         return out;
     }
@@ -222,7 +231,15 @@ public final class WaypointerScreen extends Screen {
     private List<WaypointGroup> temporaryGroups() {
         List<WaypointGroup> out = new ArrayList<>();
         for (WaypointGroup group : manager.allGroups()) {
-            if (group.temp() && !group.isEmpty()) out.add(group);
+            if (group.temp() && !isDianaGroup(group) && !group.isEmpty()) out.add(group);
+        }
+        return out;
+    }
+
+    private List<WaypointGroup> dianaGroups() {
+        List<WaypointGroup> out = new ArrayList<>();
+        for (WaypointGroup group : manager.allGroups()) {
+            if (isDianaGroup(group) && !group.isEmpty()) out.add(group);
         }
         return out;
     }
@@ -230,7 +247,7 @@ public final class WaypointerScreen extends Screen {
     private int normalGroupCountForZone(String zoneId) {
         int count = 0;
         for (WaypointGroup group : manager.groupsForZone(zoneId)) {
-            if (!group.temp()) count++;
+            if (!group.temp() && !isDianaGroup(group)) count++;
         }
         return count;
     }
@@ -243,8 +260,24 @@ public final class WaypointerScreen extends Screen {
         return count;
     }
 
+    private int dianaWaypointCount() {
+        int count = 0;
+        for (WaypointGroup group : manager.allGroups()) {
+            if (isDianaGroup(group)) count += group.size();
+        }
+        return count;
+    }
+
     private static boolean isTemporaryZone(String zoneId) {
         return TEMPORARY_ZONE_ID.equals(zoneId);
+    }
+
+    private static boolean isDianaZone(String zoneId) {
+        return DIANA_ZONE_ID.equals(zoneId);
+    }
+
+    private static boolean isDianaGroup(WaypointGroup group) {
+        return group != null && group.id().startsWith(DIANA_GROUP_PREFIX);
     }
 
     // --- render ------------------------------------------------------------------------------
@@ -274,6 +307,10 @@ public final class WaypointerScreen extends Screen {
         if (isTemporaryZone(selectedZoneId)) {
             int waypointCount = temporaryWaypointCount();
             status = TEMPORARY_ZONE_LABEL + "  .  " + waypointCount
+                    + " waypoint" + (waypointCount == 1 ? "" : "s");
+        } else if (isDianaZone(selectedZoneId)) {
+            int waypointCount = dianaWaypointCount();
+            status = DIANA_ZONE_LABEL + "  .  " + waypointCount
                     + " waypoint" + (waypointCount == 1 ? "" : "s");
         } else {
             int groupCount = visibleGroups().size();
@@ -319,38 +356,40 @@ public final class WaypointerScreen extends Screen {
         for (String id : ids) {
             boolean selected = id.equals(selectedZoneId);
             boolean temporary = isTemporaryZone(id);
+            boolean diana = isDianaZone(id);
             boolean hovered = mouseX >= x1 && mouseX <= x2
                     && mouseY >= rowY && mouseY <= rowY + ROW_H;
             drawZoneRow(g, x1, rowY, x2, id, selected, hovered,
-                    !temporary && id.equals(currentId), temporary);
+                    diana ? HUB_ZONE_ID.equals(currentId) : !temporary && id.equals(currentId),
+                    temporary, diana);
             rowY += ROW_H;
         }
     }
 
     private void drawZoneRow(GuiGraphics g, int x1, int y, int x2,
                              String zoneId, boolean selected, boolean hovered,
-                             boolean isCurrent, boolean temporary) {
+                             boolean isCurrent, boolean temporary, boolean diana) {
         int bg = selected ? SELECTED : hovered ? HOVER : 0;
         if (bg != 0) g.fill(x1, y, x2, y + ROW_H, bg);
 
         // "unknown" is intentionally quiet -- it's a placeholder zone, not the focal
         // point of an empty state. So it never gets the accent bar and renders in muted text.
         boolean isUnknown = Zone.UNKNOWN.id().equals(zoneId);
-        int accent = temporary ? TEMPORARY_ACCENT : ACCENT;
-        if (selected && (!isUnknown || temporary)) {
+        int accent = diana ? DIANA_ACCENT : temporary ? TEMPORARY_ACCENT : ACCENT;
+        if (selected && (!isUnknown || temporary || diana)) {
             g.fill(x1, y, x1 + 2, y + ROW_H, accent);
         }
 
-        String label = temporary ? TEMPORARY_ZONE_LABEL : Zone.fromId(zoneId).displayName();
-        int count = temporary ? temporaryWaypointCount() : normalGroupCountForZone(zoneId);
+        String label = diana ? DIANA_ZONE_LABEL : temporary ? TEMPORARY_ZONE_LABEL : Zone.fromId(zoneId).displayName();
+        int count = diana ? dianaWaypointCount() : temporary ? temporaryWaypointCount() : normalGroupCountForZone(zoneId);
         int textColor = isUnknown && !temporary ? TEXT_MUTED : selected ? TEXT : TEXT_DIM;
-        if (temporary && count == 0 && !selected) textColor = TEXT_MUTED;
+        if ((temporary || diana) && count == 0 && !selected) textColor = TEXT_MUTED;
         g.drawString(font, label, x1 + GAP + 2, y + 6, textColor, false);
 
         // live "current zone" indicator -- a tiny filled dot, no color, just a glyph
         if (isCurrent) {
             int dotX = x2 - GAP - 6;
-            g.fill(dotX, y + ROW_H / 2 - 2, dotX + 4, y + ROW_H / 2 + 2, ACCENT);
+            g.fill(dotX, y + ROW_H / 2 - 2, dotX + 4, y + ROW_H / 2 + 2, accent);
         }
 
         // Group count, right-aligned next to the dot (or at the edge if no dot)
@@ -369,8 +408,10 @@ public final class WaypointerScreen extends Screen {
         g.fill(x1, y1, x2, y2, SURFACE_SUBTLE);
         g.enableScissor(x1, y1, x2, y2);
 
-        g.drawString(font, isTemporaryZone(selectedZoneId) ? "Temporary Waypoints" : "Groups",
-                x1 + GAP, y1 + 6, TEXT_DIM, false);
+        String header = isDianaZone(selectedZoneId) ? "Diana Waypoints"
+                : isTemporaryZone(selectedZoneId) ? "Temporary Waypoints"
+                : "Groups";
+        g.drawString(font, header, x1 + GAP, y1 + 6, TEXT_DIM, false);
 
         int y = y1 + 20 - scrollOffset;
         int listW = x2 - x1;
@@ -395,6 +436,13 @@ public final class WaypointerScreen extends Screen {
                     x1, y1 + 8 + 14, TEXT_DIM, false);
             return;
         }
+        if (isDianaZone(selectedZoneId)) {
+            g.drawString(font, "No Diana waypoints.",
+                    x1, y1 + 8, TEXT, false);
+            g.drawString(font, "Detected burrows and estimates will appear here.",
+                    x1, y1 + 8 + 14, TEXT_DIM, false);
+            return;
+        }
         g.drawString(font, "No waypoint groups in this zone.",
                 x1, y1 + 8, TEXT, false);
         g.drawString(font, "Click \"New Group\" to start, or paste a codec into chat.",
@@ -407,7 +455,7 @@ public final class WaypointerScreen extends Screen {
         int rowBot = y1 + ROW_H + 2;
         int bg = selected ? SELECTED : hovered ? HOVER : 0;
         if (bg != 0) g.fill(x1, y1, x2, rowBot, bg);
-        int accent = group.temp() ? TEMPORARY_ACCENT : ACCENT;
+        int accent = isDianaGroup(group) ? DIANA_ACCENT : group.temp() ? TEMPORARY_ACCENT : ACCENT;
         if (selected) g.fill(x1, y1, x1 + 2, rowBot, accent);
 
         int textColor = group.enabled() ? TEXT : TEXT_MUTED;
@@ -415,7 +463,9 @@ public final class WaypointerScreen extends Screen {
         g.drawString(font, name, x1 + GAP + 2, y1 + 4, textColor, false);
 
         String sub = group.temp()
-                ? group.size() + " temp pts  " + Zone.fromId(group.zoneId()).displayName()
+                ? group.size() + (isDianaGroup(group)
+                        ? " Diana pts  Hub"
+                        : " temp pts  " + Zone.fromId(group.zoneId()).displayName())
                 : group.size() + " pts  @" + group.currentIndex()
                         + "  " + loadModeLabel(group);
         g.drawString(font, sub, x1 + GAP + 2, y1 + 14, TEXT_DIM, false);
@@ -519,7 +569,7 @@ public final class WaypointerScreen extends Screen {
     // --- actions -----------------------------------------------------------------------------
 
     private void createGroup() {
-        if (isTemporaryZone(selectedZoneId)) {
+        if (isTemporaryZone(selectedZoneId) || isDianaZone(selectedZoneId)) {
             Zone current = manager.currentZone();
             selectedZoneId = current == null ? Zone.UNKNOWN.id() : current.id();
         }

--- a/src/client/resources/waypointer.client.mixins.json
+++ b/src/client/resources/waypointer.client.mixins.json
@@ -2,7 +2,9 @@
     "required": true,
     "package": "dev.ethan.waypointer.mixin.client",
     "compatibilityLevel": "JAVA_21",
-    "client": [],
+    "client": [
+        "ClientPacketListenerMixin"
+    ],
     "injectors": {
         "defaultRequire": 1
     }

--- a/src/main/java/dev/ethan/waypointer/config/WaypointerConfig.java
+++ b/src/main/java/dev/ethan/waypointer/config/WaypointerConfig.java
@@ -7,6 +7,8 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import dev.ethan.waypointer.Waypointer;
 import dev.ethan.waypointer.core.Waypoint;
+import dev.ethan.waypointer.diana.DianaRareMob;
+import dev.ethan.waypointer.diana.DianaWarp;
 import net.fabricmc.loader.api.FabricLoader;
 
 import java.io.IOException;
@@ -53,7 +55,7 @@ public final class WaypointerConfig {
 
     private static final String FILE_NAME = "config.json";
     private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
-    private static final int CONFIG_SCHEMA_VERSION = 2;
+    private static final int CONFIG_SCHEMA_VERSION = 7;
 
     // Progression
     private int configSchemaVersion = CONFIG_SCHEMA_VERSION;
@@ -183,9 +185,6 @@ public final class WaypointerConfig {
     private BeaconBeamMode beaconBeamMode = BeaconBeamMode.OFF;
     private boolean beaconBeamExtendsBelowWaypoint = false;
 
-    // Zone detection
-    private boolean preferScoreboardFallback = false;
-
     // Quality-of-life
     private boolean chatCoordDetection = true;
     /**
@@ -214,29 +213,14 @@ public final class WaypointerConfig {
      * This is transient render focus, not a persistent route enable/disable.
      */
     private boolean focusTempWaypoints = false;
+    /**
+     * Optional cleanup for temporary waypoints: when the player enters the
+     * waypoint's reach radius, remove the temp marker immediately. Time-based
+     * temps can still expire first; this is an additional "whichever happens
+     * first" cleanup path.
+     */
+    private boolean deleteTempWaypointsWhenReached = false;
     private boolean chatCodecDetection = true;
-    /** Default exports drop names; set to {@code true} to include them at the cost of length. */
-    private boolean exportIncludeNames = false;
-    /** Default exports drop colors so shared routes inherit the recipient's palette. */
-    private boolean exportIncludeColors = false;
-    /**
-     * Per-waypoint custom radii. Off by default because most routes use the
-     * group default radius; including them only matters when the sender
-     * deliberately tuned individual waypoints.
-     */
-    private boolean exportIncludeRadii = false;
-    /**
-     * Per-waypoint flags (currently just "shown") -- almost always identical to
-     * defaults, so off by default to keep payloads short.
-     */
-    private boolean exportIncludeWaypointFlags = false;
-    /**
-     * Group-level metadata: gradient mode, load mode, custom default radius.
-     * On by default because a group with a non-default radius or sequenced load
-     * mode will play very differently if these are stripped, and a recipient
-     * has no way to know the original intent.
-     */
-    private boolean exportIncludeGroupMeta = true;
     /**
      * Hidden feature flag for the in-progress dungeon waypoint subsystem.
      * Default-off keeps beta builds from registering commands, renderers, tick
@@ -284,6 +268,64 @@ public final class WaypointerConfig {
     private int tempDefaultMode = Waypoint.TEMP_TIME;
     /** Default duration (minutes) for time-based temp waypoints. */
     private int tempDefaultDurationMin = 1;
+    /**
+     * Detects real Diana burrow particles in the Hub and renders high-confidence
+     * start/mob/treasure burrows plus conservative Ancestral Spade arrow guesses.
+     */
+    private boolean dianaBurrowWaypoints = true;
+    private boolean dianaShowStartBurrows = true;
+    private boolean dianaShowMobBurrows = true;
+    private boolean dianaShowTreasureBurrows = true;
+    /**
+     * Render Ancestral Spade estimate waypoints. Confirmed burrow particles still
+     * render when this is off; only predicted "Burrow" estimate markers
+     * are suppressed.
+     */
+    private boolean dianaSpadeEstimateWaypoints = true;
+    private String dianaEstimateWaypointName = "Burrow";
+    private int dianaEstimateWaypointColor = 0x4FE05A;
+    private int dianaStartBurrowColor = 0x4FE05A;
+    private int dianaMobBurrowColor = 0xFF4040;
+    private int dianaTreasureBurrowColor = 0xFFB02E;
+    private int dianaEstimateMinSamples = 8;
+    private double dianaEstimateStabilityRadius = 4.5;
+    private boolean dianaWarpAssist = true;
+    private boolean dianaWarpPrompt = true;
+    private double dianaWarpMinSavings = 45.0;
+    private boolean dianaWarpHub = true;
+    private boolean dianaWarpCastle = true;
+    private boolean dianaWarpMuseum = true;
+    private boolean dianaWarpWizard = true;
+    private boolean dianaWarpStonks = true;
+    private boolean dianaWarpDa = false;
+    private boolean dianaWarpCrypt = false;
+    /**
+     * Hide start burrows while chat progress says the current Griffin chain is in
+     * progress. This prevents the Diana temp group from selecting a fresh start
+     * as the active target before the current chain is actually done.
+     */
+    private boolean dianaHideStartBurrowsUntilChainComplete = true;
+    /**
+     * Targeted Diana solver diagnostics written to latest.log. This stays off by
+     * default because normal users should not pay for or see solver chatter, but
+     * it is useful when tuning missed Ancestral Spade estimates.
+     */
+    private boolean dianaSpadeDebugLogging = false;
+    /**
+     * Early Diana support: detect SkyHanni-style rare mob / inquisitor share
+     * messages in chat and turn their coordinates into temporary Hub waypoints.
+     */
+    private boolean dianaRareMobWaypoints = true;
+    private boolean dianaRareMobPartySharing = true;
+    private boolean dianaShareMinosInquisitor = true;
+    private boolean dianaShareMinosChampion = false;
+    private boolean dianaShareKingMinos = false;
+    private boolean dianaShareGaiaConstruct = false;
+    private boolean dianaShareMinotaur = false;
+    private boolean dianaShareMinosHunter = false;
+    private boolean dianaShareSiameseLynx = false;
+    private boolean dianaShareManticore = false;
+    private boolean dianaShareSphinx = false;
 
     /**
      * Debounce window for config writes. Configs mutate in bursts (EditBox
@@ -344,6 +386,15 @@ public final class WaypointerConfig {
         if (schemaVersion < 2) {
             migrateIssue31TempDefaults();
         }
+        if (schemaVersion < 3) {
+            migrateDianaSettingsSimplification();
+        }
+        if (schemaVersion < 4) {
+            migrateDianaBurrowEstimateColor();
+        }
+        if (schemaVersion < 5) {
+            migrateDianaWarpSavingsThreshold();
+        }
         configSchemaVersion = CONFIG_SCHEMA_VERSION;
     }
 
@@ -362,6 +413,32 @@ public final class WaypointerConfig {
             changed = true;
         }
         migratedDuringLoad = changed;
+    }
+
+    private void migrateDianaSettingsSimplification() {
+        dianaShowStartBurrows = true;
+        dianaShowMobBurrows = true;
+        dianaShowTreasureBurrows = true;
+        dianaSpadeEstimateWaypoints = true;
+        dianaWarpPrompt = true;
+        dianaEstimateWaypointName = "Burrow";
+        dianaEstimateMinSamples = 8;
+        dianaEstimateStabilityRadius = 4.5;
+        migratedDuringLoad = true;
+    }
+
+    private void migrateDianaBurrowEstimateColor() {
+        if ((dianaEstimateWaypointColor & 0xFFFFFF) == 0x1E5E32) {
+            dianaEstimateWaypointColor = 0x4FE05A;
+            migratedDuringLoad = true;
+        }
+    }
+
+    private void migrateDianaWarpSavingsThreshold() {
+        if (Math.abs(dianaWarpMinSavings - 30.0) < 0.0001) {
+            dianaWarpMinSavings = 45.0;
+            migratedDuringLoad = true;
+        }
     }
 
     /**
@@ -428,7 +505,6 @@ public final class WaypointerConfig {
         return beaconBeamMode == null ? BeaconBeamMode.OFF : beaconBeamMode;
     }
     public boolean beaconBeamExtendsBelowWaypoint() { return beaconBeamExtendsBelowWaypoint; }
-    public boolean preferScoreboardFallback() { return preferScoreboardFallback; }
     public boolean chatCoordDetection()       { return chatCoordDetection; }
     public List<String> chatCoordSenderBlacklist() {
         ensureChatCoordSenderBlacklist();
@@ -446,12 +522,8 @@ public final class WaypointerConfig {
     public boolean autoAddChatTempWaypoints() { return autoAddChatTempWaypoints; }
     public boolean placeNewWaypointsBelowPlayer() { return placeNewWaypointsBelowPlayer; }
     public boolean focusTempWaypoints()       { return focusTempWaypoints; }
+    public boolean deleteTempWaypointsWhenReached() { return deleteTempWaypointsWhenReached; }
     public boolean chatCodecDetection()       { return chatCodecDetection; }
-    public boolean exportIncludeNames()        { return exportIncludeNames; }
-    public boolean exportIncludeColors()       { return exportIncludeColors; }
-    public boolean exportIncludeRadii()        { return exportIncludeRadii; }
-    public boolean exportIncludeWaypointFlags(){ return exportIncludeWaypointFlags; }
-    public boolean exportIncludeGroupMeta()    { return exportIncludeGroupMeta; }
     public boolean dungeonWaypointsFeatureEnabled() { return dungeonWaypointsFeatureEnabled; }
     public boolean skipAheadMechanicEnabled() { return skipAheadMechanicEnabled; }
     public boolean checkForUpdates()            { return checkForUpdates; }
@@ -463,6 +535,65 @@ public final class WaypointerConfig {
     }
     public int tempDefaultDurationMin()         { return Math.max(1, Math.min(24 * 60, tempDefaultDurationMin)); }
     public boolean tempWaypointsExpireByDefault() { return tempDefaultMode() == Waypoint.TEMP_TIME; }
+    public boolean dianaBurrowWaypoints()       { return dianaBurrowWaypoints; }
+    public boolean dianaShowStartBurrows()      { return dianaShowStartBurrows; }
+    public boolean dianaShowMobBurrows()        { return dianaShowMobBurrows; }
+    public boolean dianaShowTreasureBurrows()   { return dianaShowTreasureBurrows; }
+    public boolean dianaSpadeEstimateWaypoints() { return dianaSpadeEstimateWaypoints; }
+    public String dianaEstimateWaypointName() { return sanitizeDianaWaypointName(dianaEstimateWaypointName, "Burrow"); }
+    public int dianaEstimateWaypointColor() { return normalizeOptionalAlphaColor(dianaEstimateWaypointColor); }
+    public int dianaStartBurrowColor() { return normalizeOptionalAlphaColor(dianaStartBurrowColor); }
+    public int dianaMobBurrowColor() { return normalizeOptionalAlphaColor(dianaMobBurrowColor); }
+    public int dianaTreasureBurrowColor() { return normalizeOptionalAlphaColor(dianaTreasureBurrowColor); }
+    public int dianaEstimateMinSamples() { return Math.max(4, Math.min(24, dianaEstimateMinSamples)); }
+    public double dianaEstimateStabilityRadius() { return clamp(dianaEstimateStabilityRadius, 0.5, 16.0); }
+    public boolean dianaWarpAssist() { return dianaWarpAssist; }
+    public boolean dianaWarpPrompt() { return dianaWarpPrompt; }
+    public double dianaWarpMinSavings() { return clamp(dianaWarpMinSavings, 0.0, 300.0); }
+    public int dianaEnabledWarpCount() {
+        int count = 0;
+        for (DianaWarp warp : DianaWarp.values()) {
+            if (dianaWarpEnabled(warp)) count++;
+        }
+        return count;
+    }
+    public boolean dianaWarpEnabled(DianaWarp warp) {
+        if (warp == null) return false;
+        return switch (warp) {
+            case HUB -> dianaWarpHub;
+            case CASTLE -> dianaWarpCastle;
+            case MUSEUM -> dianaWarpMuseum;
+            case WIZARD -> dianaWarpWizard;
+            case STONKS -> dianaWarpStonks;
+            case DA -> dianaWarpDa;
+            case CRYPT -> dianaWarpCrypt;
+        };
+    }
+    public boolean dianaHideStartBurrowsUntilChainComplete() { return dianaHideStartBurrowsUntilChainComplete; }
+    public boolean dianaSpadeDebugLogging() { return dianaSpadeDebugLogging; }
+    public boolean dianaRareMobWaypoints()      { return dianaRareMobWaypoints; }
+    public boolean dianaRareMobPartySharing()   { return dianaRareMobPartySharing; }
+    public boolean dianaRareMobShareEnabled(DianaRareMob mob) {
+        if (mob == null) return false;
+        return switch (mob) {
+            case MINOS_INQUISITOR -> dianaShareMinosInquisitor;
+            case MINOS_CHAMPION -> dianaShareMinosChampion;
+            case KING_MINOS -> dianaShareKingMinos;
+            case GAIA_CONSTRUCT -> dianaShareGaiaConstruct;
+            case MINOTAUR -> dianaShareMinotaur;
+            case MINOS_HUNTER -> dianaShareMinosHunter;
+            case SIAMESE_LYNX -> dianaShareSiameseLynx;
+            case MANTICORE -> dianaShareManticore;
+            case SPHINX -> dianaShareSphinx;
+        };
+    }
+    public int dianaRareMobShareEnabledCount() {
+        int count = 0;
+        for (DianaRareMob mob : DianaRareMob.values()) {
+            if (dianaRareMobShareEnabled(mob)) count++;
+        }
+        return count;
+    }
     public long defaultTempExpiresAtMillis(long nowMillis) {
         return tempDefaultMode() == Waypoint.TEMP_TIME
                 ? nowMillis + (long) tempDefaultDurationMin() * 60_000L
@@ -504,7 +635,6 @@ public final class WaypointerConfig {
         this.hideReachedStaticWaypointsUntilCycleComplete = v;
         save();
     }
-    public void setPreferScoreboardFallback(boolean v) { this.preferScoreboardFallback = v; save(); }
     public void setChatCoordDetection(boolean v)       { this.chatCoordDetection = v; save(); }
     public boolean addChatCoordSenderBlacklist(String senderName) {
         String normalized = normalizeChatCoordSender(senderName);
@@ -535,12 +665,11 @@ public final class WaypointerConfig {
     public void setAutoAddChatTempWaypoints(boolean v) { this.autoAddChatTempWaypoints = v; save(); }
     public void setPlaceNewWaypointsBelowPlayer(boolean v) { this.placeNewWaypointsBelowPlayer = v; save(); }
     public void setFocusTempWaypoints(boolean v)       { this.focusTempWaypoints = v; save(); }
+    public void setDeleteTempWaypointsWhenReached(boolean v) {
+        this.deleteTempWaypointsWhenReached = v;
+        save();
+    }
     public void setChatCodecDetection(boolean v)       { this.chatCodecDetection = v; save(); }
-    public void setExportIncludeNames(boolean v)        { this.exportIncludeNames = v; save(); }
-    public void setExportIncludeColors(boolean v)       { this.exportIncludeColors = v; save(); }
-    public void setExportIncludeRadii(boolean v)        { this.exportIncludeRadii = v; save(); }
-    public void setExportIncludeWaypointFlags(boolean v){ this.exportIncludeWaypointFlags = v; save(); }
-    public void setExportIncludeGroupMeta(boolean v)    { this.exportIncludeGroupMeta = v; save(); }
     public void setDungeonWaypointsFeatureEnabled(boolean v) { this.dungeonWaypointsFeatureEnabled = v; save(); }
     public void setShowLabelBackdrop(boolean v)        { this.showLabelBackdrop = v; save(); }
     public void setMaxWaypointLabels(int v) {
@@ -583,9 +712,135 @@ public final class WaypointerConfig {
     public void setTempWaypointsExpireByDefault(boolean v) {
         setTempDefaultMode(v ? Waypoint.TEMP_TIME : Waypoint.TEMP_UNTIL_LEAVE);
     }
+    public void setDianaBurrowWaypoints(boolean v) { this.dianaBurrowWaypoints = v; save(); }
+    public void setDianaShowStartBurrows(boolean v) { this.dianaShowStartBurrows = v; save(); }
+    public void setDianaShowMobBurrows(boolean v) { this.dianaShowMobBurrows = v; save(); }
+    public void setDianaShowTreasureBurrows(boolean v) { this.dianaShowTreasureBurrows = v; save(); }
+    public void setDianaSpadeEstimateWaypoints(boolean v) { this.dianaSpadeEstimateWaypoints = v; save(); }
+    public void setDianaEstimateWaypointName(String v) {
+        this.dianaEstimateWaypointName = sanitizeDianaWaypointName(v, "Burrow");
+        save();
+    }
+    public void setDianaEstimateWaypointColor(int v) { this.dianaEstimateWaypointColor = normalizeOptionalAlphaColor(v); save(); }
+    public void setDianaStartBurrowColor(int v) { this.dianaStartBurrowColor = normalizeOptionalAlphaColor(v); save(); }
+    public void setDianaMobBurrowColor(int v) { this.dianaMobBurrowColor = normalizeOptionalAlphaColor(v); save(); }
+    public void setDianaTreasureBurrowColor(int v) { this.dianaTreasureBurrowColor = normalizeOptionalAlphaColor(v); save(); }
+    public void setDianaEstimateMinSamples(int v) {
+        this.dianaEstimateMinSamples = Math.max(4, Math.min(24, v));
+        save();
+    }
+    public void setDianaEstimateStabilityRadius(double v) {
+        if (!Double.isFinite(v)) return;
+        this.dianaEstimateStabilityRadius = clamp(v, 0.5, 16.0);
+        save();
+    }
+    public void setDianaWarpAssist(boolean v) { this.dianaWarpAssist = v; save(); }
+    public void setDianaWarpPrompt(boolean v) { this.dianaWarpPrompt = v; save(); }
+    public void setDianaWarpMinSavings(double v) {
+        if (!Double.isFinite(v)) return;
+        this.dianaWarpMinSavings = clamp(v, 0.0, 300.0);
+        save();
+    }
+    public void setDianaWarpEnabled(DianaWarp warp, boolean enabled) {
+        if (warp == null) return;
+        switch (warp) {
+            case HUB -> dianaWarpHub = enabled;
+            case CASTLE -> dianaWarpCastle = enabled;
+            case MUSEUM -> dianaWarpMuseum = enabled;
+            case WIZARD -> dianaWarpWizard = enabled;
+            case STONKS -> dianaWarpStonks = enabled;
+            case DA -> dianaWarpDa = enabled;
+            case CRYPT -> dianaWarpCrypt = enabled;
+        }
+        save();
+    }
+    public void setDianaHideStartBurrowsUntilChainComplete(boolean v) {
+        this.dianaHideStartBurrowsUntilChainComplete = v;
+        save();
+    }
+    public void setDianaSpadeDebugLogging(boolean v) { this.dianaSpadeDebugLogging = v; save(); }
+    public void setDianaRareMobWaypoints(boolean v) { this.dianaRareMobWaypoints = v; save(); }
+    public void setDianaRareMobPartySharing(boolean v) { this.dianaRareMobPartySharing = v; save(); }
+    public void setDianaRareMobShareEnabled(DianaRareMob mob, boolean enabled) {
+        if (mob == null) return;
+        switch (mob) {
+            case MINOS_INQUISITOR -> dianaShareMinosInquisitor = enabled;
+            case MINOS_CHAMPION -> dianaShareMinosChampion = enabled;
+            case KING_MINOS -> dianaShareKingMinos = enabled;
+            case GAIA_CONSTRUCT -> dianaShareGaiaConstruct = enabled;
+            case MINOTAUR -> dianaShareMinotaur = enabled;
+            case MINOS_HUNTER -> dianaShareMinosHunter = enabled;
+            case SIAMESE_LYNX -> dianaShareSiameseLynx = enabled;
+            case MANTICORE -> dianaShareManticore = enabled;
+            case SPHINX -> dianaShareSphinx = enabled;
+        }
+        save();
+    }
+
+    public void disableAllFeatures() {
+        matchTracerToWaypointColor = false;
+        showWaypointNames = false;
+        showWaypointDistances = false;
+        scaleWaypointTextWithDistance = false;
+        matchWaypointTextToWaypointColor = false;
+        showCompleted = false;
+        showTracer = false;
+        dimSequenceContextWaypoints = false;
+        hideTracerOnStaticRoutes = false;
+        hideWaypointsNearPlayer = false;
+        hideReachedStaticWaypointsUntilCycleComplete = false;
+        showLabelBackdrop = false;
+        beaconBeamExtendsBelowWaypoint = false;
+        chatCoordDetection = false;
+        autoAddChatTempWaypoints = false;
+        placeNewWaypointsBelowPlayer = false;
+        focusTempWaypoints = false;
+        deleteTempWaypointsWhenReached = false;
+        chatCodecDetection = false;
+        dungeonWaypointsFeatureEnabled = false;
+        skipAheadMechanicEnabled = false;
+        checkForUpdates = false;
+        irisShaderHudFallback = false;
+        dianaBurrowWaypoints = false;
+        dianaWarpAssist = false;
+        dianaSpadeDebugLogging = false;
+        for (DianaWarp warp : DianaWarp.values()) {
+            setDianaWarpEnabledInMemory(warp, false);
+        }
+        dianaHideStartBurrowsUntilChainComplete = false;
+        dianaRareMobWaypoints = false;
+        dianaRareMobPartySharing = false;
+        beaconBeamMode = BeaconBeamMode.OFF;
+        save();
+    }
 
     private static double clamp(double v, double lo, double hi) {
         return Math.max(lo, Math.min(hi, v));
+    }
+
+    private static int normalizeOptionalAlphaColor(int color) {
+        return (color & 0xFF000000) == 0 ? color & 0xFFFFFF : color;
+    }
+
+    private static String sanitizeDianaWaypointName(String value, String fallback) {
+        String cleaned = value == null ? "" : value
+                .replace('\u00A7', '&')
+                .replaceAll("\\p{Cntrl}", "")
+                .trim();
+        if (cleaned.isEmpty()) return fallback;
+        return cleaned.length() > 32 ? cleaned.substring(0, 32) : cleaned;
+    }
+
+    private void setDianaWarpEnabledInMemory(DianaWarp warp, boolean enabled) {
+        switch (warp) {
+            case HUB -> dianaWarpHub = enabled;
+            case CASTLE -> dianaWarpCastle = enabled;
+            case MUSEUM -> dianaWarpMuseum = enabled;
+            case WIZARD -> dianaWarpWizard = enabled;
+            case STONKS -> dianaWarpStonks = enabled;
+            case DA -> dianaWarpDa = enabled;
+            case CRYPT -> dianaWarpCrypt = enabled;
+        }
     }
 
     private void ensureChatCoordSenderBlacklist() {

--- a/src/main/java/dev/ethan/waypointer/config/WaypointerConfig.java
+++ b/src/main/java/dev/ethan/waypointer/config/WaypointerConfig.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import dev.ethan.waypointer.Waypointer;
+import dev.ethan.waypointer.codec.WaypointCodec;
 import dev.ethan.waypointer.core.Waypoint;
 import dev.ethan.waypointer.diana.DianaRareMob;
 import dev.ethan.waypointer.diana.DianaWarp;
@@ -220,6 +221,15 @@ public final class WaypointerConfig {
      * first" cleanup path.
      */
     private boolean deleteTempWaypointsWhenReached = false;
+    /**
+     * Defaults for {@code /wp export} and the export screen "reset" preset.
+     * Gson repopulates these when older configs still carry the same keys.
+     */
+    private boolean exportIncludeNames = true;
+    private boolean exportIncludeColors = false;
+    private boolean exportIncludeRadii = false;
+    private boolean exportIncludeWaypointFlags = false;
+    private boolean exportIncludeGroupMeta = true;
     private boolean chatCodecDetection = true;
     /**
      * Hidden feature flag for the in-progress dungeon waypoint subsystem.
@@ -523,6 +533,11 @@ public final class WaypointerConfig {
     public boolean placeNewWaypointsBelowPlayer() { return placeNewWaypointsBelowPlayer; }
     public boolean focusTempWaypoints()       { return focusTempWaypoints; }
     public boolean deleteTempWaypointsWhenReached() { return deleteTempWaypointsWhenReached; }
+    public boolean exportIncludeNames()         { return exportIncludeNames; }
+    public boolean exportIncludeColors()        { return exportIncludeColors; }
+    public boolean exportIncludeRadii()         { return exportIncludeRadii; }
+    public boolean exportIncludeWaypointFlags() { return exportIncludeWaypointFlags; }
+    public boolean exportIncludeGroupMeta()     { return exportIncludeGroupMeta; }
     public boolean chatCodecDetection()       { return chatCodecDetection; }
     public boolean dungeonWaypointsFeatureEnabled() { return dungeonWaypointsFeatureEnabled; }
     public boolean skipAheadMechanicEnabled() { return skipAheadMechanicEnabled; }
@@ -600,6 +615,22 @@ public final class WaypointerConfig {
                 : 0L;
     }
 
+    /** Snapshot for clipboard export and {@code /wp export} with no explicit override. */
+    public WaypointCodec.Options exportCodecOptions() {
+        return WaypointCodec.Options.builder()
+                .includeNames(exportIncludeNames)
+                .includeColors(exportIncludeColors)
+                .includeRadii(exportIncludeRadii)
+                .includeWaypointFlags(exportIncludeWaypointFlags)
+                .includeGroupMeta(exportIncludeGroupMeta)
+                .build();
+    }
+
+    /** Mutable builder seeded from persisted export toggles (export screen, reset). */
+    public WaypointCodec.Options.Builder exportCodecOptionsBuilder() {
+        return exportCodecOptions().toBuilder();
+    }
+
     public void setDefaultReachRadius(double v)        { this.defaultReachRadius = clamp(v, 0.5, 100); save(); }
     public void setResetProgressOnWorldJoin(boolean v) { this.resetProgressOnWorldJoin = v; save(); }
     public void setRestartRouteWhenComplete(boolean v) { this.restartRouteWhenComplete = v; save(); }
@@ -669,6 +700,11 @@ public final class WaypointerConfig {
         this.deleteTempWaypointsWhenReached = v;
         save();
     }
+    public void setExportIncludeNames(boolean v)         { this.exportIncludeNames = v; save(); }
+    public void setExportIncludeColors(boolean v)        { this.exportIncludeColors = v; save(); }
+    public void setExportIncludeRadii(boolean v)         { this.exportIncludeRadii = v; save(); }
+    public void setExportIncludeWaypointFlags(boolean v) { this.exportIncludeWaypointFlags = v; save(); }
+    public void setExportIncludeGroupMeta(boolean v)     { this.exportIncludeGroupMeta = v; save(); }
     public void setChatCodecDetection(boolean v)       { this.chatCodecDetection = v; save(); }
     public void setDungeonWaypointsFeatureEnabled(boolean v) { this.dungeonWaypointsFeatureEnabled = v; save(); }
     public void setShowLabelBackdrop(boolean v)        { this.showLabelBackdrop = v; save(); }

--- a/src/main/java/dev/ethan/waypointer/core/ActiveGroupManager.java
+++ b/src/main/java/dev/ethan/waypointer/core/ActiveGroupManager.java
@@ -1,5 +1,7 @@
 package dev.ethan.waypointer.core;
 
+import dev.ethan.waypointer.diana.DianaBurrowWaypointGroup;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -355,6 +357,9 @@ public final class ActiveGroupManager {
         boolean focusCleared = false;
         for (WaypointGroup group : byId.values()) {
             if (!group.temp() || !zoneId.equals(group.zoneId()) || group.isEmpty()) continue;
+            // Diana burrows are re-synced from particle state; removing markers here
+            // can desync the detector's signature cache (see DianaBurrowDetector).
+            if (DianaBurrowWaypointGroup.ID.equals(group.id())) continue;
 
             List<Integer> reached = new ArrayList<>();
             group.forEachNearbyIndex(px, py, pz, group.maxEffectiveRadius(), i -> {

--- a/src/main/java/dev/ethan/waypointer/core/ActiveGroupManager.java
+++ b/src/main/java/dev/ethan/waypointer/core/ActiveGroupManager.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -48,7 +49,7 @@ public final class ActiveGroupManager {
     // separate END_MAIN handlers, so rebuilding on every call burns avoidable
     // young-gen garbage. Invalidated on zone change and on fireDataChanged(),
     // which every mutation path funnels through.
-    private List<WaypointGroup> cachedActive;
+    private volatile List<WaypointGroup> cachedActive;
 
     public Zone currentZone() {
         return currentZone;
@@ -77,25 +78,30 @@ public final class ActiveGroupManager {
      * invalidation (zone change or data change).
      */
     public List<WaypointGroup> activeGroups() {
-        if (cachedActive != null) return cachedActive;
+        List<WaypointGroup> snapshot = cachedActive;
+        if (snapshot != null) return snapshot;
 
-        if (currentZone == null) {
-            cachedActive = Collections.emptyList();
-            return cachedActive;
+        Zone zone = currentZone;
+        if (zone == null) {
+            snapshot = Collections.emptyList();
+            cachedActive = snapshot;
+            return snapshot;
         }
-        String zoneId = currentZone.id();
+        String zoneId = zone.id();
         WaypointGroup focused = focusedTempGroupForZone(zoneId);
         if (focused != null) {
-            cachedActive = List.of(focused);
-            return cachedActive;
+            snapshot = List.of(focused);
+            cachedActive = snapshot;
+            return snapshot;
         }
 
         List<WaypointGroup> active = new ArrayList<>();
         for (WaypointGroup g : byId.values()) {
             if (g.enabled() && zoneId.equals(g.zoneId())) active.add(g);
         }
-        cachedActive = List.copyOf(active);
-        return cachedActive;
+        snapshot = List.copyOf(active);
+        cachedActive = snapshot;
+        return snapshot;
     }
 
     /**
@@ -329,6 +335,52 @@ public final class ActiveGroupManager {
         return removed;
     }
 
+    /**
+     * Remove temporary waypoints in the current zone when the player enters
+     * their reach radius. This is intentionally zone-scoped so standing at the
+     * same coordinates on another island cannot clear unrelated temp markers.
+     *
+     * @return number of temporary waypoints removed
+     */
+    public int removeReachedTempWaypoints(double px, double py, double pz) {
+        return removeReachedTempWaypoints(px, py, pz, waypoint -> true);
+    }
+
+    public int removeReachedTempWaypoints(double px, double py, double pz, Predicate<Waypoint> shouldRemove) {
+        if (currentZone == null) return 0;
+        Predicate<Waypoint> filter = shouldRemove == null ? waypoint -> true : shouldRemove;
+
+        int removed = 0;
+        String zoneId = currentZone.id();
+        boolean focusCleared = false;
+        for (WaypointGroup group : byId.values()) {
+            if (!group.temp() || !zoneId.equals(group.zoneId()) || group.isEmpty()) continue;
+
+            List<Integer> reached = new ArrayList<>();
+            group.forEachNearbyIndex(px, py, pz, group.maxEffectiveRadius(), i -> {
+                if (i < 0 || i >= group.size()) return true;
+                Waypoint waypoint = group.get(i);
+                if (!waypoint.isTemp()) return true;
+                if (!filter.test(waypoint)) return true;
+                if (isWithinReach(group, waypoint, px, py, pz)) reached.add(i);
+                return true;
+            });
+
+            if (reached.isEmpty()) continue;
+            if (!focusCleared) {
+                clearTempWaypointFocus();
+                focusCleared = true;
+            }
+            for (int i = reached.size() - 1; i >= 0; i--) {
+                group.remove(reached.get(i));
+                removed++;
+            }
+        }
+
+        if (removed > 0) fireDataChanged();
+        return removed;
+    }
+
     private static String sanitizeTempSourceName(String raw) {
         if (raw == null) return "";
         String trimmed = raw.trim();
@@ -370,6 +422,15 @@ public final class ActiveGroupManager {
 
     private static String normalizeSenderName(String senderName) {
         return senderName == null ? "" : senderName.trim();
+    }
+
+    private static boolean isWithinReach(WaypointGroup group, Waypoint waypoint,
+                                         double px, double py, double pz) {
+        double radius = group.effectiveRadius(waypoint);
+        double dx = (waypoint.x() + 0.5) - px;
+        double dy = (waypoint.y() + 0.5) - py;
+        double dz = (waypoint.z() + 0.5) - pz;
+        return dx * dx + dy * dy + dz * dz <= radius * radius;
     }
 
     public List<WaypointGroup> groupsForZone(String zoneId) {

--- a/src/main/java/dev/ethan/waypointer/diana/DianaBurrowType.java
+++ b/src/main/java/dev/ethan/waypointer/diana/DianaBurrowType.java
@@ -1,0 +1,24 @@
+package dev.ethan.waypointer.diana;
+
+public enum DianaBurrowType {
+    START("Start Burrow", 0x4FE05A),
+    MOB("Mob Burrow", 0xFF4040),
+    TREASURE("Treasure Burrow", 0xFFB02E),
+    GUESS("Burrow", 0x1E5E32);
+
+    private final String label;
+    private final int color;
+
+    DianaBurrowType(String label, int color) {
+        this.label = label;
+        this.color = color;
+    }
+
+    public String label() {
+        return label;
+    }
+
+    public int color() {
+        return color;
+    }
+}

--- a/src/main/java/dev/ethan/waypointer/diana/DianaBurrowWaypointGroup.java
+++ b/src/main/java/dev/ethan/waypointer/diana/DianaBurrowWaypointGroup.java
@@ -1,0 +1,13 @@
+package dev.ethan.waypointer.diana;
+
+/**
+ * Stable ID for the client-managed Diana burrow overlay group. Declared in the
+ * main module so {@link dev.ethan.waypointer.core.ActiveGroupManager} can skip
+ * reach-based temp cleanup without depending on client-only detector code.
+ */
+public final class DianaBurrowWaypointGroup {
+
+    public static final String ID = "diana::burrows";
+
+    private DianaBurrowWaypointGroup() {}
+}

--- a/src/main/java/dev/ethan/waypointer/diana/DianaRareMob.java
+++ b/src/main/java/dev/ethan/waypointer/diana/DianaRareMob.java
@@ -1,0 +1,65 @@
+package dev.ethan.waypointer.diana;
+
+import java.util.Locale;
+
+public enum DianaRareMob {
+    MINOS_INQUISITOR("Minos Inquisitor", true, "inq", "inquisitor", "minos inquisitor"),
+    MINOS_CHAMPION("Minos Champion", false, "champion", "minos champion"),
+    KING_MINOS("King Minos", false, "king", "king minos"),
+    GAIA_CONSTRUCT("Gaia Construct", false, "gaia construct"),
+    MINOTAUR("Minotaur", false, "minotaur"),
+    MINOS_HUNTER("Minos Hunter", false, "minos hunter"),
+    SIAMESE_LYNX("Siamese Lynx", false, "siamese lynx", "siamese lynxes"),
+    MANTICORE("Manticore", false, "manticore"),
+    SPHINX("Sphinx", false, "sphinx");
+
+    private final String label;
+    private final boolean sharedByDefault;
+    private final String[] needles;
+
+    DianaRareMob(String label, boolean sharedByDefault, String... needles) {
+        this.label = label;
+        this.sharedByDefault = sharedByDefault;
+        this.needles = needles;
+    }
+
+    public String label() {
+        return label;
+    }
+
+    public boolean sharedByDefault() {
+        return sharedByDefault;
+    }
+
+    public boolean matches(String text) {
+        String lower = text == null ? "" : text.toLowerCase(Locale.ROOT);
+        for (String needle : needles) {
+            if (containsToken(lower, needle)) return true;
+        }
+        return false;
+    }
+
+    private static boolean containsToken(String text, String needle) {
+        int index = text.indexOf(needle);
+        while (index >= 0) {
+            int before = index - 1;
+            int after = index + needle.length();
+            boolean leftBoundary = before < 0 || !isNameChar(text.charAt(before));
+            boolean rightBoundary = after >= text.length() || !isNameChar(text.charAt(after));
+            if (leftBoundary && rightBoundary) return true;
+            index = text.indexOf(needle, index + 1);
+        }
+        return false;
+    }
+
+    private static boolean isNameChar(char c) {
+        return Character.isLetterOrDigit(c) || c == '_';
+    }
+
+    public static DianaRareMob fromMobName(String mobName) {
+        for (DianaRareMob mob : values()) {
+            if (mob.matches(mobName)) return mob;
+        }
+        return null;
+    }
+}

--- a/src/main/java/dev/ethan/waypointer/diana/DianaRareMobShareParser.java
+++ b/src/main/java/dev/ethan/waypointer/diana/DianaRareMobShareParser.java
@@ -1,0 +1,89 @@
+package dev.ethan.waypointer.diana;
+
+import java.util.Locale;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class DianaRareMobShareParser {
+
+    private static final char FORMAT_PREFIX = '\u00A7';
+    private static final Pattern LABELED_COORDS = Pattern.compile(
+            "(?i)(?<player>.+?):\\s*x:\\s*(?<x>-?\\d+(?:\\.\\d+)?),?\\s*y:\\s*(?<y>-?\\d+(?:\\.\\d+)?),?\\s*z:\\s*(?<z>-?\\d+(?:\\.\\d+)?)(?:\\s*\\|\\s*(?<mob>[^|]+))?.*");
+    private static final Pattern INQUISITOR_COORDS = Pattern.compile(
+            "(?i)(?<player>.+?):\\s*A MINOS INQUISITOR has spawned near \\[.*?]\\s*at Coords\\s+(?<x>-?\\d+(?:\\.\\d+)?)\\s+(?<y>-?\\d+(?:\\.\\d+)?)\\s+(?<z>-?\\d+(?:\\.\\d+)?).*");
+    private static final Pattern USERNAME_TOKEN = Pattern.compile("\\b[A-Za-z0-9_]{3,16}\\b");
+    private static final Pattern BRACKETED_PREFIX = Pattern.compile("\\[[^\\]]*]");
+
+    private DianaRareMobShareParser() {}
+
+    public static Optional<Share> parse(String message) {
+        if (message == null || message.isBlank()) return Optional.empty();
+
+        String clean = stripLegacyFormatting(message);
+        Matcher inquisitor = INQUISITOR_COORDS.matcher(clean);
+        if (inquisitor.matches()) {
+            return Optional.of(share(inquisitor, "Minos Inquisitor"));
+        }
+
+        Matcher labeled = LABELED_COORDS.matcher(clean);
+        if (labeled.matches()) {
+            String mob = labeled.group("mob");
+            String mobName = cleanMobName(mob == null ? clean : mob);
+            if (mobName == null) return Optional.empty();
+            return Optional.of(share(labeled, mobName));
+        }
+
+        return Optional.empty();
+    }
+
+    private static Share share(Matcher matcher, String mobName) {
+        return new Share(
+                playerName(matcher.group("player")),
+                mobName,
+                blockCoord(matcher.group("x")),
+                blockCoord(matcher.group("y")),
+                blockCoord(matcher.group("z")));
+    }
+
+    private static int blockCoord(String raw) {
+        return (int) Math.round(Double.parseDouble(raw));
+    }
+
+    private static String cleanMobName(String raw) {
+        if (raw == null || raw.isBlank()) return null;
+        String cleaned = raw.trim().replaceAll("\\s+", " ");
+        String lower = cleaned.toLowerCase(Locale.ROOT);
+        DianaRareMob known = DianaRareMob.fromMobName(lower);
+        if (known != null) return known.label();
+        return null;
+    }
+
+    private static String playerName(String raw) {
+        if (raw == null || raw.isBlank()) return "Unknown";
+        String prefixless = raw;
+        int party = prefixless.lastIndexOf('>');
+        if (party >= 0) prefixless = prefixless.substring(party + 1);
+        prefixless = BRACKETED_PREFIX.matcher(prefixless).replaceAll(" ");
+
+        Matcher matcher = USERNAME_TOKEN.matcher(prefixless);
+        String last = "";
+        while (matcher.find()) last = matcher.group();
+        return last.isBlank() ? "Unknown" : last;
+    }
+
+    private static String stripLegacyFormatting(String text) {
+        StringBuilder out = new StringBuilder(text.length());
+        for (int i = 0; i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (c == FORMAT_PREFIX && i + 1 < text.length()) {
+                i++;
+                continue;
+            }
+            out.append(c);
+        }
+        return out.toString();
+    }
+
+    public record Share(String playerName, String mobName, int x, int y, int z) {}
+}

--- a/src/main/java/dev/ethan/waypointer/diana/DianaSpadeCurveSolver.java
+++ b/src/main/java/dev/ethan/waypointer/diana/DianaSpadeCurveSolver.java
@@ -1,0 +1,168 @@
+package dev.ethan.waypointer.diana;
+
+import java.util.List;
+import java.util.Optional;
+
+public final class DianaSpadeCurveSolver {
+
+    private static final int DEGREE = 3;
+    private static final int TERMS = DEGREE + 1;
+    private static final int MIN_SAMPLES = 4;
+    private static final double MAX_ENDPOINT_INDEX = 380.0;
+    private static final double EPSILON = 1.0E-9;
+
+    private DianaSpadeCurveSolver() {
+    }
+
+    public static Optional<Estimate> estimate(List<Sample> samples) {
+        if (samples.size() < MIN_SAMPLES) return Optional.empty();
+
+        double[][] coefficients = fitCubic(samples);
+        if (coefficients == null) return Optional.empty();
+
+        Vec3 tangent = new Vec3(coefficients[0][1], coefficients[1][1], coefficients[2][1]);
+        double tangentLength = tangent.length();
+        if (tangentLength < EPSILON) return Optional.empty();
+
+        double endpointIndex = endpointIndex(tangent);
+        if (!Double.isFinite(endpointIndex)
+                || endpointIndex < samples.size() - 3.0
+                || endpointIndex > MAX_ENDPOINT_INDEX) {
+            return Optional.empty();
+        }
+
+        Vec3 point = evaluate(coefficients, endpointIndex);
+        if (!point.isFinite()) return Optional.empty();
+
+        return Optional.of(new Estimate(point.x(), point.y(), point.z(), endpointIndex, samples.size()));
+    }
+
+    private static double[][] fitCubic(List<Sample> samples) {
+        double[][] normal = new double[TERMS][TERMS];
+        double[][] rhs = new double[3][TERMS];
+
+        for (int i = 0; i < samples.size(); i++) {
+            Sample sample = samples.get(i);
+            double t = i;
+            double[] basis = {1.0, t, t * t, t * t * t};
+            for (int row = 0; row < TERMS; row++) {
+                for (int col = 0; col < TERMS; col++) {
+                    normal[row][col] += basis[row] * basis[col];
+                }
+                rhs[0][row] += sample.x() * basis[row];
+                rhs[1][row] += sample.y() * basis[row];
+                rhs[2][row] += sample.z() * basis[row];
+            }
+        }
+
+        double[][] coefficients = new double[3][TERMS];
+        for (int dim = 0; dim < 3; dim++) {
+            double[] solved = solve(normal, rhs[dim]);
+            if (solved == null) return null;
+            coefficients[dim] = solved;
+        }
+        return coefficients;
+    }
+
+    private static double endpointIndex(Vec3 tangent) {
+        double horizontal = Math.hypot(tangent.x(), tangent.z());
+        if (horizontal < EPSILON) return Double.NaN;
+
+        double observedPitch = -Math.atan2(tangent.y(), horizontal);
+        double releaseAngle = invertSpadePitch(observedPitch);
+        double curveReach = Math.sqrt(Math.max(0.0, 25.0 - 24.0 * Math.sin(releaseAngle)));
+        return (3.0 * curveReach) / tangent.length();
+    }
+
+    private static double invertSpadePitch(double observedPitch) {
+        double low = -Math.PI / 2.0;
+        double high = Math.PI / 2.0;
+        for (int i = 0; i < 72; i++) {
+            double mid = (low + high) / 2.0;
+            double transformed = Math.atan2(Math.sin(mid) - 0.75, Math.cos(mid));
+            if (transformed < observedPitch) {
+                low = mid;
+            } else {
+                high = mid;
+            }
+        }
+        return (low + high) / 2.0;
+    }
+
+    private static Vec3 evaluate(double[][] coefficients, double t) {
+        double[] basis = {1.0, t, t * t, t * t * t};
+        return new Vec3(
+                dot(coefficients[0], basis),
+                dot(coefficients[1], basis),
+                dot(coefficients[2], basis));
+    }
+
+    private static double dot(double[] a, double[] b) {
+        double total = 0.0;
+        for (int i = 0; i < a.length; i++) {
+            total += a[i] * b[i];
+        }
+        return total;
+    }
+
+    private static double[] solve(double[][] sourceMatrix, double[] sourceRhs) {
+        int n = sourceRhs.length;
+        double[][] matrix = new double[n][n + 1];
+        for (int row = 0; row < n; row++) {
+            System.arraycopy(sourceMatrix[row], 0, matrix[row], 0, n);
+            matrix[row][n] = sourceRhs[row];
+        }
+
+        for (int col = 0; col < n; col++) {
+            int pivot = col;
+            for (int row = col + 1; row < n; row++) {
+                if (Math.abs(matrix[row][col]) > Math.abs(matrix[pivot][col])) {
+                    pivot = row;
+                }
+            }
+            if (Math.abs(matrix[pivot][col]) < EPSILON) return null;
+
+            if (pivot != col) {
+                double[] tmp = matrix[pivot];
+                matrix[pivot] = matrix[col];
+                matrix[col] = tmp;
+            }
+
+            double pivotValue = matrix[col][col];
+            for (int j = col; j <= n; j++) {
+                matrix[col][j] /= pivotValue;
+            }
+
+            for (int row = 0; row < n; row++) {
+                if (row == col) continue;
+                double factor = matrix[row][col];
+                if (Math.abs(factor) < EPSILON) continue;
+                for (int j = col; j <= n; j++) {
+                    matrix[row][j] -= factor * matrix[col][j];
+                }
+            }
+        }
+
+        double[] solution = new double[n];
+        for (int row = 0; row < n; row++) {
+            solution[row] = matrix[row][n];
+        }
+        return solution;
+    }
+
+    public record Sample(double x, double y, double z) {
+    }
+
+    public record Estimate(double x, double y, double z, double endpointIndex, int sampleCount) {
+    }
+
+    private record Vec3(double x, double y, double z) {
+        double length() {
+            return Math.sqrt(x * x + y * y + z * z);
+        }
+
+        boolean isFinite() {
+            return Double.isFinite(x) && Double.isFinite(y) && Double.isFinite(z);
+        }
+    }
+}

--- a/src/main/java/dev/ethan/waypointer/diana/DianaWarp.java
+++ b/src/main/java/dev/ethan/waypointer/diana/DianaWarp.java
@@ -1,0 +1,37 @@
+package dev.ethan.waypointer.diana;
+
+public enum DianaWarp {
+    HUB("hub", "Hub", "warp hub", 0, 77, 0, true),
+    CASTLE("castle", "Castle", "warp castle", -250, 130, 45, true),
+    MUSEUM("museum", "Museum", "warp museum", 29, 72, 1, true),
+    WIZARD("wizard", "Wizard", "warp wizard", 44, 119, 93, true),
+    STONKS("stonks", "Stonks", "warp stonks", -36, 70, -81, true),
+    DA("da", "Dark Auction", "warp da", 91, 75, 174, false),
+    CRYPT("crypt", "Crypt", "warp crypt", -160, 62, -106, false);
+
+    private final String id;
+    private final String label;
+    private final String command;
+    private final int x;
+    private final int y;
+    private final int z;
+    private final boolean defaultEnabled;
+
+    DianaWarp(String id, String label, String command, int x, int y, int z, boolean defaultEnabled) {
+        this.id = id;
+        this.label = label;
+        this.command = command;
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.defaultEnabled = defaultEnabled;
+    }
+
+    public String id() { return id; }
+    public String label() { return label; }
+    public String command() { return command; }
+    public int x() { return x; }
+    public int y() { return y; }
+    public int z() { return z; }
+    public boolean defaultEnabled() { return defaultEnabled; }
+}

--- a/src/main/resources/assets/waypointer/lang/en_us.json
+++ b/src/main/resources/assets/waypointer/lang/en_us.json
@@ -6,5 +6,6 @@
   "key.waypointer.reposition_add_waypoint": "Reposition Mode: Add Waypoint",
   "key.waypointer.reposition_add_named_waypoint": "Reposition Mode: Add Named Waypoint",
   "key.waypointer.add_temp_waypoint_here": "Add Temporary Waypoint at Player",
+  "key.waypointer.diana_warp_assist": "Diana Warp Assist",
   "key.category.waypointer.main": "Waypointer"
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,9 +29,7 @@
         "minecraft": "1.21.11",
         "java": ">=21",
         "fabric-api": "*",
-        "owo": ">=0.13.0"
-    },
-    "suggests": {
+        "owo": ">=0.13.0",
         "hypixel-mod-api": ">=1.0"
     }
 }

--- a/src/test/java/dev/ethan/waypointer/chat/CoordScannerTest.java
+++ b/src/test/java/dev/ethan/waypointer/chat/CoordScannerTest.java
@@ -326,7 +326,7 @@ class CoordScannerTest {
         assertTrue(blockRun.style().isBold());
         ClickEvent clickEvent = blockRun.style().getClickEvent();
         ClickEvent.RunCommand runCommand = assertInstanceOf(ClickEvent.RunCommand.class, clickEvent);
-        assertEquals("/waypointer blacklist add Babbur", runCommand.command());
+        assertEquals("/waypointer blacklist toggle Babbur", runCommand.command());
         assertNotNull(blockRun.style().getHoverEvent());
     }
 

--- a/src/test/java/dev/ethan/waypointer/config/WaypointerConfigTest.java
+++ b/src/test/java/dev/ethan/waypointer/config/WaypointerConfigTest.java
@@ -2,6 +2,8 @@ package dev.ethan.waypointer.config;
 
 import dev.ethan.waypointer.placement.PlayerWaypointPlacement;
 import dev.ethan.waypointer.core.Waypoint;
+import dev.ethan.waypointer.diana.DianaRareMob;
+import dev.ethan.waypointer.diana.DianaWarp;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -190,7 +192,7 @@ class WaypointerConfigTest {
     void currentSchemaKeepsExplicitTenMinuteTempDuration() {
         WaypointerConfig config = WaypointerConfig.fromJson("""
                 {
-                  "configSchemaVersion": 2,
+                  "configSchemaVersion": 6,
                   "autoAddChatTempWaypoints": true,
                   "tempDefaultMode": 1,
                   "tempDefaultDurationMin": 10
@@ -200,6 +202,32 @@ class WaypointerConfigTest {
         assertTrue(config.autoAddChatTempWaypoints());
         assertEquals(Waypoint.TEMP_TIME, config.tempDefaultMode());
         assertEquals(10, config.tempDefaultDurationMin());
+    }
+
+    @Test
+    void oldDianaSubsettingsMigrateBackToSimpleDefaults() {
+        WaypointerConfig config = WaypointerConfig.fromJson("""
+                {
+                  "configSchemaVersion": 2,
+                  "dianaShowStartBurrows": false,
+                  "dianaShowMobBurrows": false,
+                  "dianaShowTreasureBurrows": false,
+                  "dianaSpadeEstimateWaypoints": false,
+                  "dianaWarpPrompt": false,
+                  "dianaEstimateWaypointName": "Skyhook",
+                  "dianaEstimateMinSamples": 24,
+                  "dianaEstimateStabilityRadius": 16.0
+                }
+                """);
+
+        assertTrue(config.dianaShowStartBurrows());
+        assertTrue(config.dianaShowMobBurrows());
+        assertTrue(config.dianaShowTreasureBurrows());
+        assertTrue(config.dianaSpadeEstimateWaypoints());
+        assertTrue(config.dianaWarpPrompt());
+        assertEquals("Burrow", config.dianaEstimateWaypointName());
+        assertEquals(8, config.dianaEstimateMinSamples());
+        assertEquals(4.5, config.dianaEstimateStabilityRadius());
     }
 
     @Test
@@ -298,11 +326,40 @@ class WaypointerConfigTest {
 
         assertTrue(config.chatCoordDetection());
         assertFalse(config.autoAddChatTempWaypoints());
+        assertTrue(config.dianaBurrowWaypoints());
+        assertTrue(config.dianaShowStartBurrows());
+        assertTrue(config.dianaShowMobBurrows());
+        assertTrue(config.dianaShowTreasureBurrows());
+        assertTrue(config.dianaSpadeEstimateWaypoints());
+        assertEquals("Burrow", config.dianaEstimateWaypointName());
+        assertEquals(0x4FE05A, config.dianaEstimateWaypointColor());
+        assertEquals(0x4FE05A, config.dianaStartBurrowColor());
+        assertEquals(0xFF4040, config.dianaMobBurrowColor());
+        assertEquals(0xFFB02E, config.dianaTreasureBurrowColor());
+        assertEquals(8, config.dianaEstimateMinSamples());
+        assertEquals(4.5, config.dianaEstimateStabilityRadius());
+        assertTrue(config.dianaWarpAssist());
+        assertTrue(config.dianaWarpPrompt());
+        assertEquals(45.0, config.dianaWarpMinSavings());
+        assertTrue(config.dianaWarpEnabled(DianaWarp.HUB));
+        assertTrue(config.dianaWarpEnabled(DianaWarp.CASTLE));
+        assertTrue(config.dianaWarpEnabled(DianaWarp.MUSEUM));
+        assertTrue(config.dianaWarpEnabled(DianaWarp.WIZARD));
+        assertTrue(config.dianaWarpEnabled(DianaWarp.STONKS));
+        assertFalse(config.dianaWarpEnabled(DianaWarp.DA));
+        assertFalse(config.dianaWarpEnabled(DianaWarp.CRYPT));
+        assertEquals(5, config.dianaEnabledWarpCount());
+        assertTrue(config.dianaHideStartBurrowsUntilChainComplete());
+        assertFalse(config.dianaSpadeDebugLogging());
+        assertTrue(config.dianaRareMobWaypoints());
+        assertTrue(config.dianaRareMobPartySharing());
+        assertTrue(config.dianaRareMobShareEnabled(DianaRareMob.MINOS_INQUISITOR));
+        assertFalse(config.dianaRareMobShareEnabled(DianaRareMob.SIAMESE_LYNX));
+        assertEquals(1, config.dianaRareMobShareEnabledCount());
         assertTrue(config.placeNewWaypointsBelowPlayer());
+        assertFalse(config.deleteTempWaypointsWhenReached());
         assertTrue(config.chatCodecDetection());
         assertTrue(config.dimSequenceContextWaypoints());
-        assertFalse(config.exportIncludeColors());
-        assertTrue(config.exportIncludeGroupMeta());
     }
 
     @Test
@@ -364,6 +421,115 @@ class WaypointerConfigTest {
     }
 
     @Test
+    void tempWaypointDeleteWhenReachedCanBeEnabled() {
+        WaypointerConfig config = new WaypointerConfig();
+
+        assertFalse(config.deleteTempWaypointsWhenReached());
+
+        config.setDeleteTempWaypointsWhenReached(true);
+
+        assertTrue(config.deleteTempWaypointsWhenReached());
+    }
+
+    @Test
+    void dianaAppearanceAndEstimateTuningClampToUsefulBounds() {
+        WaypointerConfig config = new WaypointerConfig();
+
+        config.setDianaEstimateWaypointName("  &2Pretty Burrow  ");
+        config.setDianaEstimateWaypointColor(0xFF1E5E32);
+        config.setDianaEstimateMinSamples(2);
+        config.setDianaEstimateStabilityRadius(0.1);
+
+        assertEquals("&2Pretty Burrow", config.dianaEstimateWaypointName());
+        assertEquals(0xFF1E5E32, config.dianaEstimateWaypointColor());
+        assertEquals(4, config.dianaEstimateMinSamples());
+        assertEquals(0.5, config.dianaEstimateStabilityRadius());
+
+        config.setDianaEstimateWaypointName("");
+        config.setDianaEstimateMinSamples(99);
+        config.setDianaEstimateStabilityRadius(99.0);
+
+        assertEquals("Burrow", config.dianaEstimateWaypointName());
+        assertEquals(24, config.dianaEstimateMinSamples());
+        assertEquals(16.0, config.dianaEstimateStabilityRadius());
+    }
+
+    @Test
+    void oldDianaEstimateColorMigratesToBrightGreen() {
+        WaypointerConfig config = WaypointerConfig.fromJson("""
+                {
+                  "configSchemaVersion": 3,
+                  "dianaEstimateWaypointColor": 1990194
+                }
+                """);
+
+        assertEquals(0x4FE05A, config.dianaEstimateWaypointColor());
+    }
+
+    @Test
+    void oldDianaWarpSavingsThresholdMigratesToFortyFiveBlocks() {
+        WaypointerConfig config = WaypointerConfig.fromJson("""
+                {
+                  "configSchemaVersion": 4,
+                  "dianaWarpMinSavings": 30.0
+                }
+                """);
+
+        assertEquals(45.0, config.dianaWarpMinSavings());
+    }
+
+    @Test
+    void dianaWarpSettingsCanBeTunedAndClampToUsefulBounds() {
+        WaypointerConfig config = new WaypointerConfig();
+
+        config.setDianaWarpAssist(false);
+        config.setDianaWarpPrompt(false);
+        config.setDianaWarpMinSavings(-10.0);
+        config.setDianaWarpEnabled(DianaWarp.DA, true);
+        config.setDianaWarpEnabled(DianaWarp.HUB, false);
+
+        assertFalse(config.dianaWarpAssist());
+        assertFalse(config.dianaWarpPrompt());
+        assertEquals(0.0, config.dianaWarpMinSavings());
+        assertTrue(config.dianaWarpEnabled(DianaWarp.DA));
+        assertFalse(config.dianaWarpEnabled(DianaWarp.HUB));
+        assertEquals(5, config.dianaEnabledWarpCount());
+
+        config.setDianaWarpMinSavings(500.0);
+        assertEquals(300.0, config.dianaWarpMinSavings());
+
+        config.setDianaWarpMinSavings(42.0);
+        config.setDianaWarpMinSavings(Double.NaN);
+        assertEquals(42.0, config.dianaWarpMinSavings());
+    }
+
+    @Test
+    void dianaSpadeDebugLoggingDefaultsOffButCanBeEnabled() {
+        WaypointerConfig config = new WaypointerConfig();
+
+        assertFalse(config.dianaSpadeDebugLogging());
+
+        config.setDianaSpadeDebugLogging(true);
+
+        assertTrue(config.dianaSpadeDebugLogging());
+    }
+
+    @Test
+    void dianaRareMobPartySharingCanSelectMobs() {
+        WaypointerConfig config = new WaypointerConfig();
+
+        assertTrue(config.dianaRareMobPartySharing());
+        assertFalse(config.dianaRareMobShareEnabled(DianaRareMob.SIAMESE_LYNX));
+
+        config.setDianaRareMobPartySharing(false);
+        config.setDianaRareMobShareEnabled(DianaRareMob.SIAMESE_LYNX, true);
+
+        assertFalse(config.dianaRareMobPartySharing());
+        assertTrue(config.dianaRareMobShareEnabled(DianaRareMob.SIAMESE_LYNX));
+        assertEquals(2, config.dianaRareMobShareEnabledCount());
+    }
+
+    @Test
     void waypointTextColorMatchingDefaultsOnButCanBeDisabled() {
         WaypointerConfig config = new WaypointerConfig();
 
@@ -390,5 +556,32 @@ class WaypointerConfigTest {
         config.setIrisShaderHudFallback(true);
 
         assertTrue(config.irisShaderHudFallback());
+    }
+
+    @Test
+    void disableAllFeaturesTurnsOffFeatureToggles() {
+        WaypointerConfig config = new WaypointerConfig();
+        config.setBeaconBeamMode(WaypointerConfig.BeaconBeamMode.ALL_VISIBLE);
+        config.setDianaRareMobWaypoints(true);
+
+        config.disableAllFeatures();
+
+        assertFalse(config.showWaypointNames());
+        assertFalse(config.showWaypointDistances());
+        assertFalse(config.showTracer());
+        assertFalse(config.chatCoordDetection());
+        assertFalse(config.chatCodecDetection());
+        assertFalse(config.deleteTempWaypointsWhenReached());
+        assertFalse(config.dianaBurrowWaypoints());
+        assertFalse(config.dianaWarpAssist());
+        assertFalse(config.dianaSpadeDebugLogging());
+        for (DianaWarp warp : DianaWarp.values()) {
+            assertFalse(config.dianaWarpEnabled(warp));
+        }
+        assertFalse(config.dianaHideStartBurrowsUntilChainComplete());
+        assertFalse(config.dianaRareMobWaypoints());
+        assertFalse(config.dianaRareMobPartySharing());
+        assertFalse(config.checkForUpdates());
+        assertEquals(WaypointerConfig.BeaconBeamMode.OFF, config.beaconBeamMode());
     }
 }

--- a/src/test/java/dev/ethan/waypointer/core/WaypointGroupTest.java
+++ b/src/test/java/dev/ethan/waypointer/core/WaypointGroupTest.java
@@ -534,6 +534,58 @@ class WaypointGroupTest {
         assertEquals(List.of(route, bucket), manager.activeGroups());
     }
 
+    @Test
+    void manager_removeReachedTempWaypointsClearsReachedTempsInCurrentZone() {
+        ActiveGroupManager manager = new ActiveGroupManager();
+        manager.onZoneChanged(new Zone("hub", "Hub"));
+        WaypointGroup route = route();
+        route.setZoneId("hub");
+        manager.add(route);
+
+        WaypointGroup bucket = manager.addTempWaypoint(1, 70, 2);
+        manager.addTempWaypoint(30, 70, 2);
+        manager.focusTempWaypoint(bucket, 0);
+
+        int removed = manager.removeReachedTempWaypoints(1.5, 70.5, 2.5);
+
+        assertEquals(1, removed);
+        assertEquals(1, bucket.size());
+        assertEquals(30, bucket.get(0).x());
+        assertEquals(List.of(route, bucket), manager.activeGroups(),
+                "removing the focused temp waypoint should restore the normal active set");
+    }
+
+    @Test
+    void manager_removeReachedTempWaypointsOnlyTouchesCurrentZone() {
+        ActiveGroupManager manager = new ActiveGroupManager();
+        manager.onZoneChanged(new Zone("hub", "Hub"));
+        WaypointGroup hubBucket = manager.addTempWaypoint(1, 70, 2);
+
+        manager.onZoneChanged(new Zone("park", "The Park"));
+        WaypointGroup parkBucket = manager.addTempWaypoint(1, 70, 2);
+
+        int removed = manager.removeReachedTempWaypoints(1.5, 70.5, 2.5);
+
+        assertEquals(1, removed);
+        assertEquals(1, hubBucket.size());
+        assertEquals(0, parkBucket.size());
+    }
+
+    @Test
+    void manager_removeReachedTempWaypointsHonorsPredicate() {
+        ActiveGroupManager manager = new ActiveGroupManager();
+        manager.onZoneChanged(new Zone("hub", "Hub"));
+        WaypointGroup bucket = manager.addTempWaypoint(1, 70, 2, "Rare Mob from Babbur");
+        manager.addTempWaypoint(1, 70, 2, "Generic temp");
+
+        int removed = manager.removeReachedTempWaypoints(1.5, 70.5, 2.5,
+                waypoint -> waypoint.name().contains("from"));
+
+        assertEquals(1, removed);
+        assertEquals(1, bucket.size());
+        assertEquals("Generic temp", bucket.get(0).name());
+    }
+
     private static int[] visibleIndices(WaypointGroup group) {
         List<Integer> indices = new ArrayList<>();
         group.forEachVisibleIndex(indices::add);

--- a/src/test/java/dev/ethan/waypointer/diana/DianaRareMobShareParserTest.java
+++ b/src/test/java/dev/ethan/waypointer/diana/DianaRareMobShareParserTest.java
@@ -1,0 +1,75 @@
+package dev.ethan.waypointer.diana;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DianaRareMobShareParserTest {
+
+    @Test
+    void parsesSkyHanniLabeledRareMobShare() {
+        var parsed = DianaRareMobShareParser.parse(
+                "\u00A79Party \u00A78> \u00A7b[MVP\u00A79+\u00A7b] _088\u00A7f: \u00A7rx: 86, y: 73, z: -29 I dug up an inquisitor come over here!");
+
+        assertTrue(parsed.isPresent());
+        assertEquals("_088", parsed.get().playerName());
+        assertEquals("Minos Inquisitor", parsed.get().mobName());
+        assertEquals(86, parsed.get().x());
+        assertEquals(73, parsed.get().y());
+        assertEquals(-29, parsed.get().z());
+    }
+
+    @Test
+    void parsesSkyHanniMobNameSuffix() {
+        var parsed = DianaRareMobShareParser.parse(
+                "\u00A79Party \u00A78> \u00A76[MVP\u00A70++\u00A76] scaryron\u00A7f: \u00A7rx: -67, y: 75, z: 116 | Minos Inquisitor spawned at [ Mountain ]!");
+
+        assertTrue(parsed.isPresent());
+        assertEquals("scaryron", parsed.get().playerName());
+        assertEquals("Minos Inquisitor", parsed.get().mobName());
+        assertEquals(-67, parsed.get().x());
+        assertEquals(75, parsed.get().y());
+        assertEquals(116, parsed.get().z());
+    }
+
+    @Test
+    void parsesInquisitorSentenceShare() {
+        var parsed = DianaRareMobShareParser.parse(
+                "\u00A79Party \u00A78> UserName\u00A7f: \u00A7rA MINOS INQUISITOR has spawned near [Foraging Island ] at Coords 1 2 -3");
+
+        assertTrue(parsed.isPresent());
+        assertEquals("UserName", parsed.get().playerName());
+        assertEquals("Minos Inquisitor", parsed.get().mobName());
+        assertEquals(1, parsed.get().x());
+        assertEquals(2, parsed.get().y());
+        assertEquals(-3, parsed.get().z());
+    }
+
+    @Test
+    void normalizesKnownDianaMobNames() {
+        var parsed = DianaRareMobShareParser.parse(
+                "Party > Babbur: x: -10, y: 77, z: 42 | Siamese Lynxes spawned nearby!");
+
+        assertTrue(parsed.isPresent());
+        assertEquals("Siamese Lynx", parsed.get().mobName());
+    }
+
+    @Test
+    void parsesSboRareMobAliases() {
+        var parsed = DianaRareMobShareParser.parse(
+                "Party > Babbur: x: -10, y: 77, z: 42 | inq");
+
+        assertTrue(parsed.isPresent());
+        assertEquals("Minos Inquisitor", parsed.get().mobName());
+    }
+
+    @Test
+    void ignoresGenericCoordinateMessagesWithoutDianaMobContext() {
+        var parsed = DianaRareMobShareParser.parse(
+                "Party > Babbur: x: -10, y: 77, z: 42");
+
+        assertFalse(parsed.isPresent());
+    }
+}

--- a/src/test/java/dev/ethan/waypointer/diana/DianaSpadeCurveSolverTest.java
+++ b/src/test/java/dev/ethan/waypointer/diana/DianaSpadeCurveSolverTest.java
@@ -1,0 +1,58 @@
+package dev.ethan.waypointer.diana;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DianaSpadeCurveSolverTest {
+
+    @Test
+    void extrapolatesLongSpadeCurveToNegativeCoordinateBurrow() {
+        var estimate = DianaSpadeCurveSolver.estimate(List.of(
+                new DianaSpadeCurveSolver.Sample(-10.301, 76.748, -12.498),
+                new DianaSpadeCurveSolver.Sample(-10.604, 76.908, -12.516),
+                new DianaSpadeCurveSolver.Sample(-11.085, 77.057, -12.56),
+                new DianaSpadeCurveSolver.Sample(-11.736, 77.195, -12.63),
+                new DianaSpadeCurveSolver.Sample(-12.552, 77.322, -12.725),
+                new DianaSpadeCurveSolver.Sample(-13.525, 77.439, -12.843),
+                new DianaSpadeCurveSolver.Sample(-14.65, 77.545, -12.985),
+                new DianaSpadeCurveSolver.Sample(-15.918, 77.642, -13.149),
+                new DianaSpadeCurveSolver.Sample(-17.325, 77.728, -13.334),
+                new DianaSpadeCurveSolver.Sample(-18.862, 77.805, -13.539),
+                new DianaSpadeCurveSolver.Sample(-20.524, 77.873, -13.762),
+                new DianaSpadeCurveSolver.Sample(-22.303, 77.931, -14.004),
+                new DianaSpadeCurveSolver.Sample(-24.194, 77.98, -14.263),
+                new DianaSpadeCurveSolver.Sample(-26.189, 78.02, -14.538),
+                new DianaSpadeCurveSolver.Sample(-28.282, 78.052, -14.828),
+                new DianaSpadeCurveSolver.Sample(-30.466, 78.075, -15.131),
+                new DianaSpadeCurveSolver.Sample(-32.734, 78.089, -15.448),
+                new DianaSpadeCurveSolver.Sample(-35.081, 78.096, -15.778)));
+
+        assertTrue(estimate.isPresent());
+        assertEquals(-117, blockCoord(estimate.get().x()));
+        assertEquals(73, blockCoord(estimate.get().y() - 0.5));
+        assertEquals(-28, blockCoord(estimate.get().z()));
+    }
+
+    @Test
+    void handlesShortCurveWhenTheBurrowIsAlreadyClose() {
+        var estimate = DianaSpadeCurveSolver.estimate(List.of(
+                new DianaSpadeCurveSolver.Sample(-198.549, 89.479, 99.492),
+                new DianaSpadeCurveSolver.Sample(-196.918, 90.461, 97.829),
+                new DianaSpadeCurveSolver.Sample(-195.75, 90.498, 96.17),
+                new DianaSpadeCurveSolver.Sample(-194.993, 89.764, 94.744),
+                new DianaSpadeCurveSolver.Sample(-194.595, 88.431, 93.782)));
+
+        assertTrue(estimate.isPresent());
+        assertEquals(-195, blockCoord(estimate.get().x()));
+        assertEquals(86, blockCoord(estimate.get().y() - 0.5));
+        assertEquals(93, blockCoord(estimate.get().z()));
+    }
+
+    private static int blockCoord(double value) {
+        return (int) Math.floor(value);
+    }
+}


### PR DESCRIPTION
this pr just includes diana waypoint support and some ui/ux changes throughout the mod to make it easier to navigate. more to follow with that. needs review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a large new event-driven Diana subsystem (particle packet mixin + solvers + auto waypoint management) and reshapes settings/UI flows, which may affect performance, rendering, and user config behavior in the Hub.
> 
> **Overview**
> Adds **Diana support** in the Hub: a new particle/chat-driven detector creates and maintains temporary `diana::` waypoint groups for burrows (including spade-curve/arrow estimates) and for rare-mob share messages, plus optional party-chat auto-sharing of your own rare-mob digs.
> 
> Introduces **Diana warp assist** (new keybind) that selects an enabled `/warp` which meaningfully reduces travel distance to the active Diana estimate waypoint.
> 
> Reworks **settings and UX**: adds `Diana` and `Temp WPs` config pages, a settings search box with inline result controls, new Diana warp/mob sub-screens, and a “Disable all features” confirm action; updates the color picker to support opacity, and makes waypoint rendering respect per-color alpha + support multi-line labels.
> 
> Other behavior changes: chat coord “block sender” click now toggles blacklist (with new command + suggestions), `Temp Until Reached` cleanup can now apply to temp buckets (with an option to exclude Diana rare-mob waypoints), export defaults are sourced via `config.exportCodecOptions*()`, zone tracking now always uses `HypixelApiZoneSource` (drops scoreboard fallback), and renderers add null-safety for `activeGroups()` plus updated default label colors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa6ce8b1ad9f4b450df6db9570e3ccea22bc9c88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->