### PR TITLE
Add waypoint painting and happy snowman mode

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,4 +1,4 @@
-# Waypointer API 1.8.2
+# Waypointer API 1.8.3
 
 Waypointer exposes a client-side Fabric API for reading routes, creating saved
 user routes, rendering session-only markers and overlays, importing and
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    modImplementation "maven.modrinth:waypointer:1.8.2"
+    modImplementation "maven.modrinth:waypointer:1.8.3"
 }
 ```
 
@@ -34,7 +34,7 @@ directory instead:
 
 ```groovy
 dependencies {
-    modImplementation files("libs/waypointer-1.8.2-mc26.1.2.jar")
+    modImplementation files("libs/waypointer-1.8.3-mc26.1.2.jar")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ it does not produce one universal jar:
 - `build/libs/waypointer-<mod-version>-mc26.2.jar`
 
 Matching `-sources.jar` files are also generated. The current mod version is
-`1.8.2`.
+`1.8.3`.
 
 ## Testing
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ loader_version=0.19.3
 loom_version=1.17.12
 
 # Mod Properties
-mod_version=1.8.2
+mod_version=1.8.3
 maven_group=com.babbur.waypointer
 archives_base_name=waypointer
 

--- a/src/client/java/com/babbur/waypointer/WaypointerClient.java
+++ b/src/client/java/com/babbur/waypointer/WaypointerClient.java
@@ -32,6 +32,7 @@ import com.babbur.waypointer.progression.TempWaypointCleaner;
 import com.babbur.waypointer.progression.WorldJoinProgressReset;
 import com.babbur.waypointer.render.TracerRenderer;
 import com.babbur.waypointer.render.WaypointRenderer;
+import com.babbur.waypointer.render.HappySnowmanSession;
 import com.babbur.waypointer.screen.WaypointerGuiScreens;
 import com.babbur.waypointer.screen.WaypointerScreen;
 import net.fabricmc.api.ClientModInitializer;
@@ -113,6 +114,7 @@ public final class WaypointerClient implements ClientModInitializer {
         new ProximityTracker(manager, config, chestInteractionGuard).install();
         new TempWaypointCleaner(manager).install();
         new WorldJoinProgressReset(manager, config).install();
+        HappySnowmanSession.install();
         new WaypointRenderer(manager, config).install();
         new TracerRenderer(manager, config).install();
         WaypointRepositionMode.install();

--- a/src/client/java/com/babbur/waypointer/commands/WaypointerCommands.java
+++ b/src/client/java/com/babbur/waypointer/commands/WaypointerCommands.java
@@ -29,6 +29,7 @@ import com.babbur.waypointer.dungeon.data.DungeonRoomData;
 import com.babbur.waypointer.input.WaypointAddFlow;
 import com.babbur.waypointer.input.WaypointRepositionMode;
 import com.babbur.waypointer.placement.PlayerWaypointPlacement;
+import com.babbur.waypointer.render.HappySnowmanSession;
 import com.babbur.waypointer.screen.DebugInspectScreen;
 import com.babbur.waypointer.screen.ImportFeedback;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
@@ -95,6 +96,11 @@ public final class WaypointerCommands {
             register(dispatcher, "waypointer");
             register(dispatcher, "wptr");
             register(dispatcher, "wp");
+            dispatcher.register(literal("happysnowman").executes(ctx -> {
+                HappySnowmanSession.activate();
+                info(ctx.getSource(), "Happy snowman mode enabled for this server.");
+                return 1;
+            }));
             suggestionOverride.setClientRoot(dispatcher.getRoot().getChild("wp"));
         });
         suggestionOverride.install();
@@ -1725,7 +1731,7 @@ public final class WaypointerCommands {
         WaypointGroup target = manager.getOrCreateActiveGroup(config.skipAheadMechanicEnabled());
         target.add(storedCommandWaypoint(target, config, x, y, z, name));
         int index = target.size() - 1;
-        addFlow.afterWaypointAdded(target, index);
+        addFlow.afterWaypointAdded(target, index, config.showWaypointChatShareButtons());
         manager.fireDataChanged();
         return index;
     }
@@ -1735,7 +1741,7 @@ public final class WaypointerCommands {
                                           int x, int y, int z, String name) {
         if (target == null || index < 0 || index > target.size()) return -1;
         target.insert(index, storedCommandWaypoint(target, config, x, y, z, name));
-        addFlow.afterWaypointAdded(target, index);
+        addFlow.afterWaypointAdded(target, index, config.showWaypointChatShareButtons());
         return index;
     }
 
@@ -2140,7 +2146,7 @@ public final class WaypointerCommands {
             return result.groups().size();
         } catch (IllegalArgumentException e) {
             error(src, "Import failed: " + e.getMessage());
-            ImportFeedback.failure(e.getMessage());
+            ImportFeedback.failure("Invalid import text.");
             return 0;
         }
     }

--- a/src/client/java/com/babbur/waypointer/dungeon/DungeonRoomRouteSync.java
+++ b/src/client/java/com/babbur/waypointer/dungeon/DungeonRoomRouteSync.java
@@ -305,6 +305,8 @@ public final class DungeonRoomRouteSync {
         group.setGradientMode(WaypointGroup.GradientMode.MANUAL);
         group.setDefaultRadius(source.defaultRadius());
         group.setSkipAheadEnabled(source.skipAheadEnabled());
+        group.setPaint(source.paint());
+        group.setPaintEnabled(source.paintEnabled());
 
         List<Waypoint> waypoints = new ArrayList<>(source.size());
         for (Waypoint stored : source.waypoints()) {

--- a/src/client/java/com/babbur/waypointer/input/WaypointAddFlow.java
+++ b/src/client/java/com/babbur/waypointer/input/WaypointAddFlow.java
@@ -6,7 +6,11 @@ import com.babbur.waypointer.core.WaypointGroup;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.HoverEvent;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.Style;
 
 /**
  * Shared side-effects run on every "player just created a waypoint" event,
@@ -14,7 +18,7 @@ import net.minecraft.network.chat.Component;
  *
  * <p>Centralising the post-add behaviour prevents the bug where the rule was
  * added at one entry point but forgotten at another -- every add site now
- * funnels through {@link #afterWaypointAdded(WaypointGroup, int)} after mutating the
+ * funnels through {@link #afterWaypointAdded(WaypointGroup, int, boolean)} after mutating the
  * group, keeping the user-visible contract consistent.
  *
  * <p>The flow focuses the route on the newly-created waypoint, keeps the route
@@ -24,7 +28,8 @@ import net.minecraft.network.chat.Component;
  */
 public final class WaypointAddFlow {
 
-    public void afterWaypointAdded(WaypointGroup group, int waypointIndex) {
+    public void afterWaypointAdded(WaypointGroup group, int waypointIndex,
+                                   boolean showChatShareButtons) {
         if (group == null) return;
         if (group.temp()) return;
 
@@ -33,7 +38,7 @@ public final class WaypointAddFlow {
         if (skipAheadWasEnabled) {
             group.setSkipAheadEnabled(false);
         }
-        showWaypointAddedMessage(group, waypointIndex);
+        showWaypointAddedMessage(group, waypointIndex, showChatShareButtons);
         showCurrentWaypointFocusedMessage(group.name(), waypointIndex);
         if (skipAheadWasEnabled) {
             showSkipAheadDisabledMessage(group.name());
@@ -41,12 +46,31 @@ public final class WaypointAddFlow {
 
     }
 
-    private static void showWaypointAddedMessage(WaypointGroup group, int waypointIndex) {
+    private static void showWaypointAddedMessage(WaypointGroup group, int waypointIndex,
+                                                 boolean showChatShareButtons) {
         if (waypointIndex < 0 || waypointIndex >= group.size()) return;
         Waypoint waypoint = group.get(waypointIndex);
-        showChatFeedback(Component.literal("Added waypoint " + waypointIndex + " at "
-                + waypoint.x() + ", " + waypoint.y() + ", " + waypoint.z())
-                .withStyle(ChatFormatting.GREEN));
+        showChatFeedback(waypointAddedMessage(waypointIndex, waypoint, showChatShareButtons));
+    }
+
+    static Component waypointAddedMessage(int waypointIndex, Waypoint waypoint,
+                                          boolean showChatShareButtons) {
+        String coordinates = waypoint.x() + ", " + waypoint.y() + ", " + waypoint.z();
+        MutableComponent message = Component.literal("Added waypoint " + waypointIndex
+                + " at " + coordinates).withStyle(ChatFormatting.GREEN);
+        if (!showChatShareButtons) return message;
+        return message
+                .append(chatShareButton("All", "/ac " + coordinates))
+                .append(chatShareButton("Party", "/pc " + coordinates));
+    }
+
+    private static Component chatShareButton(String label, String command) {
+        return Component.literal(" [" + label + "]").withStyle(Style.EMPTY
+                .withColor(ChatFormatting.AQUA)
+                .withUnderlined(true)
+                .withClickEvent(new ClickEvent.RunCommand(command))
+                .withHoverEvent(new HoverEvent.ShowText(Component.literal("Send in "
+                        + label + " chat"))));
     }
 
     private static void showCurrentWaypointFocusedMessage(String groupName, int waypointIndex) {

--- a/src/client/java/com/babbur/waypointer/input/WaypointRepositionMode.java
+++ b/src/client/java/com/babbur/waypointer/input/WaypointRepositionMode.java
@@ -338,7 +338,8 @@ public final class WaypointRepositionMode {
         addStored(group, new Waypoint(pos.getX(), pos.getY(), pos.getZ(),
                 "", editConfig.defaultWaypointColor(), flags, 0.0));
         int index = group.size() - 1;
-        new WaypointAddFlow().afterWaypointAdded(group, index);
+        new WaypointAddFlow().afterWaypointAdded(group, index,
+                editConfig.showWaypointChatShareButtons());
         editManager.fireDataChanged();
         playEditSound(mc, editConfig);
         showStatus(mc, HELP_EDIT_ADDED);
@@ -759,7 +760,8 @@ public final class WaypointRepositionMode {
     }
 
     private static void finishAddedWaypoint(Minecraft mc, Session session, int index) {
-        new WaypointAddFlow().afterWaypointAdded(session.group, index);
+        new WaypointAddFlow().afterWaypointAdded(session.group, index,
+                session.config.showWaypointChatShareButtons());
         session.manager.fireDataChanged();
         playEditSound(mc, session.config);
         active = null;

--- a/src/client/java/com/babbur/waypointer/input/WaypointerKeybinds.java
+++ b/src/client/java/com/babbur/waypointer/input/WaypointerKeybinds.java
@@ -419,7 +419,8 @@ public final class WaypointerKeybinds {
         // Stored dungeon-room routes keep room-local coordinates.
         target.add(DungeonRoomWaypointPlacement.toStoredWaypoint(target, new Waypoint(
                 pos.x(), pos.y(), pos.z(), "", config.defaultWaypointColor(), flags, 0.0)));
-        addFlow.afterWaypointAdded(target, target.size() - 1);
+        addFlow.afterWaypointAdded(target, target.size() - 1,
+                config.showWaypointChatShareButtons());
         manager.fireDataChanged();
     }
 

--- a/src/client/java/com/babbur/waypointer/mixin/client/PlayerInfoMixin.java
+++ b/src/client/java/com/babbur/waypointer/mixin/client/PlayerInfoMixin.java
@@ -1,0 +1,17 @@
+package com.babbur.waypointer.mixin.client;
+
+import com.babbur.waypointer.render.HappySnowmanSession;
+import net.minecraft.client.multiplayer.PlayerInfo;
+import net.minecraft.world.entity.player.PlayerSkin;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(PlayerInfo.class)
+public abstract class PlayerInfoMixin {
+    @Inject(method = "getSkin", at = @At("RETURN"), cancellable = true)
+    private void waypointer$happySnowmanSkin(CallbackInfoReturnable<PlayerSkin> cir) {
+        cir.setReturnValue(HappySnowmanSession.override(cir.getReturnValue()));
+    }
+}

--- a/src/client/java/com/babbur/waypointer/render/HappySnowmanSession.java
+++ b/src/client/java/com/babbur/waypointer/render/HappySnowmanSession.java
@@ -1,0 +1,113 @@
+package com.babbur.waypointer.render;
+
+import com.babbur.waypointer.Waypointer;
+import com.babbur.waypointer.core.WaypointPaint;
+import com.mojang.blaze3d.platform.NativeImage;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientPacketListener;
+import net.minecraft.client.renderer.texture.DynamicTexture;
+import net.minecraft.core.ClientAsset;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.entity.player.PlayerModelType;
+import net.minecraft.world.entity.player.PlayerSkin;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Session-only visual override enabled by the intentionally unadvertised command. */
+public final class HappySnowmanSession {
+    private static final Identifier SKIN_ID =
+            Identifier.fromNamespaceAndPath(Waypointer.MOD_ID, "happy_snowman");
+    private static final ClientAsset.Texture SKIN_TEXTURE = new ClientAsset.Texture() {
+        @Override
+        public Identifier id() {
+            return SKIN_ID;
+        }
+
+        @Override
+        public Identifier texturePath() {
+            return SKIN_ID;
+        }
+    };
+    private static final String SKIN_PNG =
+            "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAMAAACdt4HsAAAAOVBMVEUAAAAAAAADUweq5f+u5f+05f+65f+84P/D5f/H5f/J5f/NAADS5f/T6//e8P/t5f/v9//3+//4jQBwcn8aAAAAAXRSTlMAQObYZgAAAldJREFUWMPtl90SmjAQhVXU9UTPMfT9H7YX2YUEiEJ70067OsOAy+cm+8PhdHIzAAAsjqeOpfeQbtfH+neAJAGAEoEe4GXpNgyvtAaQEglQpNgFvNN1SNfbYwOgUSIgElQXMNxfgyV7bQGyA/AJkCxdH/e0tQRJ2rOE4ZHS/d4HqFgPYMmGW7LbRhYkCfiWxvvjfbNrmiMoN5CUJEUqv9dD9c9x91lniVIwPtdDU0Aas85l6WflUSQQWalcf/QBWTq7STkA0odstICFHQZQmiDTJpAkdwDMuygA3lNxeQcg8gXUZTBdfl7Kxw/P5/NZjn4hOhGowrWSQrMShVUdCwO5ioISKbEqa2+q0uKTXxbBDqCOoAtQB1BCm0M9tATfrKj/snnRmYBh3mSYHwxVdgDSv24kNZ7l9TDf3/o1s5AS5ZkAKY25LklEZfp3CZDfwLJySpp6ixAFyZsr/FaA7M5Zms/9mrImgPv1AaWUS1vHEsqPLSAjfwNMexAtUvutNjGcyw7FBZ8LE6DyW6Qxluv95xMue1uLIoWp7YkVgNUM8D7WXAYVYLMOzBMdNWMWs4QEzARAgqH88eS3mgc+A8ysKe7KopStLeUti+Fx+lX7ywGXy6UZoM3wPBbF6ffsDwCc/tu/bku94OfcDVjqBSqTOgjAQhfwSARLvXBoCVt6odIFe7TzWi9sPg8+hL/QCx1d0AdIyuNCL4zK2rkP8AdjaIM4z/42cxCgBlDXxmGA9gMWemFxvieNS70wvQLsBTR6oamDPYCVXujpgm/vD7NeaHTBqpR/AqbwTaLwf8cgAAAAAElFTkSuQmCC";
+
+    private static boolean active;
+    private static ClientPacketListener activationConnection;
+    private static boolean textureRegistered;
+    private static WaypointPaint facePaint;
+
+    private HappySnowmanSession() {}
+
+    public static void install() {
+        ClientPlayConnectionEvents.JOIN.register((handler, sender, client) -> deactivate());
+        ClientPlayConnectionEvents.DISCONNECT.register((handler, client) -> deactivate());
+    }
+
+    public static void activate() {
+        ensureLoaded();
+        activationConnection = Minecraft.getInstance().getConnection();
+        active = activationConnection != null;
+    }
+
+    public static void deactivate() {
+        active = false;
+        activationConnection = null;
+    }
+
+    public static boolean active() {
+        if (active && Minecraft.getInstance().getConnection() != activationConnection) {
+            deactivate();
+        }
+        return active;
+    }
+
+    public static WaypointPaint facePaint() {
+        return active() ? facePaint : null;
+    }
+
+    public static PlayerSkin override(PlayerSkin original) {
+        if (!active() || original == null) return original;
+        return PlayerSkin.insecure(SKIN_TEXTURE, original.cape(), original.elytra(), PlayerModelType.WIDE);
+    }
+
+    private static void ensureLoaded() {
+        if (textureRegistered) return;
+        try {
+            NativeImage image = NativeImage.read(Base64.getDecoder().decode(SKIN_PNG));
+            facePaint = facePaint(image);
+            Minecraft.getInstance().getTextureManager().register(
+                    SKIN_ID, new DynamicTexture(() -> "happy_snowman", image));
+            textureRegistered = true;
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to load the happy snowman skin", e);
+        }
+    }
+
+    static WaypointPaint facePaint(NativeImage skin) {
+        Map<Integer, Integer> paletteSlots = new LinkedHashMap<>();
+        byte[] pixels = new byte[WaypointPaint.PIXEL_COUNT];
+        for (WaypointPaint.Face face : WaypointPaint.Face.values()) {
+            for (int y = 0; y < WaypointPaint.SIZE; y++) {
+                for (int x = 0; x < WaypointPaint.SIZE; x++) {
+                    int skinX = 8 + x / 2;
+                    int skinY = 8 + y / 2;
+                    int base = skin.getPixel(skinX, skinY);
+                    int overlay = skin.getPixel(40 + x / 2, skinY);
+                    int rgb = ((overlay >>> 24) != 0 ? overlay : base) & 0xFFFFFF;
+                    int slot = paletteSlots.computeIfAbsent(rgb, ignored -> paletteSlots.size());
+                    if (slot >= WaypointPaint.PALETTE_SIZE) {
+                        throw new IllegalStateException("Happy snowman face exceeds the waypoint palette");
+                    }
+                    pixels[WaypointPaint.pixelOffset(face, x, y)] = (byte) slot;
+                }
+            }
+        }
+        int[] palette = new int[WaypointPaint.PALETTE_SIZE];
+        paletteSlots.forEach((rgb, slot) -> palette[slot] = rgb);
+        return new WaypointPaint(palette, pixels);
+    }
+}

--- a/src/client/java/com/babbur/waypointer/render/RenderHelpers.java
+++ b/src/client/java/com/babbur/waypointer/render/RenderHelpers.java
@@ -2,6 +2,7 @@ package com.babbur.waypointer.render;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.babbur.waypointer.core.WaypointPaint;
 
 /**
  * Tiny render utilities shared by {@link WaypointRenderer} and {@link TracerRenderer}.
@@ -17,6 +18,7 @@ public final class RenderHelpers {
     // We use a chunky 3px so outlined boxes stay legible at distance and against
     // busy biomes -- 1px (vanilla default) was disappearing against grass and reeds.
     private static final float DEFAULT_LINE_WIDTH = 3.0f;
+    private static final int FULL_BRIGHT_LIGHT = 0x00F000F0;
 
     private RenderHelpers() {}
 
@@ -104,6 +106,45 @@ public final class RenderHelpers {
         quad(consumer, pose, x2, y1, z1, x2, y2, z1, x2, y2, z2, x2, y1, z2, r, g, b, a);
     }
 
+    /** Append a six-face textured box using WaypointPaint's 64x48 T-atlas. */
+    public static void emitTexturedBox(VertexConsumer consumer, PoseStack ps,
+                                       float x1, float y1, float z1,
+                                       float x2, float y2, float z2,
+                                       float alpha,
+                                       double cameraX, double cameraY, double cameraZ) {
+        int a = Math.round(Math.max(0.0f, Math.min(1.0f, alpha)) * 255.0f);
+        PoseStack.Pose pose = ps.last();
+        int visible = visibleTexturedFaces(x1, y1, z1, x2, y2, z2,
+                cameraX, cameraY, cameraZ);
+
+        if ((visible & 1 << WaypointPaint.Face.DOWN.ordinal()) != 0) texturedQuad(consumer, pose, WaypointPaint.Face.DOWN,
+                x1, y1, z1, x2, y1, z1, x2, y1, z2, x1, y1, z2, a);
+        if ((visible & 1 << WaypointPaint.Face.UP.ordinal()) != 0) texturedQuad(consumer, pose, WaypointPaint.Face.UP,
+                x1, y2, z2, x2, y2, z2, x2, y2, z1, x1, y2, z1, a);
+        if ((visible & 1 << WaypointPaint.Face.NORTH.ordinal()) != 0) texturedQuad(consumer, pose, WaypointPaint.Face.NORTH,
+                x1, y1, z1, x1, y2, z1, x2, y2, z1, x2, y1, z1, a);
+        if ((visible & 1 << WaypointPaint.Face.SOUTH.ordinal()) != 0) texturedQuad(consumer, pose, WaypointPaint.Face.SOUTH,
+                x2, y1, z2, x2, y2, z2, x1, y2, z2, x1, y1, z2, a);
+        if ((visible & 1 << WaypointPaint.Face.WEST.ordinal()) != 0) texturedQuad(consumer, pose, WaypointPaint.Face.WEST,
+                x1, y1, z2, x1, y2, z2, x1, y2, z1, x1, y1, z1, a);
+        if ((visible & 1 << WaypointPaint.Face.EAST.ordinal()) != 0) texturedQuad(consumer, pose, WaypointPaint.Face.EAST,
+                x2, y1, z1, x2, y2, z1, x2, y2, z2, x2, y1, z2, a);
+    }
+
+    /** Select only the camera-facing exterior planes so rear paint cannot bleed through. */
+    static int visibleTexturedFaces(float x1, float y1, float z1,
+                                    float x2, float y2, float z2,
+                                    double cameraX, double cameraY, double cameraZ) {
+        int faces = 0;
+        if (cameraY <= y1) faces |= 1 << WaypointPaint.Face.DOWN.ordinal();
+        else if (cameraY >= y2) faces |= 1 << WaypointPaint.Face.UP.ordinal();
+        if (cameraZ <= z1) faces |= 1 << WaypointPaint.Face.NORTH.ordinal();
+        else if (cameraZ >= z2) faces |= 1 << WaypointPaint.Face.SOUTH.ordinal();
+        if (cameraX <= x1) faces |= 1 << WaypointPaint.Face.WEST.ordinal();
+        else if (cameraX >= x2) faces |= 1 << WaypointPaint.Face.EAST.ordinal();
+        return faces;
+    }
+
     /**
      * Append the four side faces of a narrow vertical column.
      *
@@ -164,6 +205,37 @@ public final class RenderHelpers {
         c.addVertex(pose, x2, y2, z2).setColor(r, g, b, a);
         c.addVertex(pose, x3, y3, z3).setColor(r, g, b, a);
         c.addVertex(pose, x4, y4, z4).setColor(r, g, b, a);
+    }
+
+    private static void texturedQuad(VertexConsumer c, PoseStack.Pose pose,
+                                     WaypointPaint.Face face,
+                                     float x1, float y1, float z1,
+                                     float x2, float y2, float z2,
+                                     float x3, float y3, float z3,
+                                     float x4, float y4, float z4,
+                                     int alpha) {
+        float halfTexelU = 0.5f / WaypointPaintTextureCache.ATLAS_WIDTH;
+        float halfTexelV = 0.5f / WaypointPaintTextureCache.ATLAS_HEIGHT;
+        float u0 = face.atlasX() / (float) WaypointPaintTextureCache.ATLAS_WIDTH + halfTexelU;
+        float v0 = face.atlasY() / (float) WaypointPaintTextureCache.ATLAS_HEIGHT + halfTexelV;
+        float u1 = (face.atlasX() + WaypointPaint.SIZE)
+                / (float) WaypointPaintTextureCache.ATLAS_WIDTH - halfTexelU;
+        float v1 = (face.atlasY() + WaypointPaint.SIZE)
+                / (float) WaypointPaintTextureCache.ATLAS_HEIGHT - halfTexelV;
+
+        texturedVertex(c, pose, x1, y1, z1, u0, v1, alpha);
+        texturedVertex(c, pose, x2, y2, z2, u0, v0, alpha);
+        texturedVertex(c, pose, x3, y3, z3, u1, v0, alpha);
+        texturedVertex(c, pose, x4, y4, z4, u1, v1, alpha);
+    }
+
+    private static void texturedVertex(VertexConsumer consumer, PoseStack.Pose pose,
+                                       float x, float y, float z, float u, float v,
+                                       int alpha) {
+        consumer.addVertex(pose, x, y, z)
+                .setColor(255, 255, 255, alpha)
+                .setUv(u, v)
+                .setLight(FULL_BRIGHT_LIGHT);
     }
 
     private static void seg(VertexConsumer c, PoseStack.Pose pose,

--- a/src/client/java/com/babbur/waypointer/render/RenderSubmission.java
+++ b/src/client/java/com/babbur/waypointer/render/RenderSubmission.java
@@ -9,8 +9,10 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 
-/** Bridges Fabric's immediate 26.1 renderer and deferred 26.2 submit nodes. */
+/** Bridges Fabric world-render submission APIs across supported versions. */
 public final class RenderSubmission {
+
+    private static final int WORLD_OVERLAY_ORDER = Integer.MAX_VALUE;
 
     @FunctionalInterface
     public interface Geometry {
@@ -20,20 +22,23 @@ public final class RenderSubmission {
     private RenderSubmission() {}
 
     static boolean requiredBindingsAvailable() {
-        if (optionalPublicMethod(LevelRenderContext.class, "bufferSource") != null) {
-            return true;
-        }
         try {
             Class<?> collectorType = Class.forName(
                     "net.minecraft.client.renderer.SubmitNodeCollector");
+            Class<?> orderedCollectorType = Class.forName(
+                    "net.minecraft.client.renderer.OrderedSubmitNodeCollector");
             Class<?> rendererType = Class.forName(
                     "net.minecraft.client.renderer.SubmitNodeCollector$CustomGeometryRenderer");
-            return optionalPublicMethod(LevelRenderContext.class, "submitNodeCollector") != null
-                    && optionalPublicMethod(collectorType, "submitCustomGeometry",
-                            PoseStack.class, RenderType.class, rendererType) != null;
+            if (optionalPublicMethod(LevelRenderContext.class, "submitNodeCollector") != null
+                    && optionalPublicMethod(collectorType, "order", int.class) != null
+                    && optionalPublicMethod(orderedCollectorType, "submitCustomGeometry",
+                            PoseStack.class, RenderType.class, rendererType) != null) {
+                return true;
+            }
         } catch (ClassNotFoundException error) {
-            return false;
+            // Fall through to Fabric's older immediate-buffer API.
         }
+        return optionalPublicMethod(LevelRenderContext.class, "bufferSource") != null;
     }
 
     public static boolean submit(LevelRenderContext context, PoseStack poseStack,
@@ -42,14 +47,14 @@ public final class RenderSubmission {
             return false;
         }
 
-        Object buffers = invokeNoArgs(context, "bufferSource");
-        if (buffers != null) {
-            return submitImmediate(buffers, poseStack, renderType, geometry);
-        }
-
         Object collector = invokeNoArgs(context, "submitNodeCollector");
         if (collector != null) {
             return submitDeferred(collector, poseStack, renderType, geometry);
+        }
+
+        Object buffers = invokeNoArgs(context, "bufferSource");
+        if (buffers != null) {
+            return submitImmediate(buffers, poseStack, renderType, geometry);
         }
         throw new IllegalStateException("No supported Fabric world-render submission API is available");
     }
@@ -77,14 +82,21 @@ public final class RenderSubmission {
             ClassLoader loader = collector.getClass().getClassLoader();
             Class<?> collectorType = Class.forName(
                     "net.minecraft.client.renderer.SubmitNodeCollector", false, loader);
+            Class<?> orderedCollectorType = Class.forName(
+                    "net.minecraft.client.renderer.OrderedSubmitNodeCollector", false, loader);
             Class<?> rendererType = Class.forName(
                     "net.minecraft.client.renderer.SubmitNodeCollector$CustomGeometryRenderer",
                     false, loader);
             Object renderer = Proxy.newProxyInstance(loader, new Class<?>[]{rendererType},
                     geometryHandler(geometry));
-            Method submit = collectorType.getMethod(
+            // Vanilla world features use order 0. A separate final collection keeps
+            // their hash-ordered render types (notably item-frame maps) from flushing
+            // after Waypointer's through-wall overlays.
+            Method order = collectorType.getMethod("order", int.class);
+            Object orderedCollector = order.invoke(collector, WORLD_OVERLAY_ORDER);
+            Method submit = orderedCollectorType.getMethod(
                     "submitCustomGeometry", PoseStack.class, RenderType.class, rendererType);
-            submit.invoke(collector, poseStack, renderType, renderer);
+            submit.invoke(orderedCollector, poseStack, renderType, renderer);
             return true;
         } catch (ReflectiveOperationException error) {
             throw new IllegalStateException("Could not submit deferred render geometry", error);

--- a/src/client/java/com/babbur/waypointer/render/WaypointPaintTextureCache.java
+++ b/src/client/java/com/babbur/waypointer/render/WaypointPaintTextureCache.java
@@ -1,0 +1,87 @@
+package com.babbur.waypointer.render;
+
+import com.babbur.waypointer.Waypointer;
+import com.babbur.waypointer.core.WaypointPaint;
+import com.mojang.blaze3d.platform.NativeImage;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.rendertype.RenderType;
+import net.minecraft.client.renderer.texture.DynamicTexture;
+import net.minecraft.resources.Identifier;
+
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+/** Builds and caches the tiny 64x48 T-atlas used by painted waypoint boxes. */
+final class WaypointPaintTextureCache {
+
+    static final int ATLAS_WIDTH = WaypointPaint.SIZE * 4;
+    static final int ATLAS_HEIGHT = WaypointPaint.SIZE * 3;
+    private static final int MAX_TEXTURES = 64;
+    private static final AtomicLong SEQUENCE = new AtomicLong();
+    private static final Map<WaypointPaint, Entry> CACHE =
+            new LinkedHashMap<>(16, 0.75f, true);
+
+    record Entry(Identifier id, RenderType throughWalls, RenderType depthTested) {}
+
+    private WaypointPaintTextureCache() {}
+
+    static Entry get(WaypointPaint paint) {
+        Entry cached = CACHE.get(paint);
+        if (cached != null) return cached;
+
+        long sequence = SEQUENCE.incrementAndGet();
+        Identifier id = Identifier.fromNamespaceAndPath(
+                Waypointer.MOD_ID, "waypoint_paint_" + sequence);
+        DynamicTexture texture = new DynamicTexture(
+                () -> "waypointer_paint_" + sequence,
+                ATLAS_WIDTH, ATLAS_HEIGHT, false);
+        Minecraft.getInstance().getTextureManager().register(id, texture);
+        bake(texture, paint);
+
+        Entry entry = new Entry(
+                id,
+                WaypointerRenderPipelines.paintedQuads(id, false),
+                WaypointerRenderPipelines.paintedQuads(id, true));
+        CACHE.put(paint, entry);
+        evictOldTextures();
+        return entry;
+    }
+
+    private static void bake(DynamicTexture texture, WaypointPaint paint) {
+        NativeImage image = texture.getPixels();
+        if (image == null) return;
+        for (int y = 0; y < ATLAS_HEIGHT; y++) {
+            for (int x = 0; x < ATLAS_WIDTH; x++) {
+                image.setPixelABGR(x, y, 0);
+            }
+        }
+        for (WaypointPaint.Face face : WaypointPaint.Face.values()) {
+            for (int y = 0; y < WaypointPaint.SIZE; y++) {
+                for (int x = 0; x < WaypointPaint.SIZE; x++) {
+                    image.setPixelABGR(face.atlasX() + x, face.atlasY() + y,
+                            packAbgr(paint.color(face, x, y)));
+                }
+            }
+        }
+        texture.upload();
+    }
+
+    private static int packAbgr(int rgb) {
+        int r = (rgb >> 16) & 0xFF;
+        int g = (rgb >> 8) & 0xFF;
+        int b = rgb & 0xFF;
+        return 0xFF000000 | (b << 16) | (g << 8) | r;
+    }
+
+    private static void evictOldTextures() {
+        Minecraft minecraft = Minecraft.getInstance();
+        Iterator<Entry> entries = CACHE.values().iterator();
+        while (CACHE.size() > MAX_TEXTURES && entries.hasNext()) {
+            Entry oldest = entries.next();
+            entries.remove();
+            minecraft.getTextureManager().release(oldest.id());
+        }
+    }
+}

--- a/src/client/java/com/babbur/waypointer/render/WaypointRenderer.java
+++ b/src/client/java/com/babbur/waypointer/render/WaypointRenderer.java
@@ -9,6 +9,7 @@ import com.babbur.waypointer.core.ActiveGroupManager;
 import com.babbur.waypointer.core.RouteProgress;
 import com.babbur.waypointer.core.Waypoint;
 import com.babbur.waypointer.core.WaypointGroup;
+import com.babbur.waypointer.core.WaypointPaint;
 import com.babbur.waypointer.core.WaypointVisibility;
 import com.babbur.waypointer.dungeon.data.DungeonRoomData;
 import com.babbur.waypointer.input.WaypointRepositionMode;
@@ -237,14 +238,9 @@ public final class WaypointRenderer implements HudElement {
 
     // ---- world-space path: cube outlines -------------------------------------------------
 
-    /**
-     * Max alpha for the filled faces of a waypoint cube. The line outline is
-     * drawn at the state's full alpha, but if we fill at the same alpha the
-     * cube becomes an opaque block that obscures the world behind it. 35% was
-     * picked by eye: dense enough to read as a coloured volume against bright
-     * biomes, translucent enough that you can still see through it.
-     */
-    private static final float FILLED_ALPHA_SCALE = 0.35f;
+    /** The opacity setting is authoritative: 100% must produce opaque faces. */
+    private static final float FILLED_ALPHA_SCALE = 1.0f;
+    private static final float PAINTED_ALPHA_SCALE = 1.0f;
     private static final float BEAM_ALPHA_SCALE = 0.18f;
     private static final float BEAM_HALF_WIDTH = 0.12f;
     private static final float BEACON_TEXTURE_SCALE_THRESHOLD = 96.0f;
@@ -263,12 +259,14 @@ public final class WaypointRenderer implements HudElement {
         boolean drawLines = style != WaypointerConfig.BoxStyle.FILLED;
         boolean drawGlobalFill = style != WaypointerConfig.BoxStyle.OUTLINED;
         boolean drawFill  = drawGlobalFill || hasFilledSubwaypoint(groups);
+        WaypointPaint defaultPaint = config.waypointPainterDefaultPaint();
+        boolean drawPaint = hasPaintedGroup(groups, defaultPaint);
         boolean drawBeams = config.beaconBeamMode() != WaypointerConfig.BeaconBeamMode.OFF;
         boolean drawTexturedBeams = drawBeams && config.useBeaconBeamTextures();
         boolean drawFlatBeams = drawBeams && !drawTexturedBeams;
         boolean drawRouteLines = config.showRouteLines();
         boolean drawDungeonEntryPaths = config.showDungeonEntryPathToFirstWaypoint();
-        if (!drawLines && !drawFill && !drawBeams && !drawRouteLines && !drawDungeonEntryPaths) return;
+        if (!drawLines && !drawFill && !drawPaint && !drawBeams && !drawRouteLines && !drawDungeonEntryPaths) return;
         if (config.beaconOpacity() <= 0.0 && !drawRouteLines && !drawDungeonEntryPaths) return;
         boolean hasDepthCheckedWaypoints = hasDepthCheckedWaypoint(groups);
         boolean hasThroughWallWaypoints = hasThroughWallWaypoint(groups) || drawDungeonEntryPaths;
@@ -328,6 +326,32 @@ public final class WaypointRenderer implements HudElement {
                 }
             });
         }
+        if (drawPaint && hasThroughWallWaypoints) {
+            for (WaypointGroup g : groups) {
+                WaypointPaint paint = effectivePaint(g, defaultPaint);
+                if (paint == null) continue;
+                WaypointPaintTextureCache.Entry paintTexture =
+                        WaypointPaintTextureCache.get(paint);
+                RenderSubmission.submit(ctx, ps, paintTexture.throughWalls(),
+                        (quads, submittedPose) -> emitPaintedBoxes(
+                                submittedPose, quads, level, g, camPos, playerPos,
+                                maxStaticDistanceSq, nearHideDistanceSq,
+                                false, mc, screenW, screenH));
+            }
+        }
+        if (drawPaint && hasDepthCheckedWaypoints) {
+            for (WaypointGroup g : groups) {
+                WaypointPaint paint = effectivePaint(g, defaultPaint);
+                if (paint == null) continue;
+                WaypointPaintTextureCache.Entry paintTexture =
+                        WaypointPaintTextureCache.get(paint);
+                RenderSubmission.submit(ctx, ps, paintTexture.depthTested(),
+                        (quads, submittedPose) -> emitPaintedBoxes(
+                                submittedPose, quads, level, g, camPos, playerPos,
+                                maxStaticDistanceSq, nearHideDistanceSq,
+                                true, mc, screenW, screenH));
+            }
+        }
         if ((drawFlatBeams || drawFill) && hasThroughWallWaypoints) {
             RenderType quadType = WaypointerRenderPipelines.quadsThroughWalls();
             int minY = beamMinY(mc);
@@ -342,6 +366,7 @@ public final class WaypointRenderer implements HudElement {
                 }
                 if (drawFill) {
                     for (WaypointGroup g : groups) {
+                        if (effectivePaint(g, defaultPaint) != null) continue;
                         emitFilledBoxes(submittedPose, quads, level, g, camPos, playerPos,
                                 maxStaticDistanceSq, nearHideDistanceSq, drawGlobalFill,
                                 false, mc, screenW, screenH);
@@ -363,6 +388,7 @@ public final class WaypointRenderer implements HudElement {
                 }
                 if (drawFill) {
                     for (WaypointGroup g : groups) {
+                        if (effectivePaint(g, defaultPaint) != null) continue;
                         emitFilledBoxes(submittedPose, quads, level, g, camPos, playerPos,
                                 maxStaticDistanceSq, nearHideDistanceSq, drawGlobalFill,
                                 true, mc, screenW, screenH);
@@ -705,6 +731,24 @@ public final class WaypointRenderer implements HudElement {
         return false;
     }
 
+    static boolean hasPaintedGroup(Iterable<WaypointGroup> groups) {
+        return hasPaintedGroup(groups, null);
+    }
+
+    static boolean hasPaintedGroup(Iterable<WaypointGroup> groups, WaypointPaint defaultPaint) {
+        for (WaypointGroup group : groups) {
+            if (effectivePaint(group, defaultPaint) != null && !group.isEmpty()) return true;
+        }
+        return false;
+    }
+
+    static WaypointPaint effectivePaint(WaypointGroup group, WaypointPaint defaultPaint) {
+        WaypointPaint happySnowmanPaint = HappySnowmanSession.facePaint();
+        if (happySnowmanPaint != null) return happySnowmanPaint;
+        if (group == null || !group.paintEnabled()) return null;
+        return group.paint() != null ? group.paint() : defaultPaint;
+    }
+
     private static boolean isSmallSubwaypoint(Waypoint waypoint) {
         return waypoint != null
                 && waypoint.isSubwaypoint()
@@ -881,6 +925,38 @@ public final class WaypointRenderer implements HudElement {
             float z2 = (float) waypointBoxBoundsScratch[BOX_MAX_Z];
             RenderHelpers.emitFilledBox(quads, ps, x1, y1, z1, x2, y2, z2,
                     w.color(), alpha * FILLED_ALPHA_SCALE);
+        });
+    }
+
+    private void emitPaintedBoxes(PoseStack ps, VertexConsumer quads,
+                                  ClientLevel level, WaypointGroup group,
+                                  Vec3 camPos, Vec3 playerPos,
+                                  double maxStaticDistanceSq, double nearHideDistanceSq,
+                                  boolean depthCheckedPass, Minecraft mc,
+                                  int screenW, int screenH) {
+        int currentIndex = group.currentIndex();
+        boolean showCompleted = config.showCompleted();
+        float beaconOpacity = (float) config.beaconOpacity();
+
+        group.forEachVisibleIndex(i -> {
+            if (!shouldRenderWaypointWorld(group, i, currentIndex, showCompleted,
+                    camPos, playerPos, maxStaticDistanceSq, nearHideDistanceSq,
+                    depthCheckedPass, mc, level, screenW, screenH)) {
+                return;
+            }
+
+            Waypoint waypoint = group.get(i);
+            State state = stateFor(group, i, currentIndex);
+            float alpha = alphaFor(group, state) * beaconOpacity * PAINTED_ALPHA_SCALE;
+            populateWaypointBoxBounds(level, waypoint, waypointBoxBoundsScratch);
+            RenderHelpers.emitTexturedBox(quads, ps,
+                    (float) waypointBoxBoundsScratch[BOX_MIN_X],
+                    (float) waypointBoxBoundsScratch[BOX_MIN_Y],
+                    (float) waypointBoxBoundsScratch[BOX_MIN_Z],
+                    (float) waypointBoxBoundsScratch[BOX_MAX_X],
+                    (float) waypointBoxBoundsScratch[BOX_MAX_Y],
+                    (float) waypointBoxBoundsScratch[BOX_MAX_Z],
+                    alpha, camPos.x, camPos.y, camPos.z);
         });
     }
 

--- a/src/client/java/com/babbur/waypointer/render/WaypointerRenderPipelines.java
+++ b/src/client/java/com/babbur/waypointer/render/WaypointerRenderPipelines.java
@@ -35,8 +35,11 @@ public final class WaypointerRenderPipelines {
     private static RenderType quadsDepthTested;
     private static RenderType beaconBeamThroughWalls;
     private static RenderType beaconBeamDepthTested;
+    private static RenderPipeline paintedQuadsThroughWallsPipeline;
+    private static RenderPipeline paintedQuadsDepthTestedPipeline;
     private static final DepthStencilState NO_DEPTH_TEST = new DepthStencilState(CompareOp.ALWAYS_PASS, false);
-    private static final DepthStencilState LEQUAL_DEPTH_TEST = new DepthStencilState(CompareOp.LESS_THAN_OR_EQUAL, false);
+    private static final DepthStencilState DEPTH_TESTED =
+            new DepthStencilState(DepthStencilState.DEFAULT.depthTest(), false);
 
     private WaypointerRenderPipelines() {}
 
@@ -81,9 +84,23 @@ public final class WaypointerRenderPipelines {
             beaconBeamDepthTested = buildBeaconBeamType(
                     "waypointer_beacon_beam_depth_tested",
                     "beacon_beam_depth_tested",
-                    LEQUAL_DEPTH_TEST);
+                    DEPTH_TESTED);
         }
         return beaconBeamDepthTested;
+    }
+
+    /** Textured translucent quads for a waypoint paint atlas. */
+    public static RenderType paintedQuads(Identifier texture, boolean depthTested) {
+        RenderPipeline pipeline = depthTested
+                ? paintedQuadsDepthTestedPipeline()
+                : paintedQuadsThroughWallsPipeline();
+        RenderSetup setup = RenderSetup.builder(pipeline)
+                .withTexture("Sampler0", texture)
+                .sortOnUpload()
+                .createRenderSetup();
+        return RenderType.create("waypointer_painted_quads_"
+                + (depthTested ? "depth_" : "through_")
+                + Integer.toUnsignedString(texture.hashCode()), setup);
     }
 
     private static RenderType buildLinesType() {
@@ -93,6 +110,32 @@ public final class WaypointerRenderPipelines {
                 .build();
         return RenderType.create("waypointer_lines_through_walls",
                 RenderSetup.builder(pipeline).createRenderSetup());
+    }
+
+    private static RenderPipeline paintedQuadsThroughWallsPipeline() {
+        if (paintedQuadsThroughWallsPipeline == null) {
+            paintedQuadsThroughWallsPipeline = buildPaintedQuadsPipeline(
+                    "painted_quads_through_walls", NO_DEPTH_TEST);
+        }
+        return paintedQuadsThroughWallsPipeline;
+    }
+
+    private static RenderPipeline paintedQuadsDepthTestedPipeline() {
+        if (paintedQuadsDepthTestedPipeline == null) {
+            paintedQuadsDepthTestedPipeline = buildPaintedQuadsPipeline(
+                    "painted_quads_depth_tested", DEPTH_TESTED);
+        }
+        return paintedQuadsDepthTestedPipeline;
+    }
+
+    private static RenderPipeline buildPaintedQuadsPipeline(String path,
+                                                             DepthStencilState depthState) {
+        return RenderPipeline.builder(RenderPipelines.BEACON_BEAM_SNIPPET)
+                .withLocation(Identifier.fromNamespaceAndPath(Waypointer.MOD_ID, path))
+                .withDepthStencilState(depthState)
+                .withColorTargetState(new ColorTargetState(BlendFunction.TRANSLUCENT))
+                .withCull(false)
+                .build();
     }
 
     private static RenderType buildQuadsType() {
@@ -116,7 +159,7 @@ public final class WaypointerRenderPipelines {
     private static RenderType buildDepthTestedLinesType() {
         RenderPipeline pipeline = RenderPipeline.builder(RenderPipelines.LINES_SNIPPET)
                 .withLocation(Identifier.fromNamespaceAndPath(Waypointer.MOD_ID, "lines_depth_tested"))
-                .withDepthStencilState(LEQUAL_DEPTH_TEST)
+                .withDepthStencilState(DEPTH_TESTED)
                 .build();
         return RenderType.create("waypointer_lines_depth_tested",
                 RenderSetup.builder(pipeline).createRenderSetup());
@@ -141,7 +184,7 @@ public final class WaypointerRenderPipelines {
     private static RenderType buildDepthTestedQuadsType() {
         RenderPipeline pipeline = RenderPipeline.builder(RenderPipelines.DEBUG_FILLED_SNIPPET)
                 .withLocation(Identifier.fromNamespaceAndPath(Waypointer.MOD_ID, "quads_depth_tested"))
-                .withDepthStencilState(LEQUAL_DEPTH_TEST)
+                .withDepthStencilState(DEPTH_TESTED)
                 .withColorTargetState(new ColorTargetState(BlendFunction.TRANSLUCENT))
                 .withCull(false)
                 .build();

--- a/src/client/java/com/babbur/waypointer/screen/AddNamedWaypointScreen.java
+++ b/src/client/java/com/babbur/waypointer/screen/AddNamedWaypointScreen.java
@@ -188,7 +188,8 @@ public final class AddNamedWaypointScreen extends Screen {
         // Stored dungeon-room routes keep room-local coordinates.
         target.add(DungeonRoomWaypointPlacement.toStoredWaypoint(target,
                 new Waypoint(x, y, z, name, config.defaultWaypointColor(), flags, 0.0)));
-        new WaypointAddFlow().afterWaypointAdded(target, target.size() - 1);
+        new WaypointAddFlow().afterWaypointAdded(target, target.size() - 1,
+                config.showWaypointChatShareButtons());
         manager.fireDataChanged();
 
         onClose();

--- a/src/client/java/com/babbur/waypointer/screen/GroupEditScreen.java
+++ b/src/client/java/com/babbur/waypointer/screen/GroupEditScreen.java
@@ -8,6 +8,7 @@ import com.babbur.waypointer.config.WaypointerConfig;
 import com.babbur.waypointer.core.ActiveGroupManager;
 import com.babbur.waypointer.core.Waypoint;
 import com.babbur.waypointer.core.WaypointGroup;
+import com.babbur.waypointer.core.WaypointPaint;
 import com.babbur.waypointer.debug.DebugEventLog;
 import com.babbur.waypointer.dungeon.DungeonRoomRouteSync;
 import com.babbur.waypointer.dungeon.DungeonRoomWaypointPlacement;
@@ -63,6 +64,8 @@ import static com.babbur.waypointer.screen.GuiTokens.*;
  * Sort is now one cycling button: Manual -> Nearest -> Y asc -> Y desc -> Manual.
  */
 public final class GroupEditScreen extends Screen {
+
+    enum RouteColorMode { COLOR, GRADIENT, ONE, PAINT }
 
     private final Screen parent;
     private final ActiveGroupManager manager;
@@ -411,8 +414,16 @@ public final class GroupEditScreen extends Screen {
         gradientStartBtn = null;
         gradientEndBtn = null;
 
-        WaypointGroup.GradientMode mode = group.gradientMode();
-        if (mode == WaypointGroup.GradientMode.STATIC) {
+        RouteColorMode routeMode = routeColorMode();
+        if (routeMode == RouteColorMode.PAINT) {
+            addSidebarWidget(styledButton(sidebarInner, y, fieldW, BTN_H,
+                    Component.literal("Paint"), b -> openWaypointPainter(),
+                    Tooltip.create(Component.literal(
+                            "Open Waypoint Painter for this route."))));
+            return y + BTN_H + GAP_TIGHT;
+        }
+
+        if (routeMode == RouteColorMode.ONE) {
             staticColorBtn = new ColorSwatchButton(sidebarInner, y, fieldW, BTN_H,
                     "One color", group.staticColor(), this::openStaticColorPicker);
             staticColorBtn.setTooltip(Tooltip.create(Component.literal(
@@ -422,7 +433,7 @@ public final class GroupEditScreen extends Screen {
             return y + BTN_H + GAP_TIGHT;
         }
 
-        if (mode == WaypointGroup.GradientMode.AUTO) {
+        if (routeMode == RouteColorMode.GRADIENT) {
             int swatchW = (fieldW - GAP_TIGHT) / 2;
             gradientStartBtn = new ColorSwatchButton(sidebarInner, y, swatchW, BTN_H,
                     "Start", group.gradientStartColor(), this::openGradientStartPicker);
@@ -446,33 +457,73 @@ public final class GroupEditScreen extends Screen {
     // --- sidebar toggles ---------------------------------------------------------------------
 
         private Component colorModeLabel() {
-        return Component.literal("Color: " + colorModeName(group.gradientMode()));
+        return Component.literal("Color: " + colorModeName(routeColorMode()));
     }
 
-    static String colorModeName(WaypointGroup.GradientMode mode) {
-        if (mode == WaypointGroup.GradientMode.AUTO) return "Gradient";
-        if (mode == WaypointGroup.GradientMode.MANUAL) return "Manual";
-        return "One";
+    private RouteColorMode routeColorMode() {
+        boolean paintActive = group.paintEnabled()
+                && (group.paint() != null || config.waypointPainterDefaultPaint() != null);
+        return routeColorMode(group.gradientMode(), paintActive);
+    }
+
+    static RouteColorMode routeColorMode(WaypointGroup.GradientMode mode, boolean paintActive) {
+        if (paintActive) return RouteColorMode.PAINT;
+        if (mode == WaypointGroup.GradientMode.AUTO) return RouteColorMode.GRADIENT;
+        if (mode == WaypointGroup.GradientMode.STATIC) return RouteColorMode.ONE;
+        return RouteColorMode.COLOR;
+    }
+
+    static String colorModeName(RouteColorMode mode) {
+        return switch (mode == null ? RouteColorMode.COLOR : mode) {
+            case COLOR -> "Color";
+            case GRADIENT -> "Gradient";
+            case ONE -> "One";
+            case PAINT -> "Paint";
+        };
     }
 
         private static Tooltip colorModeTooltip() {
         return Tooltip.create(Component.literal(
-                "Waypoint colour mode.\n"
-              + "One color: repaint whole route.\n"
+                "Waypoint color mode.\n"
+              + "Color: edit waypoint swatches.\n"
               + "Gradient: sweep between endpoints.\n"
-              + "Manual: edit waypoint swatches."));
+              + "One: repaint the whole route.\n"
+              + "Paint: use painted waypoint faces."));
     }
 
     private void toggleColorMode(Button b) {
-        group.setGradientMode(nextColorMode(group.gradientMode()));
+        RouteColorMode next = nextColorMode(routeColorMode());
+        group.setPaintEnabled(next == RouteColorMode.PAINT);
+        switch (next) {
+            case COLOR -> group.setGradientMode(WaypointGroup.GradientMode.MANUAL);
+            case GRADIENT -> group.setGradientMode(WaypointGroup.GradientMode.AUTO);
+            case ONE -> group.setGradientMode(WaypointGroup.GradientMode.STATIC);
+            case PAINT -> {
+                if (group.paint() == null && config.waypointPainterDefaultPaint() == null) {
+                    group.setPaint(new WaypointPaint(
+                            config.waypointPainterPalette(),
+                            new byte[WaypointPaint.PIXEL_COUNT]));
+                }
+            }
+        }
         manager.fireDataChanged();
         rebuildWidgets();
     }
 
-    static WaypointGroup.GradientMode nextColorMode(WaypointGroup.GradientMode mode) {
-        if (mode == WaypointGroup.GradientMode.STATIC) return WaypointGroup.GradientMode.AUTO;
-        if (mode == WaypointGroup.GradientMode.AUTO) return WaypointGroup.GradientMode.MANUAL;
-        return WaypointGroup.GradientMode.STATIC;
+    static RouteColorMode nextColorMode(RouteColorMode mode) {
+        return switch (mode == null ? RouteColorMode.COLOR : mode) {
+            case COLOR -> RouteColorMode.GRADIENT;
+            case GRADIENT -> RouteColorMode.ONE;
+            case ONE -> RouteColorMode.PAINT;
+            case PAINT -> RouteColorMode.COLOR;
+        };
+    }
+
+    private void openWaypointPainter() {
+        WaypointGroup editTarget = durableEditTarget();
+        if (editTarget == null) return;
+        MinecraftCompat.setScreen(minecraft,
+                new WaypointPainterScreen(this, config, manager, editTarget));
     }
 
         private void updateColorModeButtons() {
@@ -499,6 +550,7 @@ public final class GroupEditScreen extends Screen {
 
         private void onStaticColorPicked(int picked) {
         group.setStaticColor(picked);
+        group.setPaintEnabled(false);
         group.setGradientMode(WaypointGroup.GradientMode.STATIC);
         updateColorModeButtons();
         manager.fireDataChanged();
@@ -524,12 +576,14 @@ public final class GroupEditScreen extends Screen {
 
         private void onGradientStartPicked(int picked) {
         group.setGradientStartColor(picked);
+        group.setPaintEnabled(false);
         updateColorModeButtons();
         manager.fireDataChanged();
     }
 
         private void onGradientEndPicked(int picked) {
         group.setGradientEndColor(picked);
+        group.setPaintEnabled(false);
         updateColorModeButtons();
         manager.fireDataChanged();
     }
@@ -593,9 +647,35 @@ public final class GroupEditScreen extends Screen {
         box.setMaxLength(12);
         box.setHint(Component.literal(label));
         box.setTooltip(Tooltip.create(Component.literal(
-                "Edit the selected waypoint's " + label + " coordinate.")));
+                "Edit the selected waypoint's " + label + " coordinate.\n"
+                        + "Scroll while hovering to adjust by 1.")));
         box.setResponder(v -> updateSelectedCoordinate(axis, v));
         return box;
+    }
+
+    static int coordinateAfterScroll(int value, double verticalScroll) {
+        if (verticalScroll > 0.0) return value == Integer.MAX_VALUE ? value : value + 1;
+        if (verticalScroll < 0.0) return value == Integer.MIN_VALUE ? value : value - 1;
+        return value;
+    }
+
+    private int coordinateAxisAt(double mouseX, double mouseY) {
+        if (coordXBox != null && coordXBox.visible && coordXBox.active
+                && coordXBox.isMouseOver(mouseX, mouseY)) return 0;
+        if (coordYBox != null && coordYBox.visible && coordYBox.active
+                && coordYBox.isMouseOver(mouseX, mouseY)) return 1;
+        if (coordZBox != null && coordZBox.visible && coordZBox.active
+                && coordZBox.isMouseOver(mouseX, mouseY)) return 2;
+        return -1;
+    }
+
+    private void scrollCoordinate(int axis, double verticalScroll) {
+        Waypoint waypoint = group.get(selectedIndex);
+        int current = axis == 0 ? waypoint.x() : axis == 1 ? waypoint.y() : waypoint.z();
+        int next = coordinateAfterScroll(current, verticalScroll);
+        if (next == current) return;
+        EditBox box = axis == 0 ? coordXBox : axis == 1 ? coordYBox : coordZBox;
+        box.setValue(Integer.toString(next));
     }
 
     private void updateSelectedCoordinate(int axis, String raw) {
@@ -721,7 +801,8 @@ public final class GroupEditScreen extends Screen {
         int newIndex = editTarget.size() - 1;
         // Run the shared post-add flow (focus + mode/toast updates) so the
         // GUI add button behaves identically to /wp add and the keybind path.
-        new WaypointAddFlow().afterWaypointAdded(editTarget, newIndex);
+        new WaypointAddFlow().afterWaypointAdded(editTarget, newIndex,
+                config.showWaypointChatShareButtons());
         if (skipAheadBtn != null) skipAheadBtn.setMessage(skipAheadLabel());
         if (editTarget == group) selectWaypoint(newIndex);
         manager.fireDataChanged();
@@ -1746,6 +1827,7 @@ public final class GroupEditScreen extends Screen {
         int idx = waypointColorPickerIndex;
         waypointColorPickerIndex = -1;
         if (idx < 0 || idx >= group.size()) return;
+        group.setPaintEnabled(false);
         if (group.gradientMode() != WaypointGroup.GradientMode.MANUAL) {
             group.setGradientMode(WaypointGroup.GradientMode.MANUAL);
             Waypoint cur = group.get(idx);
@@ -1756,8 +1838,8 @@ public final class GroupEditScreen extends Screen {
         }
         Waypoint cur = group.get(idx);
         group.set(idx, cur.withColor(picked).withFlags(cur.flags() | Waypoint.FLAG_LOCKED_COLOR));
-        updateColorModeButtons();
         manager.fireDataChanged();
+        rebuildWidgets();
     }
 
     private void unlockWaypointColor(int idx) {
@@ -1794,6 +1876,11 @@ public final class GroupEditScreen extends Screen {
     @Override
     public boolean mouseScrolled(double mouseX, double mouseY, double horiz, double vert) {
         Layout layout = layout();
+        int coordinateAxis = coordinateAxisAt(mouseX, mouseY);
+        if (coordinateAxis >= 0) {
+            scrollCoordinate(coordinateAxis, vert);
+            return true;
+        }
         if (mouseX >= layout.sidebarLeft() && mouseX <= layout.sidebarRight()
                 && mouseY >= layout.top() && mouseY <= layout.bottom()) {
             int viewportHeight = sidebarViewportBottom(layout) - sidebarViewportTop(layout);

--- a/src/client/java/com/babbur/waypointer/screen/SettingsScreen.java
+++ b/src/client/java/com/babbur/waypointer/screen/SettingsScreen.java
@@ -1,6 +1,7 @@
 package com.babbur.waypointer.screen;
 
 import com.babbur.waypointer.compat.MinecraftCompat;
+import com.babbur.waypointer.WaypointerClient;
 import com.mojang.blaze3d.platform.InputConstants;
 import com.mojang.blaze3d.platform.cursor.CursorTypes;
 import com.babbur.waypointer.config.WaypointerConfig;
@@ -594,6 +595,8 @@ public final class SettingsScreen extends Screen {
                     controlRight, rowTop, CONFIRM_RESET_DEFAULTS, "Reset to Defaults", "Confirm Reset",
                     this::confirmedResetDefaults);
             case SettingsCatalog.ACTION_PERF_TEST -> buildPerfTestControls(row, setting, controlRight, rowTop);
+            case SettingsCatalog.ACTION_WAYPOINT_PAINT -> buildDialogActionControl(row, setting,
+                    controlRight, rowTop, "Open painter", this::openWaypointPainter);
             default -> { }
         }
     }
@@ -606,8 +609,8 @@ public final class SettingsScreen extends Screen {
                         minecraft.keyboardHandler.setClipboard(PerfStressTestController.report());
                         PerfStressTestController.noteReportCopied();
                     }
-                }, Tooltip.create(Component.literal(
-                        "Copy the full performance rundown to your clipboard.")));
+                }, tooltipFor(setting,
+                        "Copy the full performance rundown to your clipboard."));
 
         boolean running = PerfStressTestController.running();
         Button run = styledButton(controlRight - buttonW * 2 - GAP, 0, buttonW, BTN_H,
@@ -624,12 +627,18 @@ public final class SettingsScreen extends Screen {
         registerRowWidget(row, copy, rowTop + 2, PerfStressTestController::hasReport);
     }
 
+    private void openWaypointPainter() {
+        if (WaypointerClient.manager() == null) return;
+        MinecraftCompat.setScreen(minecraft,
+                new WaypointPainterScreen(this, config, WaypointerClient.manager()));
+    }
+
     private void buildConfigCodeControls(Row row, Setting setting, int controlRight, int rowTop) {
         int buttonW = 112;
         Button importButton = styledButton(controlRight - buttonW, 0, buttonW, BTN_H,
                 Component.literal("Import config code"), this::importConfigCode,
-                Tooltip.create(Component.literal(
-                        "Import settings. This will overwrite existing settings.")));
+                tooltipFor(setting,
+                        "Import settings. This will overwrite existing settings."));
         Button copyButton = styledButton(controlRight - buttonW * 2 - GAP, 0, buttonW, BTN_H,
                 Component.literal("Copy config code"), this::copyConfigCode, tooltipOrNull(setting));
         registerRowWidget(row, copyButton, rowTop + 2);
@@ -649,7 +658,7 @@ public final class SettingsScreen extends Screen {
             int w = Math.max(60, font.width(label) + 16);
             x -= w;
             Button button = styledButton(x, 0, w, BTN_H, Component.literal(label),
-                    b -> applyPreset(id), null);
+                    b -> applyPreset(id), tooltipOrNull(setting));
             registerRowWidget(row, button, rowTop + 2);
             x -= GAP_TIGHT;
         }
@@ -752,7 +761,7 @@ public final class SettingsScreen extends Screen {
                             });
                 });
         swatchRef[0] = swatch;
-        swatch.setTooltip(Tooltip.create(Component.literal(setting.colorSwatchTooltip())));
+        swatch.setTooltip(tooltipFor(setting, setting.colorSwatchTooltip()));
 
         box.setResponder(v -> {
             Integer parsed = parseRgbHexColor(v);
@@ -793,9 +802,9 @@ public final class SettingsScreen extends Screen {
                     applySetting(setting, defaultValue);
                     rebuildPending = true; // controls re-read config on rebuild
                 });
-        dot.setTooltip(Tooltip.create(Component.literal(
+        dot.setTooltip(tooltipFor(setting,
                 "Modified (default: " + setting.formatValue(defaultValue) + ")\n"
-                        + "Click to reset this setting.")));
+                        + "Click to reset this setting."));
         dot.visible = false;
         row.dot = new WidgetSlot(dot, layout.rowsTop() + row.y + 2);
         addWidget(dot);
@@ -1269,12 +1278,22 @@ public final class SettingsScreen extends Screen {
 
     // --- tooltips ------------------------------------------------------------------------------
 
-    private static Component tooltipFor(Setting setting) {
-        String text = normalizeTooltipText(setting.tooltip());
-        MutableComponent out = Component.literal(text).withStyle(ChatFormatting.WHITE);
+    static Component tooltipFor(Setting setting) {
+        return tooltipComponent(setting, setting.tooltip());
+    }
+
+    private static Tooltip tooltipFor(Setting setting, String text) {
+        return Tooltip.create(tooltipComponent(setting, text));
+    }
+
+    private static Component tooltipComponent(Setting setting, String rawText) {
+        String text = normalizeTooltipText(rawText);
+        MutableComponent out = Component.literal(setting.label()).withStyle(ChatFormatting.GRAY);
+        if (!text.isEmpty()) {
+            out.append(Component.literal("\n" + text).withStyle(ChatFormatting.WHITE));
+        }
         if (setting.impact() != null) {
-            String prefix = text.isEmpty() ? "Impact: " : "\n\nImpact: ";
-            out.append(Component.literal(prefix).withStyle(ChatFormatting.WHITE));
+            out.append(Component.literal("\n\nImpact: ").withStyle(ChatFormatting.WHITE));
             out.append(Component.literal(setting.impact().word()).withStyle(chatColor(setting.impact())));
         }
         return out;

--- a/src/client/java/com/babbur/waypointer/screen/WaypointPaintApplyScreen.java
+++ b/src/client/java/com/babbur/waypointer/screen/WaypointPaintApplyScreen.java
@@ -1,0 +1,318 @@
+package com.babbur.waypointer.screen;
+
+import com.babbur.waypointer.compat.MinecraftCompat;
+import com.babbur.waypointer.core.ActiveGroupManager;
+import com.babbur.waypointer.core.WaypointGroup;
+import com.babbur.waypointer.core.Zone;
+import com.babbur.waypointer.util.MathUtil;
+import com.mojang.blaze3d.platform.cursor.CursorTypes;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.client.gui.components.Tooltip;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.input.KeyEvent;
+import net.minecraft.client.input.MouseButtonEvent;
+import net.minecraft.network.chat.Component;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+
+import static com.babbur.waypointer.screen.GuiTokens.*;
+import static org.lwjgl.glfw.GLFW.*;
+
+/** Apply-target chooser and searchable route picker for Waypoint Painter. */
+public final class WaypointPaintApplyScreen extends Screen {
+
+    private enum Mode { CHOICE, GROUPS }
+
+    private static final int CHOICE_W = 150;
+    private static final int LIST_W_MAX = 460;
+    private static final int ROW_PITCH = 28;
+    private static final int SEARCH_W = 220;
+    private static final int CLEAR_W = 52;
+
+    private final WaypointPainterScreen painter;
+    private final ActiveGroupManager manager;
+    private Mode mode = Mode.CHOICE;
+    private EditBox searchBox;
+    private Button searchClearButton;
+    private String searchQuery = "";
+    private int scrollOffset;
+    private int selectedRow;
+
+    WaypointPaintApplyScreen(WaypointPainterScreen painter, ActiveGroupManager manager) {
+        super(Component.literal("Apply to..."));
+        this.painter = painter;
+        this.manager = manager;
+    }
+
+    @Override
+    protected void init() {
+        searchBox = null;
+        searchClearButton = null;
+        if (mode == Mode.CHOICE) {
+            buildChoiceButtons();
+        } else {
+            buildGroupSearch();
+        }
+        addRenderableWidget(styledButton(PAD_OUTER, height - FOOTER_H, 64, BTN_H,
+                Component.literal("Back"), b -> goBack(), null));
+    }
+
+    private void buildChoiceButtons() {
+        int totalW = CHOICE_W * 2 + GAP_SECTION;
+        int x = (width - totalW) / 2;
+        int y = Math.max(PAD_OUTER + 48, height / 2 - BTN_H / 2);
+        Button all = styledButton(x, y, CHOICE_W, BTN_H,
+                Component.literal("All Waypoints"), b -> applyAll(),
+                Tooltip.create(Component.literal("Apply this paint to every saved route.")));
+        all.active = !eligibleGroups(manager).isEmpty();
+        addRenderableWidget(all);
+        Button pick = styledButton(x + CHOICE_W + GAP_SECTION, y, CHOICE_W, BTN_H,
+                Component.literal("Pick Group..."), b -> showGroups(),
+                Tooltip.create(Component.literal("Search saved routes and apply to one group.")));
+        pick.active = all.active;
+        addRenderableWidget(pick);
+    }
+
+    private void buildGroupSearch() {
+        int listLeft = listLeft();
+        int searchWidth = Math.min(SEARCH_W,
+                Math.max(80, listWidth() - CLEAR_W - GAP_TIGHT));
+        searchBox = new EditBox(font, listLeft, listTop() - BTN_H - GAP,
+                searchWidth, BTN_H, Component.literal("Search groups"));
+        searchBox.setMaxLength(80);
+        searchBox.setValue(searchQuery);
+        searchBox.setHint(Component.literal("Search groups"));
+        searchBox.setResponder(value -> {
+            searchQuery = value == null ? "" : value;
+            scrollOffset = 0;
+            selectedRow = 0;
+            if (searchClearButton != null) searchClearButton.active = !searchQuery.isEmpty();
+        });
+        addRenderableWidget(searchBox);
+        searchClearButton = styledButton(listLeft + searchWidth + GAP_TIGHT,
+                listTop() - BTN_H - GAP, CLEAR_W, BTN_H,
+                Component.literal("Clear"), b -> searchBox.setValue(""),
+                Tooltip.create(Component.literal("Clear group search.")));
+        searchClearButton.active = !searchQuery.isEmpty();
+        addRenderableWidget(searchClearButton);
+    }
+
+    @Override
+    public void extractRenderState(GuiGraphicsExtractor g, int mouseX, int mouseY, float partial) {
+        g.fill(0, 0, width, height, SURFACE);
+        String title = getTitle().getString();
+        g.text(font, title, (width - font.width(title)) / 2, PAD_OUTER, TEXT, false);
+
+        if (mode == Mode.GROUPS) drawGroupList(g, mouseX, mouseY);
+        super.extractRenderState(g, mouseX, mouseY, partial);
+    }
+
+    private void drawGroupList(GuiGraphicsExtractor g, int mouseX, int mouseY) {
+        int left = listLeft();
+        int right = left + listWidth();
+        int top = listTop();
+        int bottom = listBottom();
+        g.fill(left, top, right, bottom, SURFACE_SUBTLE);
+
+        List<WaypointGroup> groups = matchingGroups(manager, searchQuery);
+        int maxScroll = maxScroll(groups.size(), bottom - top);
+        scrollOffset = MathUtil.clamp(scrollOffset, 0, maxScroll);
+        if (groups.isEmpty()) {
+            String empty = searchQuery.isBlank() ? "No saved groups." : "No matching groups.";
+            g.text(font, empty, left + GAP, top + GAP, TEXT_DIM, false);
+            return;
+        }
+
+        selectedRow = MathUtil.clamp(selectedRow, 0, groups.size() - 1);
+        g.enableScissor(left, top, right, bottom);
+        String activeZone = activeZoneId(manager);
+        for (int i = 0; i < groups.size(); i++) {
+            int rowY = top + i * ROW_PITCH - scrollOffset;
+            if (rowY + ROW_PITCH <= top) continue;
+            if (rowY >= bottom) break;
+            WaypointGroup group = groups.get(i);
+            boolean active = isActive(group, activeZone);
+            boolean hovered = mouseX >= left && mouseX < right
+                    && mouseY >= rowY && mouseY < rowY + ROW_PITCH
+                    && mouseY >= top && mouseY < bottom;
+            if (hovered) g.requestCursor(CursorTypes.POINTING_HAND);
+            if (i == selectedRow || hovered) {
+                g.fill(left, rowY, right, rowY + ROW_PITCH,
+                        i == selectedRow ? SELECTED : HOVER);
+            }
+            if (active) g.fill(left, rowY, left + 2, rowY + ROW_PITCH, ACCENT);
+
+            int textX = left + GAP;
+            int rightText = right - GAP;
+            String state = active ? "Active" : group.enabled() ? "Shown" : "Hidden";
+            int stateColor = active ? ACCENT : group.enabled() ? TEXT_DIM : TEXT_MUTED;
+            int stateX = rightText - font.width(state);
+            g.text(font, state, stateX, rowY + 5, stateColor, false);
+
+            String name = group.name().isBlank() ? "Unnamed group" : group.name();
+            name = font.plainSubstrByWidth(name, Math.max(20, stateX - GAP - textX));
+            g.text(font, name, textX, rowY + 4, TEXT, false);
+            String detail = Zone.fromId(group.zoneId()).displayName()
+                    + "  |  " + group.size() + (group.size() == 1 ? " waypoint" : " waypoints");
+            detail = font.plainSubstrByWidth(detail, Math.max(20, rightText - textX));
+            g.text(font, detail, textX, rowY + 15, TEXT_MUTED, false);
+        }
+        g.disableScissor();
+        drawScrollbar(g, right - 3, top, bottom, groups.size(), scrollOffset);
+    }
+
+    private void drawScrollbar(GuiGraphicsExtractor g, int x, int top, int bottom,
+                               int groupCount, int scroll) {
+        int viewport = bottom - top;
+        int content = groupCount * ROW_PITCH;
+        if (content <= viewport) return;
+        int thumbH = Math.max(12, viewport * viewport / content);
+        int max = Math.max(1, content - viewport);
+        int thumbY = top + scroll * (viewport - thumbH) / max;
+        g.fill(x, top + 2, x + 2, bottom - 2, BORDER);
+        g.fill(x, thumbY, x + 2, thumbY + thumbH, TEXT_MUTED);
+    }
+
+    @Override
+    public boolean mouseClicked(MouseButtonEvent event, boolean doubleClick) {
+        if (super.mouseClicked(event, doubleClick)) return true;
+        if (mode != Mode.GROUPS || event.button() != 0) return false;
+        if (event.x() < listLeft() || event.x() >= listLeft() + listWidth()
+                || event.y() < listTop() || event.y() >= listBottom()) return false;
+        List<WaypointGroup> groups = matchingGroups(manager, searchQuery);
+        int index = (int) ((event.y() - listTop() + scrollOffset) / ROW_PITCH);
+        if (index < 0 || index >= groups.size()) return true;
+        selectedRow = index;
+        painter.applyToGroup(groups.get(index));
+        MinecraftCompat.setScreen(minecraft, painter);
+        return true;
+    }
+
+    @Override
+    public boolean mouseScrolled(double mouseX, double mouseY, double horiz, double vert) {
+        if (mode != Mode.GROUPS) return false;
+        List<WaypointGroup> groups = matchingGroups(manager, searchQuery);
+        scrollOffset = MathUtil.clamp(scrollOffset - (int) (vert * ROW_PITCH),
+                0, maxScroll(groups.size(), listBottom() - listTop()));
+        return true;
+    }
+
+    @Override
+    public boolean keyPressed(KeyEvent event) {
+        if (mode == Mode.GROUPS) {
+            List<WaypointGroup> groups = matchingGroups(manager, searchQuery);
+            if (event.key() == GLFW_KEY_DOWN && !groups.isEmpty()) {
+                selectedRow = Math.min(groups.size() - 1, selectedRow + 1);
+                scrollSelectedIntoView(groups.size());
+                return true;
+            }
+            if (event.key() == GLFW_KEY_UP && !groups.isEmpty()) {
+                selectedRow = Math.max(0, selectedRow - 1);
+                scrollSelectedIntoView(groups.size());
+                return true;
+            }
+            if (event.key() == GLFW_KEY_ENTER && !groups.isEmpty()) {
+                painter.applyToGroup(groups.get(MathUtil.clamp(selectedRow, 0, groups.size() - 1)));
+                MinecraftCompat.setScreen(minecraft, painter);
+                return true;
+            }
+        }
+        return super.keyPressed(event);
+    }
+
+    private void scrollSelectedIntoView(int groupCount) {
+        int viewport = listBottom() - listTop();
+        int rowTop = selectedRow * ROW_PITCH;
+        int rowBottom = rowTop + ROW_PITCH;
+        if (rowTop < scrollOffset) scrollOffset = rowTop;
+        if (rowBottom > scrollOffset + viewport) scrollOffset = rowBottom - viewport;
+        scrollOffset = MathUtil.clamp(scrollOffset, 0, maxScroll(groupCount, viewport));
+    }
+
+    private void applyAll() {
+        painter.applyToAllGroups();
+        MinecraftCompat.setScreen(minecraft, painter);
+    }
+
+    private void showGroups() {
+        mode = Mode.GROUPS;
+        scrollOffset = 0;
+        selectedRow = 0;
+        rebuildWidgets();
+    }
+
+    private void goBack() {
+        if (mode == Mode.GROUPS) {
+            mode = Mode.CHOICE;
+            rebuildWidgets();
+        } else {
+            onClose();
+        }
+    }
+
+    @Override
+    public void onClose() {
+        MinecraftCompat.setScreen(minecraft, painter);
+    }
+
+    private int listWidth() {
+        return Math.min(LIST_W_MAX, Math.max(180, width - PAD_OUTER * 2));
+    }
+
+    private int listLeft() {
+        return (width - listWidth()) / 2;
+    }
+
+    private int listTop() {
+        return PAD_OUTER + font.lineHeight + GAP + BTN_H + GAP;
+    }
+
+    private int listBottom() {
+        return height - FOOTER_H - GAP;
+    }
+
+    private static int maxScroll(int groupCount, int viewportHeight) {
+        return Math.max(0, groupCount * ROW_PITCH - Math.max(0, viewportHeight));
+    }
+
+    static List<WaypointGroup> eligibleGroups(ActiveGroupManager manager) {
+        if (manager == null) return List.of();
+        List<WaypointGroup> groups = new ArrayList<>();
+        for (WaypointGroup group : manager.allGroups()) {
+            if (!group.temp() && !group.runtimeOnly()) groups.add(group);
+        }
+        String activeZone = activeZoneId(manager);
+        groups.sort(Comparator.comparingInt(group -> targetRank(group, activeZone)));
+        return groups;
+    }
+
+    static List<WaypointGroup> matchingGroups(ActiveGroupManager manager, String query) {
+        List<WaypointGroup> groups = eligibleGroups(manager);
+        String needle = query == null ? "" : query.trim().toLowerCase(Locale.ROOT);
+        if (needle.isEmpty()) return groups;
+        return groups.stream().filter(group -> {
+            String zoneName = Zone.fromId(group.zoneId()).displayName();
+            return group.name().toLowerCase(Locale.ROOT).contains(needle)
+                    || group.zoneId().toLowerCase(Locale.ROOT).contains(needle)
+                    || zoneName.toLowerCase(Locale.ROOT).contains(needle);
+        }).toList();
+    }
+
+    private static int targetRank(WaypointGroup group, String activeZone) {
+        if (isActive(group, activeZone)) return 0;
+        return group.enabled() ? 1 : 2;
+    }
+
+    private static boolean isActive(WaypointGroup group, String activeZone) {
+        return activeZone != null && group.enabled() && activeZone.equals(group.zoneId());
+    }
+
+    private static String activeZoneId(ActiveGroupManager manager) {
+        return manager == null || manager.currentZone() == null ? null : manager.currentZone().id();
+    }
+}

--- a/src/client/java/com/babbur/waypointer/screen/WaypointPaintPreviewTexture.java
+++ b/src/client/java/com/babbur/waypointer/screen/WaypointPaintPreviewTexture.java
@@ -1,0 +1,189 @@
+package com.babbur.waypointer.screen;
+
+import com.babbur.waypointer.Waypointer;
+import com.babbur.waypointer.core.WaypointPaint;
+import com.mojang.blaze3d.platform.NativeImage;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.texture.DynamicTexture;
+import net.minecraft.resources.Identifier;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicLong;
+
+/** Perspective-correct software cube used for the painter's rotating live preview. */
+final class WaypointPaintPreviewTexture {
+
+    static final int SIZE = 256;
+    private static final int EDGE_ABGR = 0xFFD9DDE2;
+    private static final AtomicLong SEQUENCE = new AtomicLong();
+    private static final double[][] VERTICES = {
+            {-1, -1, -1}, {1, -1, -1}, {1, 1, -1}, {-1, 1, -1},
+            {-1, -1,  1}, {1, -1,  1}, {1, 1,  1}, {-1, 1,  1}
+    };
+    private static final FaceQuad[] FACES = {
+            new FaceQuad(WaypointPaint.Face.NORTH, 0, 3, 2, 1,  0,  0, -1),
+            new FaceQuad(WaypointPaint.Face.SOUTH, 5, 6, 7, 4,  0,  0,  1),
+            new FaceQuad(WaypointPaint.Face.WEST,  4, 7, 3, 0, -1,  0,  0),
+            new FaceQuad(WaypointPaint.Face.EAST,  1, 2, 6, 5,  1,  0,  0),
+            new FaceQuad(WaypointPaint.Face.UP,    7, 6, 2, 3,  0,  1,  0),
+            new FaceQuad(WaypointPaint.Face.DOWN, 0, 1, 5, 4,  0, -1,  0)
+    };
+    private final Identifier id;
+    private final DynamicTexture texture;
+    private final float[] depth = new float[SIZE * SIZE];
+    private final double[][] projected = new double[8][3];
+    private final boolean[] visibleFaces = new boolean[FACES.length];
+    private WaypointPaint lastPaint;
+    private int lastAngleStep = Integer.MIN_VALUE;
+
+    WaypointPaintPreviewTexture() {
+        long sequence = SEQUENCE.incrementAndGet();
+        id = Identifier.fromNamespaceAndPath(Waypointer.MOD_ID, "paint_preview_" + sequence);
+        texture = new DynamicTexture(() -> "waypointer_paint_preview", SIZE, SIZE, false);
+        Minecraft.getInstance().getTextureManager().register(id, texture);
+    }
+
+    Identifier id() {
+        return id;
+    }
+
+    void update(WaypointPaint paint, float angleDegrees) {
+        int angleStep = Math.floorMod(Math.round(angleDegrees), 360);
+        if (paint.equals(lastPaint) && angleStep == lastAngleStep) return;
+        lastPaint = paint;
+        lastAngleStep = angleStep;
+        rasterize(paint, angleStep);
+    }
+
+    void release() {
+        Minecraft.getInstance().getTextureManager().release(id);
+    }
+
+    private void rasterize(WaypointPaint paint, float angleDegrees) {
+        NativeImage image = texture.getPixels();
+        if (image == null) return;
+        Arrays.fill(depth, Float.POSITIVE_INFINITY);
+        for (int y = 0; y < SIZE; y++) {
+            for (int x = 0; x < SIZE; x++) image.setPixelABGR(x, y, 0);
+        }
+
+        double yaw = Math.toRadians(angleDegrees);
+        // Positive pitch presents the cube from above, matching the world view and mockup.
+        double pitch = Math.toRadians(24.0);
+        double cy = Math.cos(yaw), sy = Math.sin(yaw);
+        double cp = Math.cos(pitch), sp = Math.sin(pitch);
+        for (int i = 0; i < VERTICES.length; i++) {
+            double x = VERTICES[i][0];
+            double y = VERTICES[i][1];
+            double z = VERTICES[i][2];
+            double rx = x * cy + z * sy;
+            double rz = -x * sy + z * cy;
+            double ry = y * cp - rz * sp;
+            double rzz = y * sp + rz * cp;
+            double cameraDepth = 4.2 - rzz;
+            projected[i][0] = SIZE * 0.5 + rx * (SIZE * 0.67) / cameraDepth;
+            projected[i][1] = SIZE * 0.5 - ry * (SIZE * 0.67) / cameraDepth;
+            projected[i][2] = cameraDepth;
+        }
+
+        for (int faceIndex = 0; faceIndex < FACES.length; faceIndex++) {
+            FaceQuad face = FACES[faceIndex];
+            double nz = -face.nx * sy + face.nz * cy;
+            double nzz = face.ny * sp + nz * cp;
+            visibleFaces[faceIndex] = nzz > 1.0E-6;
+            if (!visibleFaces[faceIndex]) continue;
+            drawTriangle(image, paint, face.face,
+                    face.a, face.b, face.c,
+                    0, 1, 0, 0, 1, 0);
+            drawTriangle(image, paint, face.face,
+                    face.a, face.c, face.d,
+                    0, 1, 1, 0, 1, 1);
+        }
+        for (int faceIndex = 0; faceIndex < FACES.length; faceIndex++) {
+            if (!visibleFaces[faceIndex]) continue;
+            FaceQuad face = FACES[faceIndex];
+            drawEdge(image, face.a, face.b);
+            drawEdge(image, face.b, face.c);
+            drawEdge(image, face.c, face.d);
+            drawEdge(image, face.d, face.a);
+        }
+        texture.upload();
+    }
+
+    private void drawTriangle(NativeImage image, WaypointPaint paint, WaypointPaint.Face face,
+                              int ia, int ib, int ic,
+                              double ua, double va, double ub, double vb,
+                              double uc, double vc) {
+        double[] a = projected[ia], b = projected[ib], c = projected[ic];
+        double area = edge(a[0], a[1], b[0], b[1], c[0], c[1]);
+        if (Math.abs(area) < 1.0E-6) return;
+        int minX = clamp((int) Math.floor(Math.min(a[0], Math.min(b[0], c[0]))), 0, SIZE - 1);
+        int maxX = clamp((int) Math.ceil(Math.max(a[0], Math.max(b[0], c[0]))), 0, SIZE - 1);
+        int minY = clamp((int) Math.floor(Math.min(a[1], Math.min(b[1], c[1]))), 0, SIZE - 1);
+        int maxY = clamp((int) Math.ceil(Math.max(a[1], Math.max(b[1], c[1]))), 0, SIZE - 1);
+
+        for (int y = minY; y <= maxY; y++) {
+            for (int x = minX; x <= maxX; x++) {
+                double px = x + 0.5, py = y + 0.5;
+                double wa = edge(b[0], b[1], c[0], c[1], px, py) / area;
+                double wb = edge(c[0], c[1], a[0], a[1], px, py) / area;
+                double wc = 1.0 - wa - wb;
+                if (wa < -1.0E-5 || wb < -1.0E-5 || wc < -1.0E-5) continue;
+                double inverseZ = wa / a[2] + wb / b[2] + wc / c[2];
+                float z = (float) (1.0 / inverseZ);
+                int offset = y * SIZE + x;
+                if (z >= depth[offset]) continue;
+                depth[offset] = z;
+                double u = perspectiveInterpolate(
+                        wa, wb, wc, ua, ub, uc, a[2], b[2], c[2]);
+                double v = perspectiveInterpolate(
+                        wa, wb, wc, va, vb, vc, a[2], b[2], c[2]);
+                int tx = clamp((int) Math.floor(u * WaypointPaint.SIZE), 0, WaypointPaint.SIZE - 1);
+                int ty = clamp((int) Math.floor(v * WaypointPaint.SIZE), 0, WaypointPaint.SIZE - 1);
+                image.setPixelABGR(x, y, rgbToAbgr(paint.color(face, tx, ty)));
+            }
+        }
+    }
+
+    private void drawEdge(NativeImage image, int fromIndex, int toIndex) {
+        double[] from = projected[fromIndex];
+        double[] to = projected[toIndex];
+        int steps = Math.max(1, (int) Math.ceil(Math.max(
+                Math.abs(to[0] - from[0]), Math.abs(to[1] - from[1]))));
+        for (int step = 0; step <= steps; step++) {
+            double t = step / (double) steps;
+            int x = (int) Math.round(from[0] + (to[0] - from[0]) * t);
+            int y = (int) Math.round(from[1] + (to[1] - from[1]) * t);
+            if (x < 0 || x >= SIZE || y < 0 || y >= SIZE) continue;
+            float z = (float) (1.0 / ((1.0 - t) / from[2] + t / to[2]));
+            int offset = y * SIZE + x;
+            if (z <= depth[offset] + 0.04f) image.setPixelABGR(x, y, EDGE_ABGR);
+        }
+    }
+
+    static double perspectiveInterpolate(double wa, double wb, double wc,
+                                         double va, double vb, double vc,
+                                         double za, double zb, double zc) {
+        double inverseZ = wa / za + wb / zb + wc / zc;
+        return (wa * va / za + wb * vb / zb + wc * vc / zc) / inverseZ;
+    }
+
+    private static double edge(double ax, double ay, double bx, double by,
+                               double px, double py) {
+        return (px - ax) * (by - ay) - (py - ay) * (bx - ax);
+    }
+
+    private static int rgbToAbgr(int rgb) {
+        int r = (rgb >> 16) & 0xFF;
+        int g = (rgb >> 8) & 0xFF;
+        int b = rgb & 0xFF;
+        return 0xFF000000 | (b << 16) | (g << 8) | r;
+    }
+
+    private static int clamp(int value, int min, int max) {
+        return Math.max(min, Math.min(max, value));
+    }
+
+    private record FaceQuad(WaypointPaint.Face face, int a, int b, int c, int d,
+                            double nx, double ny, double nz) {}
+}

--- a/src/client/java/com/babbur/waypointer/screen/WaypointPainterScreen.java
+++ b/src/client/java/com/babbur/waypointer/screen/WaypointPainterScreen.java
@@ -1,0 +1,576 @@
+package com.babbur.waypointer.screen;
+
+import com.babbur.waypointer.compat.MinecraftCompat;
+import com.babbur.waypointer.config.WaypointerConfig;
+import com.babbur.waypointer.core.ActiveGroupManager;
+import com.babbur.waypointer.core.WaypointGroup;
+import com.babbur.waypointer.core.WaypointPaint;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.AbstractButton;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.Tooltip;
+import net.minecraft.client.gui.narration.NarrationElementOutput;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.input.InputWithModifiers;
+import net.minecraft.client.input.KeyEvent;
+import net.minecraft.client.input.MouseButtonEvent;
+import net.minecraft.client.renderer.RenderPipelines;
+import net.minecraft.network.chat.Component;
+
+import java.util.Arrays;
+
+import static com.babbur.waypointer.screen.GuiTokens.*;
+import static org.lwjgl.glfw.GLFW.*;
+
+/** Pixel editor for one repeated face or the full six-face waypoint cubemap. */
+public final class WaypointPainterScreen extends Screen {
+
+    private enum FaceView { ONE, ALL }
+
+    private static final int PALETTE_W = 84;
+    private static final int PREVIEW_MAX = 176;
+    private static final int SWATCH_H = 16;
+    private static final int SWATCH_GAP = 2;
+
+    private final Screen parent;
+    private final WaypointerConfig config;
+    private final ActiveGroupManager manager;
+    private final WaypointGroup targetGroup;
+    private final int[] palette;
+    private final byte[] pixels;
+    private FaceView faceView;
+    private int selectedPalette;
+    private WaypointPaint.Face cursorFace = WaypointPaint.Face.NORTH;
+    private int cursorX;
+    private int cursorY;
+    private boolean painting;
+    private int lastPaintOffset = -1;
+    private WaypointPaint snapshot;
+    private WaypointPaintPreviewTexture preview;
+    private String status = "";
+    private Button faceViewButton;
+    private CanvasButton canvasButton;
+
+    public WaypointPainterScreen(Screen parent, WaypointerConfig config,
+                                 ActiveGroupManager manager) {
+        this(parent, config, manager, null);
+    }
+
+    public WaypointPainterScreen(Screen parent, WaypointerConfig config,
+                                 ActiveGroupManager manager, WaypointGroup targetGroup) {
+        super(Component.literal("Waypoint Painter"));
+        this.parent = parent;
+        this.config = config;
+        this.manager = manager;
+        this.targetGroup = targetGroup;
+        WaypointPaint initial = initialPaint(manager, config, targetGroup);
+        if (!config.hasWaypointPainterPalette()) {
+            config.setWaypointPainterPalette(initial.paletteCopy());
+        }
+        this.palette = config.waypointPainterPalette();
+        this.pixels = initial.pixelsCopy();
+        this.faceView = initial.hasIdenticalFaces() ? FaceView.ONE : FaceView.ALL;
+    }
+
+    @Override
+    protected void init() {
+        Layout layout = layout();
+        if (preview == null) preview = new WaypointPaintPreviewTexture();
+
+        int columns = layout.paletteColumns();
+        int swatchW = (PALETTE_W - SWATCH_GAP * (columns - 1)) / columns;
+        for (int slot = 0; slot < WaypointPaint.PALETTE_SIZE; slot++) {
+            int column = slot % columns;
+            int row = slot / columns;
+            int x = layout.paletteX() + column * (swatchW + SWATCH_GAP);
+            int y = layout.swatchesY() + row * (SWATCH_H + SWATCH_GAP);
+            PaletteButton button = new PaletteButton(x, y, swatchW, SWATCH_H, slot);
+            button.setTooltip(Tooltip.create(Component.literal(
+                    "Select color " + (slot + 1) + " (#" + String.format("%06X", palette[slot]) + ").")));
+            addRenderableWidget(button);
+        }
+
+        addRenderableWidget(styledButton(layout.paletteX(), layout.editColorY(),
+                PALETTE_W, BTN_H, Component.literal("Colors"),
+                b -> editSelectedColor(),
+                Tooltip.create(Component.literal("Change the selected swatch."))));
+
+        faceViewButton = styledButton(layout.paletteX(), layout.faceViewY(),
+                PALETTE_W, BTN_H, Component.literal(faceViewLabel()),
+                b -> toggleFaceView(),
+                Tooltip.create(Component.literal(
+                        "One repeats one face on every side. All Faces edits each side.")));
+        addRenderableWidget(faceViewButton);
+
+        canvasButton = new CanvasButton(layout.canvasLeft(), layout.contentTop(),
+                layout.canvasRight() - layout.canvasLeft(),
+                layout.contentBottom() - layout.contentTop());
+        addRenderableWidget(canvasButton);
+
+        addRenderableWidget(styledButton(PAD_OUTER, height - FOOTER_H,
+                64, BTN_H, Component.literal("Back"), b -> onClose(), null));
+        addRenderableWidget(styledButton(width - PAD_OUTER - 72, height - FOOTER_H,
+                72, BTN_H, Component.literal("Apply"), b -> openApplyTargets(),
+                Tooltip.create(Component.literal(targetGroup == null
+                        ? "Choose which waypoint routes receive this paint."
+                        : "Apply this paint to the current route."))));
+    }
+
+    @Override
+    public void extractRenderState(GuiGraphicsExtractor g, int mouseX, int mouseY, float partial) {
+        Layout layout = layout();
+        g.fill(0, 0, width, height, SURFACE);
+        String title = getTitle().getString();
+        g.text(font, title, (width - font.width(title)) / 2, PAD_OUTER, TEXT, false);
+
+        g.fill(layout.paletteX() - 4, layout.contentTop(),
+                layout.paletteX() + PALETTE_W + 4, layout.contentBottom(), SURFACE_SUBTLE);
+        g.text(font, "Swatches", layout.paletteX(), layout.contentTop() + 6, TEXT_DIM, false);
+        g.text(font, "Face View", layout.paletteX(), layout.faceViewY() - 11, TEXT_DIM, false);
+
+        drawCanvas(g, layout, mouseX, mouseY);
+        drawPreview(g, layout);
+        super.extractRenderState(g, mouseX, mouseY, partial);
+
+        if (!status.isEmpty()) {
+            String clipped = font.plainSubstrByWidth(status, Math.max(0, width - 190));
+            g.text(font, clipped, (width - font.width(clipped)) / 2,
+                    height - FOOTER_H + 6, TEXT_DIM, false);
+        }
+    }
+
+    private void drawCanvas(GuiGraphicsExtractor g, Layout layout, int mouseX, int mouseY) {
+        g.fill(layout.canvasLeft(), layout.contentTop(),
+                layout.canvasRight(), layout.contentBottom(), SURFACE_SUBTLE);
+        String label = faceView == FaceView.ONE ? "16x16 face" : "All Faces";
+        g.text(font, label, layout.canvasLeft() + 6, layout.contentTop() + 6, TEXT_DIM, false);
+
+        if (faceView == FaceView.ONE) {
+            drawFace(g, layout, WaypointPaint.Face.NORTH, 0, 0, mouseX, mouseY);
+        } else {
+            for (WaypointPaint.Face face : WaypointPaint.Face.values()) {
+                drawFace(g, layout, face, face.atlasX() / WaypointPaint.SIZE,
+                        face.atlasY() / WaypointPaint.SIZE, mouseX, mouseY);
+            }
+        }
+    }
+
+    private void drawFace(GuiGraphicsExtractor g, Layout layout, WaypointPaint.Face face,
+                          int faceColumn, int faceRow, int mouseX, int mouseY) {
+        int left = layout.gridLeft() + faceColumn * WaypointPaint.SIZE * layout.cell();
+        int top = layout.gridTop() + faceRow * WaypointPaint.SIZE * layout.cell();
+        int faceSize = WaypointPaint.SIZE * layout.cell();
+        g.fill(left - 1, top - 1, left + faceSize + 1, top + faceSize + 1, BORDER);
+        for (int y = 0; y < WaypointPaint.SIZE; y++) {
+            for (int x = 0; x < WaypointPaint.SIZE; x++) {
+                int color = palette[Byte.toUnsignedInt(pixels[WaypointPaint.pixelOffset(face, x, y)])];
+                int x1 = left + x * layout.cell();
+                int y1 = top + y * layout.cell();
+                g.fill(x1, y1, x1 + layout.cell(), y1 + layout.cell(), 0xFF000000 | color);
+            }
+        }
+        if (layout.cell() >= 3) {
+            for (int line = 1; line < WaypointPaint.SIZE; line++) {
+                int lineX = left + line * layout.cell();
+                int lineY = top + line * layout.cell();
+                g.fill(lineX, top, lineX + 1, top + faceSize, 0x70000000);
+                g.fill(left, lineY, left + faceSize, lineY + 1, 0x70000000);
+            }
+        }
+
+        PaintCell hovered = cellAt(layout, mouseX, mouseY);
+        if (hovered != null && hovered.face() == face) {
+            outlineCell(g, left, top, hovered.x(), hovered.y(), layout.cell(), 0xFFFFFFFF);
+        }
+        if (getFocused() == canvasButton && cursorFace == face) {
+            outlineCell(g, left, top, cursorX, cursorY, layout.cell(), ACCENT);
+        }
+    }
+
+    private static void outlineCell(GuiGraphicsExtractor g, int faceLeft, int faceTop,
+                                    int x, int y, int cell, int color) {
+        int x1 = faceLeft + x * cell;
+        int y1 = faceTop + y * cell;
+        int x2 = x1 + cell;
+        int y2 = y1 + cell;
+        g.fill(x1, y1, x2, y1 + 1, color);
+        g.fill(x1, y2 - 1, x2, y2, color);
+        g.fill(x1, y1, x1 + 1, y2, color);
+        g.fill(x2 - 1, y1, x2, y2, color);
+    }
+
+    private void drawPreview(GuiGraphicsExtractor g, Layout layout) {
+        g.fill(layout.previewX(), layout.previewY(),
+                layout.previewX() + layout.previewSize(),
+                layout.previewY() + layout.previewSize(), SURFACE_SUBTLE);
+        preview.update(snapshot(), (System.currentTimeMillis() % 12_000L) * 0.03f);
+        g.blit(RenderPipelines.GUI_TEXTURED, preview.id(),
+                layout.previewX(), layout.previewY(), 0f, 0f,
+                layout.previewSize(), layout.previewSize(),
+                WaypointPaintPreviewTexture.SIZE, WaypointPaintPreviewTexture.SIZE,
+                WaypointPaintPreviewTexture.SIZE, WaypointPaintPreviewTexture.SIZE);
+        String label = "Live preview";
+        g.text(font, label,
+                layout.previewX() + (layout.previewSize() - font.width(label)) / 2,
+                layout.previewY() + layout.previewSize() + 5, TEXT_DIM, false);
+    }
+
+    private void editSelectedColor() {
+        ColorPickerScreen.open(this, "Paint Swatch", palette[selectedPalette], picked -> {
+            palette[selectedPalette] = picked & 0xFFFFFF;
+            config.setWaypointPainterPalette(palette);
+            snapshot = null;
+            status = "";
+        });
+    }
+
+    private void toggleFaceView() {
+        if (faceView == FaceView.ALL) {
+            faceView = FaceView.ONE;
+            cursorFace = WaypointPaint.Face.NORTH;
+        } else {
+            faceView = FaceView.ALL;
+        }
+        snapshot = null;
+        status = "";
+        if (faceViewButton != null) faceViewButton.setMessage(Component.literal(faceViewLabel()));
+    }
+
+    static void repeatFace(byte[] pixels, WaypointPaint.Face source) {
+        if (pixels == null || pixels.length != WaypointPaint.PIXEL_COUNT || source == null) {
+            throw new IllegalArgumentException("complete waypoint paint and source face are required");
+        }
+        int sourceOffset = source.ordinal() * WaypointPaint.FACE_PIXELS;
+        byte[] face = Arrays.copyOfRange(
+                pixels, sourceOffset, sourceOffset + WaypointPaint.FACE_PIXELS);
+        for (WaypointPaint.Face target : WaypointPaint.Face.values()) {
+            System.arraycopy(face, 0, pixels,
+                    target.ordinal() * WaypointPaint.FACE_PIXELS,
+                    WaypointPaint.FACE_PIXELS);
+        }
+    }
+
+    private String faceViewLabel() {
+        return faceView == FaceView.ONE ? "One" : "All";
+    }
+
+    private void openApplyTargets() {
+        if (targetGroup != null) {
+            applyToGroup(targetGroup);
+            onClose();
+            return;
+        }
+        MinecraftCompat.setScreen(minecraft, new WaypointPaintApplyScreen(this, manager));
+    }
+
+    void applyToAllGroups() {
+        int count = applyToAllGroups(manager, config, snapshot());
+        status = count == 1 ? "Applied to 1 route." : "Applied to " + count + " routes.";
+    }
+
+    static int applyToAllGroups(ActiveGroupManager manager, WaypointerConfig config,
+                                WaypointPaint paint) {
+        int count = 0;
+        for (WaypointGroup group : manager.allGroups()) {
+            if (!isPaintTarget(group)) continue;
+            group.setPaint(paint);
+            group.setPaintEnabled(true);
+            count++;
+        }
+        config.setWaypointPainterDefaultPaint(paint);
+        if (count > 0) manager.fireDataChanged();
+        return count;
+    }
+
+    void applyToGroup(WaypointGroup group) {
+        if (!isPaintTarget(group) || manager.get(group.id()) != group) return;
+        group.setPaint(snapshot());
+        group.setPaintEnabled(true);
+        manager.fireDataChangedFor(group);
+        status = "Applied to " + group.name() + ".";
+    }
+
+    private static boolean isPaintTarget(WaypointGroup group) {
+        return group != null && !group.temp() && !group.runtimeOnly();
+    }
+
+    private WaypointPaint snapshot() {
+        if (snapshot == null) {
+            byte[] snapshotPixels = faceView == FaceView.ONE
+                    ? repeatedFaceCopy(pixels, WaypointPaint.Face.NORTH)
+                    : pixels;
+            snapshot = new WaypointPaint(palette, snapshotPixels);
+        }
+        return snapshot;
+    }
+
+    static byte[] repeatedFaceCopy(byte[] pixels, WaypointPaint.Face source) {
+        if (pixels == null) throw new IllegalArgumentException("waypoint paint is required");
+        byte[] repeated = pixels.clone();
+        repeatFace(repeated, source);
+        return repeated;
+    }
+
+    private void paint(PaintCell cell) {
+        int offset = WaypointPaint.pixelOffset(cell.face(), cell.x(), cell.y());
+        if (offset == lastPaintOffset) return;
+        lastPaintOffset = offset;
+        cursorFace = cell.face();
+        cursorX = cell.x();
+        cursorY = cell.y();
+        if (faceView == FaceView.ONE) {
+            for (WaypointPaint.Face face : WaypointPaint.Face.values()) {
+                pixels[WaypointPaint.pixelOffset(face, cell.x(), cell.y())] = (byte) selectedPalette;
+            }
+        } else {
+            pixels[offset] = (byte) selectedPalette;
+        }
+        snapshot = null;
+        status = "";
+    }
+
+    @Override
+    public boolean mouseClicked(MouseButtonEvent event, boolean doubleClick) {
+        if (event.button() == 0) {
+            PaintCell cell = cellAt(layout(), event.x(), event.y());
+            if (cell != null) {
+                setFocused(null);
+                painting = true;
+                lastPaintOffset = -1;
+                paint(cell);
+                return true;
+            }
+            Layout layout = layout();
+            if (event.x() >= layout.canvasLeft() && event.x() < layout.canvasRight()
+                    && event.y() >= layout.contentTop() && event.y() < layout.contentBottom()) {
+                setFocused(null);
+                return true;
+            }
+        }
+        return super.mouseClicked(event, doubleClick);
+    }
+
+    @Override
+    public boolean mouseDragged(MouseButtonEvent event, double dx, double dy) {
+        if (painting && event.button() == 0) {
+            PaintCell cell = cellAt(layout(), event.x(), event.y());
+            if (cell != null) paint(cell);
+            return true;
+        }
+        return super.mouseDragged(event, dx, dy);
+    }
+
+    @Override
+    public boolean mouseReleased(MouseButtonEvent event) {
+        painting = false;
+        lastPaintOffset = -1;
+        return super.mouseReleased(event);
+    }
+
+    @Override
+    public boolean keyPressed(KeyEvent event) {
+        if (getFocused() == canvasButton && event.key() != GLFW_KEY_TAB) {
+            switch (event.key()) {
+                case GLFW_KEY_LEFT -> moveCursor(-1, 0);
+                case GLFW_KEY_RIGHT -> moveCursor(1, 0);
+                case GLFW_KEY_UP -> moveCursor(0, -1);
+                case GLFW_KEY_DOWN -> moveCursor(0, 1);
+                case GLFW_KEY_SPACE, GLFW_KEY_ENTER -> {
+                    lastPaintOffset = -1;
+                    paint(new PaintCell(cursorFace, cursorX, cursorY));
+                }
+                default -> { return super.keyPressed(event); }
+            }
+            return true;
+        }
+        return super.keyPressed(event);
+    }
+
+    private void moveCursor(int dx, int dy) {
+        if (faceView == FaceView.ONE) {
+            cursorX = Math.max(0, Math.min(WaypointPaint.SIZE - 1, cursorX + dx));
+            cursorY = Math.max(0, Math.min(WaypointPaint.SIZE - 1, cursorY + dy));
+            return;
+        }
+
+        int atlasX = cursorFace.atlasX() + cursorX + dx;
+        int atlasY = cursorFace.atlasY() + cursorY + dy;
+        WaypointPaint.Face target = faceAtAtlasPixel(atlasX, atlasY);
+        if (target == null) return;
+        cursorFace = target;
+        cursorX = atlasX - target.atlasX();
+        cursorY = atlasY - target.atlasY();
+    }
+
+    static WaypointPaint.Face faceAtAtlasPixel(int atlasX, int atlasY) {
+        for (WaypointPaint.Face face : WaypointPaint.Face.values()) {
+            if (atlasX >= face.atlasX() && atlasX < face.atlasX() + WaypointPaint.SIZE
+                    && atlasY >= face.atlasY() && atlasY < face.atlasY() + WaypointPaint.SIZE) {
+                return face;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void onClose() {
+        MinecraftCompat.setScreen(minecraft, parent);
+    }
+
+    @Override
+    public void removed() {
+        if (preview != null) {
+            preview.release();
+            preview = null;
+        }
+        super.removed();
+    }
+
+    private PaintCell cellAt(Layout layout, double mouseX, double mouseY) {
+        if (faceView == FaceView.ONE) {
+            return cellInsideFace(layout, WaypointPaint.Face.NORTH, 0, 0, mouseX, mouseY);
+        }
+        for (WaypointPaint.Face face : WaypointPaint.Face.values()) {
+            PaintCell cell = cellInsideFace(layout, face,
+                    face.atlasX() / WaypointPaint.SIZE,
+                    face.atlasY() / WaypointPaint.SIZE, mouseX, mouseY);
+            if (cell != null) return cell;
+        }
+        return null;
+    }
+
+    private static PaintCell cellInsideFace(Layout layout, WaypointPaint.Face face,
+                                            int column, int row,
+                                            double mouseX, double mouseY) {
+        int left = layout.gridLeft() + column * WaypointPaint.SIZE * layout.cell();
+        int top = layout.gridTop() + row * WaypointPaint.SIZE * layout.cell();
+        int size = WaypointPaint.SIZE * layout.cell();
+        if (mouseX < left || mouseX >= left + size || mouseY < top || mouseY >= top + size) {
+            return null;
+        }
+        return new PaintCell(face,
+                (int) ((mouseX - left) / layout.cell()),
+                (int) ((mouseY - top) / layout.cell()));
+    }
+
+    private Layout layout() {
+        int contentTop = PAD_OUTER + font.lineHeight + GAP;
+        int contentBottom = height - FOOTER_H - GAP;
+        int paletteX = PAD_OUTER + 4;
+        int paletteColumns = height < 300 ? 4 : 2;
+        int paletteRows = (WaypointPaint.PALETTE_SIZE + paletteColumns - 1) / paletteColumns;
+        int swatchesY = contentTop + 18;
+        int editColorY = swatchesY + paletteRows * (SWATCH_H + SWATCH_GAP) + GAP_TIGHT;
+        int faceViewY = Math.min(contentBottom - BTN_H,
+                editColorY + BTN_H + font.lineHeight + GAP);
+
+        int previewSize = Math.min(PREVIEW_MAX,
+                Math.max(72, Math.min(contentBottom - contentTop - 18, width / 5)));
+        int previewX = width - PAD_OUTER - previewSize;
+        int previewY = contentTop + Math.max(0,
+                (contentBottom - contentTop - previewSize - font.lineHeight) / 2);
+        int canvasLeft = paletteX + PALETTE_W + GAP_SECTION;
+        int canvasRight = previewX - GAP_SECTION;
+        int canvasWidth = Math.max(16, canvasRight - canvasLeft - 12);
+        int canvasHeight = Math.max(16, contentBottom - contentTop - 28);
+        int columns = faceView == FaceView.ONE ? 1 : 4;
+        int rows = faceView == FaceView.ONE ? 1 : 3;
+        int cell = Math.max(1, Math.min(12,
+                Math.min(canvasWidth / (columns * WaypointPaint.SIZE),
+                        canvasHeight / (rows * WaypointPaint.SIZE))));
+        int gridWidth = columns * WaypointPaint.SIZE * cell;
+        int gridHeight = rows * WaypointPaint.SIZE * cell;
+        int gridLeft = canvasLeft + Math.max(6, (canvasRight - canvasLeft - gridWidth) / 2);
+        int gridTop = contentTop + 22 + Math.max(0,
+                (contentBottom - contentTop - 22 - gridHeight) / 2);
+        return new Layout(contentTop, contentBottom, paletteX, paletteColumns, swatchesY,
+                editColorY, faceViewY, canvasLeft, canvasRight,
+                gridLeft, gridTop, cell, previewX, previewY, previewSize);
+    }
+
+    private static WaypointPaint initialPaint(ActiveGroupManager manager, WaypointerConfig config,
+                                              WaypointGroup targetGroup) {
+        if (targetGroup != null) {
+            if (targetGroup.paint() != null) return targetGroup.paint();
+            WaypointPaint inherited = config.waypointPainterDefaultPaint();
+            if (targetGroup.paintEnabled() && inherited != null) return inherited;
+            return new WaypointPaint(config.waypointPainterPalette(),
+                    new byte[WaypointPaint.PIXEL_COUNT]);
+        }
+        if (manager != null) {
+            String activeZone = manager.currentZone() == null ? null : manager.currentZone().id();
+            for (WaypointGroup group : manager.allGroups()) {
+                if (isPaintTarget(group) && group.enabled()
+                        && activeZone != null && activeZone.equals(group.zoneId())
+                        && group.paint() != null) {
+                    return group.paint();
+                }
+            }
+            for (WaypointGroup group : manager.allGroups()) {
+                if (isPaintTarget(group) && group.paint() != null) return group.paint();
+            }
+        }
+        WaypointPaint inherited = config.waypointPainterDefaultPaint();
+        return inherited != null ? inherited : new WaypointPaint(
+                config.waypointPainterPalette(), new byte[WaypointPaint.PIXEL_COUNT]);
+    }
+
+    private record PaintCell(WaypointPaint.Face face, int x, int y) {}
+
+    private record Layout(int contentTop, int contentBottom, int paletteX,
+                          int paletteColumns, int swatchesY, int editColorY, int faceViewY,
+                          int canvasLeft, int canvasRight,
+                          int gridLeft, int gridTop, int cell,
+                          int previewX, int previewY, int previewSize) {}
+
+    private final class PaletteButton extends AbstractButton {
+        private final int slot;
+
+        private PaletteButton(int x, int y, int width, int height, int slot) {
+            super(x, y, width, height, Component.literal("Paint color " + (slot + 1)));
+            this.slot = slot;
+        }
+
+        @Override
+        public void onPress(InputWithModifiers input) {
+            selectedPalette = slot;
+        }
+
+        @Override
+        protected void extractContents(GuiGraphicsExtractor g, int mouseX, int mouseY, float partial) {
+            int border = selectedPalette == slot ? ACCENT
+                    : isHoveredOrFocused() ? 0xFFFFFFFF : BORDER;
+            g.fill(getX(), getY(), getX() + getWidth(), getY() + getHeight(), border);
+            g.fill(getX() + 2, getY() + 2,
+                    getX() + getWidth() - 2, getY() + getHeight() - 2,
+                    0xFF000000 | palette[slot]);
+        }
+
+        @Override
+        protected void updateWidgetNarration(NarrationElementOutput output) {
+            defaultButtonNarrationText(output);
+        }
+    }
+
+    private final class CanvasButton extends AbstractButton {
+        private CanvasButton(int x, int y, int width, int height) {
+            super(x, y, width, height, Component.literal(
+                    "Waypoint paint canvas. Arrow keys move; Space paints."));
+        }
+
+        @Override
+        public void onPress(InputWithModifiers input) {
+            // Focus is the action; painting is handled by the screen with pixel coordinates.
+        }
+
+        @Override
+        protected void extractContents(GuiGraphicsExtractor g, int mouseX, int mouseY, float partial) {
+            // Focus is shown on the keyboard cursor cell, not around the pane.
+        }
+
+        @Override
+        protected void updateWidgetNarration(NarrationElementOutput output) {
+            defaultButtonNarrationText(output);
+        }
+    }
+}

--- a/src/client/java/com/babbur/waypointer/screen/WaypointerScreen.java
+++ b/src/client/java/com/babbur/waypointer/screen/WaypointerScreen.java
@@ -123,7 +123,7 @@ public final class WaypointerScreen extends Screen {
             "Hide every shown route in this zone.\n"
           + "Double click to confirm.";
     private static final String CONFIRM_LABEL = "Confirm?";
-    private static final String NO_SEL_LABEL  = "Pick route";
+    private static final String NO_SEL_LABEL  = "Select";
     private static final String DELETE_TOOLTIP_DEFAULT =
             "Remove the selected route permanently.\n"
           + "Double click to confirm.";
@@ -2404,8 +2404,8 @@ public final class WaypointerScreen extends Screen {
                 selectedZoneId = selectorEntryForZoneId(first.zoneId());
                 selectGroupById(first.id());
             }
-        } catch (IllegalArgumentException e) {
-            ImportFeedback.failure(e.getMessage());
+        } catch (IllegalArgumentException ignored) {
+            ImportFeedback.failure("Invalid import text.");
         }
     }
 

--- a/src/client/java/com/babbur/waypointer/screen/settings/SettingsCatalog.java
+++ b/src/client/java/com/babbur/waypointer/screen/settings/SettingsCatalog.java
@@ -62,6 +62,7 @@ public final class SettingsCatalog {
     public static final String ACTION_DISABLE_ALL = "action.disableAll";
     public static final String ACTION_RESET_DEFAULTS = "action.resetDefaults";
     public static final String ACTION_PERF_TEST = "action.perfTest";
+    public static final String ACTION_WAYPOINT_PAINT = "action.waypointPaint";
 
     private static final Setting.EnabledWhen ANY_LABEL_TEXT = (c, d) ->
             c.showWaypointNames() || c.showWaypointDistances() || c.showRouteProgress();
@@ -188,6 +189,9 @@ public final class SettingsCatalog {
                                 "Default Waypoint Colour", "Pick default waypoint color.",
                                 (c, d) -> c.defaultWaypointColor(),
                                 (c, d, v) -> c.setDefaultWaypointColor(rgb(v))),
+                        Setting.action(ACTION_WAYPOINT_PAINT, "Paint",
+                                "Design a 16x16 texture for waypoint boxes, then apply it to every route or a selected route.")
+                                .aliases("painter", "texture", "pixel"),
                         Setting.bool("placeNewWaypointsBelowPlayer", MAIN, "Add new waypoints below player",
                                 "Waypoints created at your position go one block below you, under your feet.",
                                 (c, d) -> c.placeNewWaypointsBelowPlayer(),
@@ -474,6 +478,10 @@ public final class SettingsCatalog {
                                 (c, d) -> c.autoAddChatTempWaypoints(),
                                 (c, d, v) -> c.setAutoAddChatTempWaypoints((Boolean) v))),
                 Group.plain(null,
+                        Setting.bool("showWaypointChatShareButtons", MAIN, "New waypoint chat share buttons",
+                                "Show [All] and [Party] buttons after creating a waypoint.",
+                                (c, d) -> c.showWaypointChatShareButtons(),
+                                (c, d, v) -> c.setShowWaypointChatShareButtons((Boolean) v)),
                         Setting.bool("chatCodecDetection", MAIN, "Chat codec detection (imports)",
                                 "Detect Waypointer share codes in chat.",
                                 (c, d) -> c.chatCodecDetection(),

--- a/src/client/java/com/babbur/waypointer/screen/settings/SettingsPresets.java
+++ b/src/client/java/com/babbur/waypointer/screen/settings/SettingsPresets.java
@@ -32,6 +32,7 @@ public final class SettingsPresets {
         out.setDimSequenceContextWaypoints(false);
         out.setEditSounds(false);
         out.setShowEditModeSubtitle(false);
+        out.setShowWaypointChatShareButtons(false);
         out.setShowContributorBadges(false);
         out.setMaxWaypointLabels(12);
         out.setMaxStaticWaypointRenderDistance(128);

--- a/src/client/resources/waypointer.client.mixins.json
+++ b/src/client/resources/waypointer.client.mixins.json
@@ -5,6 +5,7 @@
     "client": [
         "ChatComponentMixin",
         "ClientPacketListenerMixin",
+        "PlayerInfoMixin",
         "PlayerTabOverlayMixin"
     ],
     "injectors": {

--- a/src/main/java/com/babbur/waypointer/config/Storage.java
+++ b/src/main/java/com/babbur/waypointer/config/Storage.java
@@ -9,6 +9,7 @@ import com.babbur.waypointer.Waypointer;
 import com.babbur.waypointer.core.ActiveGroupManager;
 import com.babbur.waypointer.core.Waypoint;
 import com.babbur.waypointer.core.WaypointGroup;
+import com.babbur.waypointer.core.WaypointPaint;
 import net.fabricmc.loader.api.FabricLoader;
 
 import java.io.IOException;
@@ -271,6 +272,8 @@ public final class Storage {
         // less parser branch in load().
         o.addProperty("gradientStartColor", g.gradientStartColor());
         o.addProperty("gradientEndColor",   g.gradientEndColor());
+        o.addProperty("paintEnabled", g.paintEnabled());
+        if (g.paint() != null) o.add("paint", paintToJson(g.paint()));
         JsonArray wps = new JsonArray();
         for (Waypoint w : g.waypoints()) {
             // Temporary waypoints are client-session ephemeral by contract.
@@ -300,6 +303,17 @@ public final class Storage {
         // missing values leave the group on its built-in cyan/red defaults.
         if (o.has("gradientStartColor")) g.setGradientStartColor(o.get("gradientStartColor").getAsInt());
         if (o.has("gradientEndColor"))   g.setGradientEndColor(o.get("gradientEndColor").getAsInt());
+        if (o.has("paintEnabled")) g.setPaintEnabled(o.get("paintEnabled").getAsBoolean());
+        if (o.has("paint") && !o.get("paint").isJsonNull()) {
+            try {
+                g.setPaint(paintFromJson(o.getAsJsonObject("paint")));
+            } catch (RuntimeException invalidPaint) {
+                // Paint is optional presentation metadata. A damaged texture must
+                // not quarantine an otherwise valid route library and risk hiding
+                // every waypoint from the user.
+                Waypointer.LOGGER.warn("Ignoring invalid waypoint paint for group {}", id, invalidPaint);
+            }
+        }
         if (o.has("waypoints")) {
             List<Waypoint> waypoints = new ArrayList<>(o.getAsJsonArray("waypoints").size());
             for (JsonElement el : o.getAsJsonArray("waypoints")) {
@@ -341,6 +355,34 @@ public final class Storage {
         int preciseY = o.has("preciseY") ? o.get("preciseY").getAsInt() : base.preciseY();
         int preciseZ = o.has("preciseZ") ? o.get("preciseZ").getAsInt() : base.preciseZ();
         return base.withPreciseSixteenths(preciseX, preciseY, preciseZ);
+    }
+
+    static JsonObject paintToJson(WaypointPaint paint) {
+        JsonObject out = new JsonObject();
+        JsonArray palette = new JsonArray();
+        for (int color : paint.paletteCopy()) palette.add(color);
+        out.add("palette", palette);
+        out.addProperty("pixels", paint.pixelsBase64());
+        return out;
+    }
+
+    static WaypointPaint paintFromJson(JsonObject o) {
+        if (o == null || !o.has("palette") || !o.get("palette").isJsonArray()) {
+            throw new IllegalArgumentException("waypoint paint palette is missing");
+        }
+        JsonArray paletteJson = o.getAsJsonArray("palette");
+        if (paletteJson.size() != WaypointPaint.PALETTE_SIZE) {
+            throw new IllegalArgumentException("waypoint paint palette must contain 16 colors");
+        }
+        int[] palette = new int[WaypointPaint.PALETTE_SIZE];
+        for (int i = 0; i < palette.length; i++) {
+            palette[i] = paletteJson.get(i).getAsInt();
+        }
+        if (!o.has("pixels") || !o.get("pixels").isJsonPrimitive()) {
+            throw new IllegalArgumentException("waypoint paint pixels are missing");
+        }
+        return new WaypointPaint(palette,
+                WaypointPaint.decodePixels(o.get("pixels").getAsString()));
     }
 
     private static <E extends Enum<E>> Optional<E> parseEnum(Class<E> type, String raw) {

--- a/src/main/java/com/babbur/waypointer/config/WaypointerConfig.java
+++ b/src/main/java/com/babbur/waypointer/config/WaypointerConfig.java
@@ -8,6 +8,7 @@ import com.google.gson.JsonParser;
 import com.babbur.waypointer.Waypointer;
 import com.babbur.waypointer.core.Waypoint;
 import com.babbur.waypointer.core.WaypointGroup;
+import com.babbur.waypointer.core.WaypointPaint;
 import com.babbur.waypointer.dungeon.config.DungeonConfig;
 import net.fabricmc.loader.api.FabricLoader;
 
@@ -83,6 +84,12 @@ public final class WaypointerConfig {
     // a fresh install with matchTracerToWaypointColor=false still shows one
     // consistent color scheme across boxes and lines.
     private int defaultWaypointColor = Waypoint.DEFAULT_COLOR;
+    /** Local painter swatches. Null keeps old configs on the generated defaults. */
+    private int[] waypointPainterPalette;
+    /** Paint inherited by routes without their own paint after Apply to All. */
+    private int[] waypointPainterDefaultPalette;
+    private String waypointPainterDefaultPixels;
+    private transient WaypointPaint waypointPainterDefaultPaintCache;
     private int tracerColor = 0x4FE05A;
     /**
      * When {@code true} (default), the tracer line to the current waypoint
@@ -283,6 +290,8 @@ public final class WaypointerConfig {
      * This is transient render focus, not a persistent route enable/disable.
      */
     private boolean focusTempWaypoints = false;
+    /** Show one-click All/Party chat actions after a player creates a waypoint. */
+    private boolean showWaypointChatShareButtons = true;
     private boolean chatCodecDetection = true;
     private boolean showContributorBadges = true;
     /** Default color mode applied after any route import. */
@@ -498,6 +507,32 @@ public final class WaypointerConfig {
     public boolean resetProgressOnWorldJoin() { return resetProgressOnWorldJoin; }
     public boolean restartRouteWhenComplete() { return restartRouteWhenComplete; }
     public int defaultWaypointColor()         { return defaultWaypointColor & 0xFFFFFF; }
+    public int[] waypointPainterPalette() {
+        int[] source = waypointPainterPalette;
+        if (source == null || source.length != WaypointPaint.PALETTE_SIZE) {
+            return WaypointPaint.defaultPalette(defaultWaypointColor());
+        }
+        int[] copy = source.clone();
+        for (int i = 0; i < copy.length; i++) copy[i] &= 0xFFFFFF;
+        return copy;
+    }
+    public boolean hasWaypointPainterPalette() {
+        return waypointPainterPalette != null
+                && waypointPainterPalette.length == WaypointPaint.PALETTE_SIZE;
+    }
+    public WaypointPaint waypointPainterDefaultPaint() {
+        if (waypointPainterDefaultPaintCache != null) return waypointPainterDefaultPaintCache;
+        if (waypointPainterDefaultPalette == null || waypointPainterDefaultPixels == null) return null;
+        try {
+            waypointPainterDefaultPaintCache = new WaypointPaint(waypointPainterDefaultPalette,
+                    WaypointPaint.decodePixels(waypointPainterDefaultPixels));
+            return waypointPainterDefaultPaintCache;
+        } catch (RuntimeException invalidPaint) {
+            waypointPainterDefaultPalette = null;
+            waypointPainterDefaultPixels = null;
+            return null;
+        }
+    }
     public int tracerColor()                  { return tracerColor; }
     public boolean matchTracerToWaypointColor() { return matchTracerToWaypointColor; }
     public double tracerOpacity()             { return tracerOpacity; }
@@ -542,6 +577,7 @@ public final class WaypointerConfig {
     public boolean editSounds() { return editSounds; }
     public boolean showEditModeSubtitle() { return showEditModeSubtitle; }
     public boolean chatCoordDetection()       { return chatCoordDetection; }
+    public boolean showWaypointChatShareButtons() { return showWaypointChatShareButtons; }
     public List<String> chatCoordSenderBlacklist() {
         ensureChatCoordSenderBlacklist();
         return List.copyOf(chatCoordSenderBlacklist);
@@ -597,6 +633,22 @@ public final class WaypointerConfig {
     public void setResetProgressOnWorldJoin(boolean v) { this.resetProgressOnWorldJoin = v; save(); }
     public void setRestartRouteWhenComplete(boolean v) { this.restartRouteWhenComplete = v; save(); }
     public void setDefaultWaypointColor(int v)         { this.defaultWaypointColor = v & 0xFFFFFF; save(); }
+    public void setWaypointPainterPalette(int[] palette) {
+        if (palette == null || palette.length != WaypointPaint.PALETTE_SIZE) {
+            throw new IllegalArgumentException("waypoint painter palette must contain 16 colors");
+        }
+        waypointPainterPalette = palette.clone();
+        for (int i = 0; i < waypointPainterPalette.length; i++) {
+            waypointPainterPalette[i] &= 0xFFFFFF;
+        }
+        save();
+    }
+    public void setWaypointPainterDefaultPaint(WaypointPaint paint) {
+        waypointPainterDefaultPalette = paint == null ? null : paint.paletteCopy();
+        waypointPainterDefaultPixels = paint == null ? null : paint.pixelsBase64();
+        waypointPainterDefaultPaintCache = paint;
+        save();
+    }
     public void setTracerColor(int v)                  { this.tracerColor = v & 0xFFFFFF; save(); }
     public void setMatchTracerToWaypointColor(boolean v) { this.matchTracerToWaypointColor = v; save(); }
     public void setTracerOpacity(double v)             { this.tracerOpacity = clamp(v, 0, 1); save(); }
@@ -702,6 +754,7 @@ public final class WaypointerConfig {
     public void setAutoAddChatTempWaypoints(boolean v) { this.autoAddChatTempWaypoints = v; save(); }
     public void setPlaceNewWaypointsBelowPlayer(boolean v) { this.placeNewWaypointsBelowPlayer = v; save(); }
     public void setFocusTempWaypoints(boolean v)       { this.focusTempWaypoints = v; save(); }
+    public void setShowWaypointChatShareButtons(boolean v) { this.showWaypointChatShareButtons = v; save(); }
     public void setChatCodecDetection(boolean v)       { this.chatCodecDetection = v; save(); }
     public void setShowContributorBadges(boolean v)    { this.showContributorBadges = v; save(); }
         public void setImportedRouteColorMode(WaypointGroup.GradientMode v) {
@@ -827,6 +880,7 @@ public final class WaypointerConfig {
         autoAddChatTempWaypoints = replacement.autoAddChatTempWaypoints;
         placeNewWaypointsBelowPlayer = replacement.placeNewWaypointsBelowPlayer;
         focusTempWaypoints = replacement.focusTempWaypoints;
+        showWaypointChatShareButtons = replacement.showWaypointChatShareButtons;
         chatCodecDetection = replacement.chatCodecDetection;
         showContributorBadges = replacement.showContributorBadges;
         importedRouteColorMode = replacement.importedRouteColorMode;
@@ -877,6 +931,7 @@ public final class WaypointerConfig {
         autoAddChatTempWaypoints = false;
         placeNewWaypointsBelowPlayer = false;
         focusTempWaypoints = false;
+        showWaypointChatShareButtons = false;
         chatCodecDetection = false;
         showContributorBadges = false;
         importedRouteColorMode = WaypointGroup.GradientMode.MANUAL;
@@ -904,6 +959,10 @@ public final class WaypointerConfig {
         resetProgressOnWorldJoin = defaults.resetProgressOnWorldJoin;
         restartRouteWhenComplete = defaults.restartRouteWhenComplete;
         defaultWaypointColor = defaults.defaultWaypointColor;
+        waypointPainterPalette = null;
+        waypointPainterDefaultPalette = null;
+        waypointPainterDefaultPixels = null;
+        waypointPainterDefaultPaintCache = null;
         tracerColor = defaults.tracerColor;
         matchTracerToWaypointColor = defaults.matchTracerToWaypointColor;
         tracerOpacity = defaults.tracerOpacity;
@@ -948,6 +1007,7 @@ public final class WaypointerConfig {
         autoAddChatTempWaypoints = defaults.autoAddChatTempWaypoints;
         placeNewWaypointsBelowPlayer = defaults.placeNewWaypointsBelowPlayer;
         focusTempWaypoints = defaults.focusTempWaypoints;
+        showWaypointChatShareButtons = defaults.showWaypointChatShareButtons;
         chatCodecDetection = defaults.chatCodecDetection;
         showContributorBadges = defaults.showContributorBadges;
         importedRouteColorMode = defaults.importedRouteColorMode;

--- a/src/main/java/com/babbur/waypointer/config/WaypointerConfigCodec.java
+++ b/src/main/java/com/babbur/waypointer/config/WaypointerConfigCodec.java
@@ -93,6 +93,7 @@ public final class WaypointerConfigCodec {
     private static final int DUNGEON_ENTRY_PATH_TO_FOLLOWING_WAYPOINTS = 62;
     private static final int SHOW_CONTRIBUTOR_BADGES = 63;
     private static final int SHOW_LABEL_TEXT_SHADOW = 64;
+    private static final int SHOW_WAYPOINT_CHAT_SHARE_BUTTONS = 65;
 
     private WaypointerConfigCodec() {
     }
@@ -192,6 +193,8 @@ public final class WaypointerConfigCodec {
         writeBoolean(out, AUTO_ADD_CHAT_TEMP_WAYPOINTS, config.autoAddChatTempWaypoints(), defaults.autoAddChatTempWaypoints());
         writeBoolean(out, PLACE_NEW_WAYPOINTS_BELOW_PLAYER, config.placeNewWaypointsBelowPlayer(), defaults.placeNewWaypointsBelowPlayer());
         writeBoolean(out, FOCUS_TEMP_WAYPOINTS, config.focusTempWaypoints(), defaults.focusTempWaypoints());
+        writeBoolean(out, SHOW_WAYPOINT_CHAT_SHARE_BUTTONS,
+                config.showWaypointChatShareButtons(), defaults.showWaypointChatShareButtons());
         writeBoolean(out, CHAT_CODEC_DETECTION, config.chatCodecDetection(), defaults.chatCodecDetection());
         writeBoolean(out, SHOW_CONTRIBUTOR_BADGES, config.showContributorBadges(), defaults.showContributorBadges());
         writeEnum(out, IMPORTED_ROUTE_COLOR_MODE, config.importedRouteColorMode(), defaults.importedRouteColorMode());
@@ -262,6 +265,8 @@ public final class WaypointerConfigCodec {
                 case AUTO_ADD_CHAT_TEMP_WAYPOINTS -> config.setAutoAddChatTempWaypoints(in.readBoolean());
                 case PLACE_NEW_WAYPOINTS_BELOW_PLAYER -> config.setPlaceNewWaypointsBelowPlayer(in.readBoolean());
                 case FOCUS_TEMP_WAYPOINTS -> config.setFocusTempWaypoints(in.readBoolean());
+                case SHOW_WAYPOINT_CHAT_SHARE_BUTTONS ->
+                        config.setShowWaypointChatShareButtons(in.readBoolean());
                 case CHAT_CODEC_DETECTION -> config.setChatCodecDetection(in.readBoolean());
                 case SHOW_CONTRIBUTOR_BADGES -> config.setShowContributorBadges(in.readBoolean());
                 case IMPORTED_ROUTE_COLOR_MODE -> config.setImportedRouteColorMode(readEnum(in, WaypointGroup.GradientMode.values(), WaypointGroup.GradientMode.STATIC));

--- a/src/main/java/com/babbur/waypointer/core/WaypointGroup.java
+++ b/src/main/java/com/babbur/waypointer/core/WaypointGroup.java
@@ -91,6 +91,15 @@ public final class WaypointGroup {
     // so "next" is visually the calmest point on a route.
     private int gradientStartColor = 0x00BFFF;
     private int gradientEndColor   = 0xFF3040;
+    /** Optional six-face pixel paint. Null keeps the normal per-waypoint color fill. */
+    private WaypointPaint paint;
+    /**
+     * Whether this route uses painted faces when either a route paint or the
+     * painter's global default exists. Defaults on so an "All Waypoints" paint
+     * also reaches routes created later; choosing Color, Gradient, or One turns
+     * it off for that route without deleting its artwork.
+     */
+    private boolean paintEnabled = true;
     /**
      * Session-only reach state for static-route cycling. Unlike currentIndex,
      * this is unordered: a static map overlay lets the player visit points in
@@ -160,6 +169,8 @@ public final class WaypointGroup {
         public int staticColor()      { return staticColor; }
     public int gradientStartColor() { return gradientStartColor; }
     public int gradientEndColor()   { return gradientEndColor; }
+    public WaypointPaint paint()    { return paint; }
+    public boolean paintEnabled()   { return paintEnabled; }
     public boolean skipAheadEnabled() { return skipAheadEnabled; }
     public boolean temp()           { return temp; }
     public boolean runtimeOnly()    { return runtimeOnly; }
@@ -290,6 +301,8 @@ public final class WaypointGroup {
     public void setSkipAheadEnabled(boolean on)         { this.skipAheadEnabled = on; }
     public void setTemp(boolean on)                     { this.temp = on; }
     public void setRuntimeOnly(boolean on)              { this.runtimeOnly = on; }
+    public void setPaint(WaypointPaint paint)            { this.paint = paint; }
+    public void setPaintEnabled(boolean on)               { this.paintEnabled = on; }
 
     /**
      * Set the group's gradient endpoints. Setters immediately reapply the gradient

--- a/src/main/java/com/babbur/waypointer/core/WaypointPaint.java
+++ b/src/main/java/com/babbur/waypointer/core/WaypointPaint.java
@@ -1,0 +1,153 @@
+package com.babbur.waypointer.core;
+
+import java.util.Arrays;
+import java.util.Base64;
+
+/**
+ * Immutable 16x16 texture for the six faces of a waypoint box.
+ *
+ * <p>Pixels store indices into a fixed sixteen-color palette. That keeps a full
+ * six-face paint close to 2 KiB on disk instead of repeating a 24-bit color for
+ * every texel, while still matching the painter's sixteen visible swatches.
+ */
+public final class WaypointPaint {
+
+    public static final int SIZE = 16;
+    public static final int PALETTE_SIZE = 16;
+    public static final int FACE_PIXELS = SIZE * SIZE;
+    public static final int PIXEL_COUNT = FACE_PIXELS * Face.values().length;
+
+    /** T-shaped atlas placement used by both the editor and the world renderer. */
+    public enum Face {
+        NORTH(1, 1),
+        EAST(2, 1),
+        SOUTH(3, 1),
+        WEST(0, 1),
+        UP(1, 0),
+        DOWN(1, 2);
+
+        private final int atlasColumn;
+        private final int atlasRow;
+
+        Face(int atlasColumn, int atlasRow) {
+            this.atlasColumn = atlasColumn;
+            this.atlasRow = atlasRow;
+        }
+
+        public int atlasX() {
+            return atlasColumn * SIZE;
+        }
+
+        public int atlasY() {
+            return atlasRow * SIZE;
+        }
+    }
+
+    private final int[] palette;
+    private final byte[] pixels;
+    private final int hashCode;
+
+    public WaypointPaint(int[] palette, byte[] pixels) {
+        if (palette == null || palette.length != PALETTE_SIZE) {
+            throw new IllegalArgumentException("waypoint paint palette must contain 16 colors");
+        }
+        if (pixels == null || pixels.length != PIXEL_COUNT) {
+            throw new IllegalArgumentException("waypoint paint must contain 1536 pixels");
+        }
+        this.palette = palette.clone();
+        for (int i = 0; i < this.palette.length; i++) {
+            this.palette[i] &= 0xFFFFFF;
+        }
+        this.pixels = pixels.clone();
+        for (byte pixel : this.pixels) {
+            if (Byte.toUnsignedInt(pixel) >= PALETTE_SIZE) {
+                throw new IllegalArgumentException("waypoint paint pixel uses an invalid palette slot");
+            }
+        }
+        this.hashCode = 31 * Arrays.hashCode(this.palette) + Arrays.hashCode(this.pixels);
+    }
+
+    public static WaypointPaint solid(int rgb) {
+        return new WaypointPaint(defaultPalette(rgb), new byte[PIXEL_COUNT]);
+    }
+
+    public static int[] defaultPalette(int firstColor) {
+        return new int[] {
+                firstColor & 0xFFFFFF,
+                0xF5F7FA, 0x171A1F, 0xE64646,
+                0xF28C28, 0xF2D94E, 0x4FD15A, 0x45D7D7,
+                0x4387F5, 0x7B61D1, 0xC850D1, 0xF06DAD,
+                0x8B5A3C, 0x626A73, 0xAAB1BA, 0x343A42
+        };
+    }
+
+    public int color(Face face, int x, int y) {
+        return palette[paletteIndex(face, x, y)];
+    }
+
+    public int paletteColor(int slot) {
+        checkPaletteSlot(slot);
+        return palette[slot];
+    }
+
+    public int paletteIndex(Face face, int x, int y) {
+        return Byte.toUnsignedInt(pixels[pixelOffset(face, x, y)]);
+    }
+
+    public int[] paletteCopy() {
+        return palette.clone();
+    }
+
+    public byte[] pixelsCopy() {
+        return pixels.clone();
+    }
+
+    public String pixelsBase64() {
+        return Base64.getEncoder().encodeToString(pixels);
+    }
+
+    public static byte[] decodePixels(String encoded) {
+        if (encoded == null) throw new IllegalArgumentException("waypoint paint pixels are missing");
+        byte[] decoded = Base64.getDecoder().decode(encoded);
+        if (decoded.length != PIXEL_COUNT) {
+            throw new IllegalArgumentException("waypoint paint must contain 1536 pixels");
+        }
+        return decoded;
+    }
+
+    public boolean hasIdenticalFaces() {
+        for (int face = 1; face < Face.values().length; face++) {
+            int offset = face * FACE_PIXELS;
+            for (int i = 0; i < FACE_PIXELS; i++) {
+                if (pixels[i] != pixels[offset + i]) return false;
+            }
+        }
+        return true;
+    }
+
+    public static int pixelOffset(Face face, int x, int y) {
+        if (face == null) throw new IllegalArgumentException("waypoint paint face is missing");
+        if (x < 0 || x >= SIZE || y < 0 || y >= SIZE) {
+            throw new IndexOutOfBoundsException("waypoint paint pixel outside 16x16 face");
+        }
+        return face.ordinal() * FACE_PIXELS + y * SIZE + x;
+    }
+
+    private static void checkPaletteSlot(int slot) {
+        if (slot < 0 || slot >= PALETTE_SIZE) {
+            throw new IndexOutOfBoundsException("waypoint paint palette slot outside 0..15");
+        }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) return true;
+        if (!(other instanceof WaypointPaint paint)) return false;
+        return Arrays.equals(palette, paint.palette) && Arrays.equals(pixels, paint.pixels);
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCode;
+    }
+}

--- a/src/test/java/com/babbur/waypointer/config/StorageJsonTest.java
+++ b/src/test/java/com/babbur/waypointer/config/StorageJsonTest.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonParser;
 import com.babbur.waypointer.core.ActiveGroupManager;
 import com.babbur.waypointer.core.Waypoint;
 import com.babbur.waypointer.core.WaypointGroup;
+import com.babbur.waypointer.core.WaypointPaint;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -391,6 +392,29 @@ class StorageJsonTest {
 
         assertEquals(0x112233, copy.gradientStartColor());
         assertEquals(0xFEDCBA, copy.gradientEndColor());
+    }
+
+    @Test
+    void group_waypointPaintRoundTripsAndInvalidOptionalPaintIsIgnored() {
+        WaypointGroup group = WaypointGroup.create("painted", "hub");
+        byte[] pixels = new byte[WaypointPaint.PIXEL_COUNT];
+        pixels[WaypointPaint.pixelOffset(WaypointPaint.Face.UP, 4, 5)] = 7;
+        WaypointPaint paint = new WaypointPaint(
+                WaypointPaint.defaultPalette(0x123456), pixels);
+        group.setPaint(paint);
+        group.setPaintEnabled(false);
+
+        JsonObject json = Storage.groupToJson(group);
+        assertEquals(paint, Storage.groupFromJson(json).paint());
+        assertFalse(Storage.groupFromJson(json).paintEnabled());
+
+        json.remove("paintEnabled");
+        assertTrue(Storage.groupFromJson(json).paintEnabled(),
+                "old routes inherit future Apply to All paint by default");
+
+        json.getAsJsonObject("paint").addProperty("pixels", "AA==");
+        assertNull(Storage.groupFromJson(json).paint(),
+                "bad optional paint must not discard the otherwise valid group");
     }
 
         @Test

--- a/src/test/java/com/babbur/waypointer/config/WaypointerConfigTest.java
+++ b/src/test/java/com/babbur/waypointer/config/WaypointerConfigTest.java
@@ -4,21 +4,64 @@ import com.babbur.waypointer.codec.AsciiStreamCodec;
 import com.babbur.waypointer.placement.PlayerWaypointPlacement;
 import com.babbur.waypointer.core.Waypoint;
 import com.babbur.waypointer.core.WaypointGroup;
+import com.babbur.waypointer.core.WaypointPaint;
 import com.babbur.waypointer.dungeon.config.DungeonConfig;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
+import java.util.Arrays;
 import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class WaypointerConfigTest {
+
+    @Test
+    void waypointPainterPalettePersistsAndDefensivelyCopies() {
+        WaypointerConfig config = new WaypointerConfig();
+        int[] palette = WaypointPaint.defaultPalette(0xAA123456);
+        palette[5] = 0xCCABCDEF;
+
+        config.setWaypointPainterPalette(palette);
+        palette[5] = 0;
+        int[] stored = config.waypointPainterPalette();
+        assertEquals(0xABCDEF, stored[5]);
+        stored[5] = 0;
+        assertEquals(0xABCDEF, config.waypointPainterPalette()[5]);
+
+        WaypointerConfig restarted = WaypointerConfig.fromJson(
+                "{\"waypointPainterPalette\":"
+                        + Arrays.toString(config.waypointPainterPalette()) + "}");
+        assertArrayEquals(config.waypointPainterPalette(), restarted.waypointPainterPalette());
+
+        restarted.resetToDefaults();
+        assertArrayEquals(WaypointPaint.defaultPalette(Waypoint.DEFAULT_COLOR),
+                restarted.waypointPainterPalette());
+    }
+
+    @Test
+    void applyAllDefaultPaintSurvivesConfigReloadForFutureRoutes() {
+        int[] palette = WaypointPaint.defaultPalette(0x123456);
+        byte[] pixels = new byte[WaypointPaint.PIXEL_COUNT];
+        pixels[WaypointPaint.pixelOffset(WaypointPaint.Face.UP, 2, 3)] = 5;
+        WaypointPaint paint = new WaypointPaint(palette, pixels);
+
+        WaypointerConfig restarted = WaypointerConfig.fromJson(
+                "{\"waypointPainterDefaultPalette\":" + Arrays.toString(palette)
+                        + ",\"waypointPainterDefaultPixels\":\"" + paint.pixelsBase64() + "\"}");
+
+        assertEquals(paint, restarted.waypointPainterDefaultPaint());
+        restarted.resetToDefaults();
+        assertNull(restarted.waypointPainterDefaultPaint());
+    }
 
     @Test
     void defaultReachRadiusIsAlwaysFiniteAndBounded() {
@@ -167,6 +210,19 @@ class WaypointerConfigTest {
 
         config.resetToDefaults();
         assertTrue(config.showContributorBadges());
+    }
+
+    @Test
+    void waypointChatShareButtonsDefaultOnAndResetWithOtherToggles() {
+        WaypointerConfig config = new WaypointerConfig();
+
+        assertTrue(config.showWaypointChatShareButtons());
+
+        config.disableAllSettings();
+        assertFalse(config.showWaypointChatShareButtons());
+
+        config.resetToDefaults();
+        assertTrue(config.showWaypointChatShareButtons());
     }
 
     @Test

--- a/src/test/java/com/babbur/waypointer/core/WaypointPaintTest.java
+++ b/src/test/java/com/babbur/waypointer/core/WaypointPaintTest.java
@@ -1,0 +1,59 @@
+package com.babbur.waypointer.core;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WaypointPaintTest {
+
+    @Test
+    void solidPaintRepeatsTheFirstPaletteColorAcrossEveryFace() {
+        WaypointPaint paint = WaypointPaint.solid(0x123456);
+
+        assertTrue(paint.hasIdenticalFaces());
+        for (WaypointPaint.Face face : WaypointPaint.Face.values()) {
+            assertEquals(0x123456, paint.color(face, 0, 0));
+            assertEquals(0x123456, paint.color(face, 15, 15));
+        }
+    }
+
+    @Test
+    void constructorDefensivelyCopiesAndValidatesPaletteIndices() {
+        int[] palette = WaypointPaint.defaultPalette(0x111111);
+        byte[] pixels = new byte[WaypointPaint.PIXEL_COUNT];
+        pixels[WaypointPaint.pixelOffset(WaypointPaint.Face.EAST, 4, 7)] = 3;
+        WaypointPaint paint = new WaypointPaint(palette, pixels);
+
+        palette[3] = 0;
+        pixels[WaypointPaint.pixelOffset(WaypointPaint.Face.EAST, 4, 7)] = 0;
+        assertEquals(0xE64646, paint.color(WaypointPaint.Face.EAST, 4, 7));
+
+        byte[] invalid = new byte[WaypointPaint.PIXEL_COUNT];
+        invalid[0] = 16;
+        assertThrows(IllegalArgumentException.class,
+                () -> new WaypointPaint(WaypointPaint.defaultPalette(0), invalid));
+    }
+
+    @Test
+    void base64PixelsRoundTripWithoutChangingFaceOrder() {
+        byte[] pixels = new byte[WaypointPaint.PIXEL_COUNT];
+        pixels[WaypointPaint.pixelOffset(WaypointPaint.Face.UP, 2, 9)] = 11;
+        WaypointPaint paint = new WaypointPaint(WaypointPaint.defaultPalette(0), pixels);
+
+        assertArrayEquals(pixels, WaypointPaint.decodePixels(paint.pixelsBase64()));
+        assertThrows(IllegalArgumentException.class, () -> WaypointPaint.decodePixels("AA=="));
+    }
+
+    @Test
+    void identicalFaceDetectionNoticesOneChangedTexel() {
+        byte[] pixels = new byte[WaypointPaint.PIXEL_COUNT];
+        assertTrue(new WaypointPaint(WaypointPaint.defaultPalette(0), pixels).hasIdenticalFaces());
+
+        pixels[WaypointPaint.pixelOffset(WaypointPaint.Face.SOUTH, 8, 8)] = 1;
+        assertFalse(new WaypointPaint(WaypointPaint.defaultPalette(0), pixels).hasIdenticalFaces());
+    }
+}

--- a/src/test/java/com/babbur/waypointer/dungeon/DungeonRoomRouteSyncTest.java
+++ b/src/test/java/com/babbur/waypointer/dungeon/DungeonRoomRouteSyncTest.java
@@ -3,6 +3,7 @@ package com.babbur.waypointer.dungeon;
 import com.babbur.waypointer.core.ActiveGroupManager;
 import com.babbur.waypointer.core.Waypoint;
 import com.babbur.waypointer.core.WaypointGroup;
+import com.babbur.waypointer.core.WaypointPaint;
 import com.babbur.waypointer.dungeon.config.DungeonConfig;
 import com.babbur.waypointer.dungeon.data.DungeonRoomData;
 import com.babbur.waypointer.dungeon.data.DungeonRoomDefinition;
@@ -125,6 +126,21 @@ class DungeonRoomRouteSyncTest {
 
         assertTrue(group.get(0).hasFlag(Waypoint.FLAG_SKIP_ON_STAND));
         assertFalse(group.get(0).hasFlag(Waypoint.FLAG_SKIP_ON_INTERACT));
+    }
+
+    @Test
+    void transformedUserRouteCarriesWaypointPaintIntoRuntimeMirror() {
+        DungeonRoom room = room("paint-room", "Paint Room");
+        WaypointGroup source = WaypointGroup.create("Painted Route", "paint-room");
+        source.add(Waypoint.at(1, 70, 2));
+        source.setPaint(WaypointPaint.solid(0xBADA55));
+        source.setPaintEnabled(false);
+
+        WaypointGroup mirror = DungeonRoomRouteSync.transformedRouteGroupForRoom(
+                room, source, null);
+
+        assertEquals(source.paint(), mirror.paint());
+        assertFalse(mirror.paintEnabled());
     }
 
     @Test

--- a/src/test/java/com/babbur/waypointer/input/WaypointAddFlowTest.java
+++ b/src/test/java/com/babbur/waypointer/input/WaypointAddFlowTest.java
@@ -1,0 +1,40 @@
+package com.babbur.waypointer.input;
+
+import com.babbur.waypointer.core.Waypoint;
+import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WaypointAddFlowTest {
+
+    @Test
+    void waypointAddedMessageOffersExactAllAndPartyCommands() {
+        Component message = WaypointAddFlow.waypointAddedMessage(
+                2, Waypoint.at(12, 70, -4), true);
+
+        assertEquals("Added waypoint 2 at 12, 70, -4 [All] [Party]", message.getString());
+        assertEquals(2, message.getSiblings().size());
+        assertCommand(message.getSiblings().get(0), "/ac 12, 70, -4");
+        assertCommand(message.getSiblings().get(1), "/pc 12, 70, -4");
+    }
+
+    @Test
+    void waypointAddedMessageOmitsShareActionsWhenDisabled() {
+        Component message = WaypointAddFlow.waypointAddedMessage(
+                2, Waypoint.at(12, 70, -4), false);
+
+        assertEquals("Added waypoint 2 at 12, 70, -4", message.getString());
+        assertTrue(message.getSiblings().isEmpty());
+    }
+
+    private static void assertCommand(Component action, String expected) {
+        ClickEvent.RunCommand command = assertInstanceOf(ClickEvent.RunCommand.class,
+                action.getStyle().getClickEvent());
+        assertEquals(expected, command.command());
+        assertTrue(action.getStyle().isUnderlined());
+    }
+}

--- a/src/test/java/com/babbur/waypointer/render/HappySnowmanSessionTest.java
+++ b/src/test/java/com/babbur/waypointer/render/HappySnowmanSessionTest.java
@@ -1,0 +1,27 @@
+package com.babbur.waypointer.render;
+
+import com.babbur.waypointer.core.WaypointPaint;
+import com.mojang.blaze3d.platform.NativeImage;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HappySnowmanSessionTest {
+    @Test
+    void compositesHatLayerAndDoublesFacePixelsOntoEveryWaypointFace() {
+        try (NativeImage skin = new NativeImage(64, 64, true)) {
+            for (int y = 8; y < 16; y++) {
+                for (int x = 8; x < 16; x++) skin.setPixel(x, y, 0xFF112233);
+            }
+            skin.setPixel(40, 8, 0xFFABCDEF);
+
+            WaypointPaint paint = HappySnowmanSession.facePaint(skin);
+
+            for (WaypointPaint.Face face : WaypointPaint.Face.values()) {
+                assertEquals(0xABCDEF, paint.color(face, 0, 0));
+                assertEquals(0xABCDEF, paint.color(face, 1, 1));
+                assertEquals(0x112233, paint.color(face, 2, 0));
+            }
+        }
+    }
+}

--- a/src/test/java/com/babbur/waypointer/render/RenderHelpersTest.java
+++ b/src/test/java/com/babbur/waypointer/render/RenderHelpersTest.java
@@ -1,0 +1,88 @@
+package com.babbur.waypointer.render;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RenderHelpersTest {
+
+    @Test
+    void paintedBoxWritesTheCompleteBeaconVertexContract() {
+        RecordingConsumer consumer = new RecordingConsumer();
+
+        RenderHelpers.emitTexturedBox(consumer, new PoseStack(),
+                0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f, 0.75f,
+                2.0, 2.0, 2.0);
+
+        assertAll(
+                () -> assertEquals(12, consumer.vertices),
+                () -> assertEquals(12, consumer.colors),
+                () -> assertEquals(12, consumer.uvs),
+                () -> assertEquals(12, consumer.lights));
+    }
+
+    @Test
+    void paintedBoxSelectsOnlyTheThreeCameraFacingPlanes() {
+        int expected = 1 << com.babbur.waypointer.core.WaypointPaint.Face.UP.ordinal()
+                | 1 << com.babbur.waypointer.core.WaypointPaint.Face.SOUTH.ordinal()
+                | 1 << com.babbur.waypointer.core.WaypointPaint.Face.EAST.ordinal();
+
+        assertEquals(expected, RenderHelpers.visibleTexturedFaces(
+                0, 0, 0, 1, 1, 1, 2, 2, 2));
+    }
+
+    private static final class RecordingConsumer implements VertexConsumer {
+        private int vertices;
+        private int colors;
+        private int uvs;
+        private int lights;
+
+        @Override
+        public VertexConsumer addVertex(float x, float y, float z) {
+            vertices++;
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setColor(int red, int green, int blue, int alpha) {
+            colors++;
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setColor(int argb) {
+            colors++;
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setUv(float u, float v) {
+            uvs++;
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setUv1(int u, int v) {
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setUv2(int u, int v) {
+            lights++;
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setNormal(float x, float y, float z) {
+            return this;
+        }
+
+        @Override
+        public VertexConsumer setLineWidth(float width) {
+            return this;
+        }
+    }
+}

--- a/src/test/java/com/babbur/waypointer/render/WaypointRendererTest.java
+++ b/src/test/java/com/babbur/waypointer/render/WaypointRendererTest.java
@@ -3,6 +3,7 @@ package com.babbur.waypointer.render;
 import com.babbur.waypointer.config.WaypointerConfig;
 import com.babbur.waypointer.core.Waypoint;
 import com.babbur.waypointer.core.WaypointGroup;
+import com.babbur.waypointer.core.WaypointPaint;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.phys.AABB;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,24 @@ class WaypointRendererTest {
 
         assertTrue(WaypointRenderer.hasDepthCheckedWaypoint(List.of(mixed)));
         assertTrue(WaypointRenderer.hasThroughWallWaypoint(List.of(mixed)));
+    }
+
+    @Test
+    void paintedGroupDetectionRequiresPaintAndAtLeastOneWaypoint() {
+        WaypointGroup emptyPainted = WaypointGroup.create("Empty", "hub");
+        emptyPainted.setPaint(WaypointPaint.solid(0x123456));
+        WaypointGroup painted = groupWith(waypoint(0));
+        painted.setPaint(WaypointPaint.solid(0x654321));
+
+        assertFalse(WaypointRenderer.hasPaintedGroup(List.of(emptyPainted)));
+        assertTrue(WaypointRenderer.hasPaintedGroup(List.of(emptyPainted, painted)));
+
+        painted.setPaintEnabled(false);
+        assertFalse(WaypointRenderer.hasPaintedGroup(List.of(painted)));
+
+        WaypointGroup inherited = groupWith(waypoint(0));
+        assertTrue(WaypointRenderer.hasPaintedGroup(
+                List.of(inherited), WaypointPaint.solid(0xABCDEF)));
     }
 
     @Test

--- a/src/test/java/com/babbur/waypointer/screen/GroupEditScreenTest.java
+++ b/src/test/java/com/babbur/waypointer/screen/GroupEditScreenTest.java
@@ -42,6 +42,19 @@ class GroupEditScreenTest {
     }
 
     @Test
+    void coordinateScrollStepsOnceInTheWheelDirectionAndClampsAtIntegerBounds() {
+        assertEquals(13, GroupEditScreen.coordinateAfterScroll(12, 0.25));
+        assertEquals(11, GroupEditScreen.coordinateAfterScroll(12, -4.0));
+        assertEquals(-11, GroupEditScreen.coordinateAfterScroll(-12, 1.0));
+        assertEquals(-13, GroupEditScreen.coordinateAfterScroll(-12, -1.0));
+        assertEquals(12, GroupEditScreen.coordinateAfterScroll(12, 0.0));
+        assertEquals(Integer.MAX_VALUE,
+                GroupEditScreen.coordinateAfterScroll(Integer.MAX_VALUE, 1.0));
+        assertEquals(Integer.MIN_VALUE,
+                GroupEditScreen.coordinateAfterScroll(Integer.MIN_VALUE, -1.0));
+    }
+
+    @Test
     void waypointRowTextWidthReservesControlAndMetadataSpace() {
         int textLeft = 220;
         int rowRight = 560;
@@ -192,19 +205,24 @@ class GroupEditScreenTest {
 
     @Test
     void colorModeCycleAndLabelsMatchEditorControls() {
-        assertEquals("One", GroupEditScreen.colorModeName(WaypointGroup.GradientMode.STATIC));
-        assertEquals("Gradient", GroupEditScreen.colorModeName(WaypointGroup.GradientMode.AUTO));
-        assertEquals("Manual", GroupEditScreen.colorModeName(WaypointGroup.GradientMode.MANUAL));
-        assertEquals("One", GroupEditScreen.colorModeName(null));
+        assertEquals("Color", GroupEditScreen.colorModeName(GroupEditScreen.RouteColorMode.COLOR));
+        assertEquals("Gradient", GroupEditScreen.colorModeName(GroupEditScreen.RouteColorMode.GRADIENT));
+        assertEquals("One", GroupEditScreen.colorModeName(GroupEditScreen.RouteColorMode.ONE));
+        assertEquals("Paint", GroupEditScreen.colorModeName(GroupEditScreen.RouteColorMode.PAINT));
 
-        assertEquals(WaypointGroup.GradientMode.AUTO,
-                GroupEditScreen.nextColorMode(WaypointGroup.GradientMode.STATIC));
-        assertEquals(WaypointGroup.GradientMode.MANUAL,
-                GroupEditScreen.nextColorMode(WaypointGroup.GradientMode.AUTO));
-        assertEquals(WaypointGroup.GradientMode.STATIC,
-                GroupEditScreen.nextColorMode(WaypointGroup.GradientMode.MANUAL));
-        assertEquals(WaypointGroup.GradientMode.STATIC,
-                GroupEditScreen.nextColorMode(null));
+        assertEquals(GroupEditScreen.RouteColorMode.GRADIENT,
+                GroupEditScreen.nextColorMode(GroupEditScreen.RouteColorMode.COLOR));
+        assertEquals(GroupEditScreen.RouteColorMode.ONE,
+                GroupEditScreen.nextColorMode(GroupEditScreen.RouteColorMode.GRADIENT));
+        assertEquals(GroupEditScreen.RouteColorMode.PAINT,
+                GroupEditScreen.nextColorMode(GroupEditScreen.RouteColorMode.ONE));
+        assertEquals(GroupEditScreen.RouteColorMode.COLOR,
+                GroupEditScreen.nextColorMode(GroupEditScreen.RouteColorMode.PAINT));
+
+        assertEquals(GroupEditScreen.RouteColorMode.COLOR,
+                GroupEditScreen.routeColorMode(WaypointGroup.GradientMode.MANUAL, false));
+        assertEquals(GroupEditScreen.RouteColorMode.PAINT,
+                GroupEditScreen.routeColorMode(WaypointGroup.GradientMode.AUTO, true));
     }
 
     @Test

--- a/src/test/java/com/babbur/waypointer/screen/SettingsScreenTest.java
+++ b/src/test/java/com/babbur/waypointer/screen/SettingsScreenTest.java
@@ -3,6 +3,9 @@ package com.babbur.waypointer.screen;
 import com.babbur.waypointer.config.WaypointerConfig;
 import com.babbur.waypointer.screen.settings.Setting;
 import com.babbur.waypointer.screen.settings.SettingsCatalog;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TextColor;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -101,5 +104,15 @@ class SettingsScreenTest {
         assertEquals("one two", SettingsScreen.normalizeTooltipText("one\ntwo"));
         assertEquals("one\n\ntwo", SettingsScreen.normalizeTooltipText("one\n\ntwo"));
         assertEquals("a b\n\nc", SettingsScreen.normalizeTooltipText("  a \r\n b \r\n\r\n c "));
+    }
+
+    @Test
+    void settingTooltipsStartWithTheGrayControlLabel() {
+        Setting setting = SettingsCatalog.byId("hideReachedStaticWaypointsUntilCycleComplete");
+
+        Component tooltip = SettingsScreen.tooltipFor(setting);
+
+        assertTrue(tooltip.getString().startsWith(setting.label() + "\n"));
+        assertEquals(TextColor.fromLegacyFormat(ChatFormatting.GRAY), tooltip.getStyle().getColor());
     }
 }

--- a/src/test/java/com/babbur/waypointer/screen/WaypointPaintApplyScreenTest.java
+++ b/src/test/java/com/babbur/waypointer/screen/WaypointPaintApplyScreenTest.java
@@ -1,0 +1,49 @@
+package com.babbur.waypointer.screen;
+
+import com.babbur.waypointer.core.ActiveGroupManager;
+import com.babbur.waypointer.core.WaypointGroup;
+import com.babbur.waypointer.core.Zone;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class WaypointPaintApplyScreenTest {
+
+    @Test
+    void eligibleGroupsPutCurrentActiveRoutesFirstAndExcludeRuntimeBuckets() {
+        ActiveGroupManager manager = new ActiveGroupManager();
+        WaypointGroup otherShown = group("other", "The End", true);
+        WaypointGroup active = group("active", "Hub Route", true);
+        WaypointGroup hidden = group("hidden", "Hidden Hub", false);
+        WaypointGroup temp = group("temp", "Temp", true);
+        temp.setTemp(true);
+        WaypointGroup runtime = group("runtime", "Runtime", true);
+        runtime.setRuntimeOnly(true);
+        manager.addAll(List.of(otherShown, hidden, temp, active, runtime));
+        manager.onZoneChanged(Zone.fromId("hub"));
+
+        assertEquals(List.of("active", "other", "hidden"),
+                WaypointPaintApplyScreen.eligibleGroups(manager).stream()
+                        .map(WaypointGroup::id).toList());
+    }
+
+    @Test
+    void groupSearchMatchesNameZoneIdAndFriendlyZoneName() {
+        ActiveGroupManager manager = new ActiveGroupManager();
+        manager.add(group("route", "Crystal Run", true));
+
+        assertEquals(1, WaypointPaintApplyScreen.matchingGroups(manager, "crystal run").size());
+        assertEquals(1, WaypointPaintApplyScreen.matchingGroups(manager, "the end").size());
+        assertEquals(1, WaypointPaintApplyScreen.matchingGroups(manager, "the_end").size());
+        assertEquals(0, WaypointPaintApplyScreen.matchingGroups(manager, "hub").size());
+    }
+
+    private static WaypointGroup group(String id, String name, boolean enabled) {
+        WaypointGroup group = new WaypointGroup(id, name, "the_end");
+        if ("active".equals(id) || "hidden".equals(id)) group.setZoneId("hub");
+        group.setEnabled(enabled);
+        return group;
+    }
+}

--- a/src/test/java/com/babbur/waypointer/screen/WaypointPaintPreviewTextureTest.java
+++ b/src/test/java/com/babbur/waypointer/screen/WaypointPaintPreviewTextureTest.java
@@ -1,0 +1,18 @@
+package com.babbur.waypointer.screen;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class WaypointPaintPreviewTextureTest {
+
+    @Test
+    void interpolatesTextureCoordinatesInPerspective() {
+        double value = WaypointPaintPreviewTexture.perspectiveInterpolate(
+                0.5, 0.25, 0.25,
+                0.0, 1.0, 1.0,
+                2.0, 4.0, 4.0);
+
+        assertEquals(1.0 / 3.0, value, 1.0E-9);
+    }
+}

--- a/src/test/java/com/babbur/waypointer/screen/WaypointPainterScreenTest.java
+++ b/src/test/java/com/babbur/waypointer/screen/WaypointPainterScreenTest.java
@@ -1,0 +1,62 @@
+package com.babbur.waypointer.screen;
+
+import com.babbur.waypointer.core.WaypointPaint;
+import com.babbur.waypointer.core.Waypoint;
+import com.babbur.waypointer.core.WaypointGroup;
+import com.babbur.waypointer.core.ActiveGroupManager;
+import com.babbur.waypointer.config.WaypointerConfig;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WaypointPainterScreenTest {
+
+    @Test
+    void applyAllPersistsAnInheritedPaintForFutureRoutesAndWaypoints() {
+        ActiveGroupManager manager = new ActiveGroupManager();
+        WaypointGroup existing = WaypointGroup.create("Existing", "hub");
+        existing.add(Waypoint.at(1, 2, 3));
+        manager.add(existing);
+        WaypointerConfig config = new WaypointerConfig();
+        WaypointPaint paint = WaypointPaint.solid(0x123456);
+
+        assertEquals(1, WaypointPainterScreen.applyToAllGroups(manager, config, paint));
+        assertEquals(paint, existing.paint());
+        assertEquals(paint, config.waypointPainterDefaultPaint());
+
+        WaypointGroup future = WaypointGroup.create("Future", "hub");
+        future.add(Waypoint.at(4, 5, 6));
+        assertTrue(future.paintEnabled());
+        assertNull(future.paint(), "future routes inherit the saved all-waypoint paint");
+    }
+
+    @Test
+    void oneFaceSnapshotRepeatsWithoutDestroyingTheSixFaceDesign() {
+        byte[] pixels = new byte[WaypointPaint.PIXEL_COUNT];
+        pixels[WaypointPaint.pixelOffset(WaypointPaint.Face.NORTH, 3, 4)] = 7;
+        pixels[WaypointPaint.pixelOffset(WaypointPaint.Face.SOUTH, 3, 4)] = 2;
+
+        byte[] repeated = WaypointPainterScreen.repeatedFaceCopy(
+                pixels, WaypointPaint.Face.NORTH);
+
+        for (WaypointPaint.Face face : WaypointPaint.Face.values()) {
+            assertEquals(7, Byte.toUnsignedInt(
+                    repeated[WaypointPaint.pixelOffset(face, 3, 4)]));
+        }
+        assertEquals(2, Byte.toUnsignedInt(
+                pixels[WaypointPaint.pixelOffset(WaypointPaint.Face.SOUTH, 3, 4)]));
+    }
+
+    @Test
+    void atlasNavigationCrossesAdjacentFacesAndRejectsEmptySlots() {
+        assertEquals(WaypointPaint.Face.UP,
+                WaypointPainterScreen.faceAtAtlasPixel(16, 15));
+        assertEquals(WaypointPaint.Face.WEST,
+                WaypointPainterScreen.faceAtAtlasPixel(15, 16));
+        assertEquals(WaypointPaint.Face.NORTH,
+                WaypointPainterScreen.faceAtAtlasPixel(16, 16));
+        assertNull(WaypointPainterScreen.faceAtAtlasPixel(0, 0));
+    }
+}

--- a/src/test/java/com/babbur/waypointer/screen/settings/SettingsCatalogTest.java
+++ b/src/test/java/com/babbur/waypointer/screen/settings/SettingsCatalogTest.java
@@ -33,7 +33,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class SettingsCatalogTest {
 
     /** Internal-only WaypointerConfig fields with no settings-surface meaning. */
-    private static final Set<String> MAIN_EXEMPT = Set.of("configSchemaVersion");
+    private static final Set<String> MAIN_EXEMPT = Set.of(
+            "configSchemaVersion",
+            "waypointPainterPalette",
+            "waypointPainterDefaultPalette",
+            "waypointPainterDefaultPixels");
 
     /** DungeonConfig fields deliberately kept out of the GUI (debug/UX-state). */
     private static final Set<String> DUNGEON_EXEMPT = Set.of(
@@ -206,6 +210,20 @@ class SettingsCatalogTest {
             assertEquals(Setting.Store.NONE, setting.store());
             assertFalse(setting.isModified(a, null, b, null));
         }
+    }
+
+    @Test
+    void waypointPainterIsAnActionInTheWaypointsCategory() {
+        Setting paint = SettingsCatalog.byId(SettingsCatalog.ACTION_WAYPOINT_PAINT);
+
+        assertNotNull(paint);
+        assertEquals("Paint", paint.label());
+        assertEquals(Setting.Kind.ACTION, paint.kind());
+        assertEquals("waypoints", SettingsCatalog.categories().stream()
+                .filter(category -> category.groups().stream()
+                        .flatMap(group -> group.settings().stream())
+                        .anyMatch(setting -> setting.id().equals(SettingsCatalog.ACTION_WAYPOINT_PAINT)))
+                .findFirst().orElseThrow().id());
     }
 
     @Test

--- a/src/test/java/com/babbur/waypointer/screen/settings/SettingsPresetsTest.java
+++ b/src/test/java/com/babbur/waypointer/screen/settings/SettingsPresetsTest.java
@@ -20,6 +20,7 @@ class SettingsPresetsTest {
         assertFalse(minimal.showTracer());
         assertFalse(minimal.editSounds());
         assertFalse(minimal.showEditModeSubtitle());
+        assertFalse(minimal.showWaypointChatShareButtons());
         assertFalse(minimal.showContributorBadges());
         assertEquals(12, minimal.maxWaypointLabels());
         assertEquals(128.0, minimal.maxStaticWaypointRenderDistance());


### PR DESCRIPTION
## Added
- Waypoint painting! You can paint a waypoint to change its appearance/16x16 texture in game.
<img width="2523" height="1282" alt="image" src="https://github.com/user-attachments/assets/e7f977b8-cadd-4308-b458-b0dfb8b7f16a" />
You can paint waypoints per-route, globally, or use the defaults if you wish.

- Labels to settings inputs for more clarity when navigating
- Scroll over coordinate boxes to change their values by +1/-1 for quick edits
- New waypoints will now have clickable chat messages to send them in all/party chat, toggleable in settings

## Fixed
- Waypoints would render behind entities, such as players/maps
- 100% opacity wasn't actually 100%
- Fixed overflowing toast for importing waypoints and made the message more simple
- Fixed 'Pick Route' confirmation text in the delete route button not fitting