### PR TITLE
Expand troubleshooting diagnostics

### DIFF
--- a/src/client/java/com/babbur/waypointer/WaypointerClient.java
+++ b/src/client/java/com/babbur/waypointer/WaypointerClient.java
@@ -58,6 +58,7 @@ public final class WaypointerClient implements ClientModInitializer {
     private static DungeonRouteSession dungeonRouteSession;
     private static DungeonRouteDownloader dungeonRouteDownloader;
     private static DeveloperModeMonitor developerModeMonitor;
+    private static WaypointerKeybinds keybinds;
     private static boolean dungeonRouteSessionInDungeonContext;
     private static Screen suspendedWaypointerGuiScreen;
 
@@ -97,6 +98,10 @@ public final class WaypointerClient implements ClientModInitializer {
         return developerModeMonitor;
     }
 
+    public static WaypointerKeybinds keybinds() {
+        return keybinds;
+    }
+
     @Override
     public void onInitializeClient() {
         config = WaypointerConfig.load();
@@ -126,7 +131,8 @@ public final class WaypointerClient implements ClientModInitializer {
 
         ChatImportCache chatImportCache = new ChatImportCache();
         new WaypointerCommands(manager, storage, config, chatImportCache, WaypointerClient::openGui).install();
-        new WaypointerKeybinds(WaypointerClient::openGui, manager, config).install();
+        keybinds = new WaypointerKeybinds(WaypointerClient::openGui, manager, config);
+        keybinds.install();
         new ChatCoordDetector(config, manager).install();
         new ChatImportDetector(config, chatImportCache).install();
         int apiEntrypoints = WaypointerApiEntrypoints.invokeFabricEntrypoints(api);

--- a/src/client/java/com/babbur/waypointer/commands/WaypointerCommands.java
+++ b/src/client/java/com/babbur/waypointer/commands/WaypointerCommands.java
@@ -939,7 +939,7 @@ public final class WaypointerCommands {
                                     "blacklist remove Babbur"))),
             new HelpSection("debug", "Debug",
                     List.of(
-                            new HelpRow(" debug", "Open the Waypointer debug inspector.",
+                            new HelpRow(" debug", "Open the all-in-one troubleshooting report.",
                                     "debug"),
                             new HelpRow(" devmode [on|off|status|report]",
                                     "Monitor dungeon room detection and write diagnostic reports.",

--- a/src/client/java/com/babbur/waypointer/debug/ConfigChangeHistory.java
+++ b/src/client/java/com/babbur/waypointer/debug/ConfigChangeHistory.java
@@ -1,0 +1,64 @@
+package com.babbur.waypointer.debug;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/** Session-only audit trail for settings changes that may explain a new problem. */
+public final class ConfigChangeHistory {
+
+    private static final int MAX_ENTRIES = 24;
+    private static final Entry[] ENTRIES = new Entry[MAX_ENTRIES];
+    private static int nextIndex;
+    private static int count;
+
+    private ConfigChangeHistory() {
+    }
+
+    public static synchronized void recordSetting(String settingId, String before, String after) {
+        String normalizedId = normalize(settingId, "(unknown setting)");
+        String normalizedBefore = normalize(before, "(empty)");
+        String normalizedAfter = normalize(after, "(empty)");
+        if (Objects.equals(normalizedBefore, normalizedAfter)) return;
+        append(new Entry(System.currentTimeMillis(), "setting", normalizedId,
+                normalizedBefore, normalizedAfter));
+    }
+
+    public static synchronized void recordBulk(String action) {
+        append(new Entry(System.currentTimeMillis(), "bulk", normalize(action, "bulk update"),
+                "(multiple settings)", "(current values shown below)"));
+    }
+
+    /** Entries ordered newest first for fast troubleshooting. */
+    public static synchronized List<Entry> snapshot() {
+        List<Entry> entries = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            int index = (nextIndex - 1 - i + MAX_ENTRIES) % MAX_ENTRIES;
+            Entry entry = ENTRIES[index];
+            if (entry != null) entries.add(entry);
+        }
+        return List.copyOf(entries);
+    }
+
+    public static synchronized void clear() {
+        for (int i = 0; i < ENTRIES.length; i++) ENTRIES[i] = null;
+        nextIndex = 0;
+        count = 0;
+    }
+
+    private static void append(Entry entry) {
+        ENTRIES[nextIndex] = entry;
+        nextIndex = (nextIndex + 1) % MAX_ENTRIES;
+        if (count < MAX_ENTRIES) count++;
+    }
+
+    private static String normalize(String value, String fallback) {
+        if (value == null) return fallback;
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? fallback : trimmed;
+    }
+
+    public record Entry(long capturedAtMillis, String kind, String subject,
+                        String before, String after) {
+    }
+}

--- a/src/client/java/com/babbur/waypointer/debug/DebugLogTail.java
+++ b/src/client/java/com/babbur/waypointer/debug/DebugLogTail.java
@@ -1,0 +1,112 @@
+package com.babbur.waypointer.debug;
+
+import net.fabricmc.loader.api.FabricLoader;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/** Reads a bounded tail of recent log lines that are likely useful for support. */
+public final class DebugLogTail {
+
+    private static final int MAX_TAIL_BYTES = 256 * 1024;
+    private static final int MAX_LINE_CHARS = 500;
+    private static final int MAX_STACK_CONTINUATION_LINES = 24;
+
+    private DebugLogTail() {
+    }
+
+    public static List<String> capture(int maxLines) {
+        Path latestLog = FabricLoader.getInstance().getGameDir().resolve("logs").resolve("latest.log");
+        return readRelevant(latestLog, maxLines);
+    }
+
+    static List<String> readRelevant(Path file, int maxLines) {
+        if (file == null || maxLines <= 0 || !Files.isRegularFile(file)) return List.of();
+        byte[] tail;
+        boolean startsMidFile;
+        try (RandomAccessFile input = new RandomAccessFile(file.toFile(), "r")) {
+            long length = input.length();
+            long start = Math.max(0L, length - MAX_TAIL_BYTES);
+            startsMidFile = start > 0L;
+            input.seek(start);
+            tail = new byte[(int) (length - start)];
+            input.readFully(tail);
+        } catch (IOException | RuntimeException ignored) {
+            return List.of();
+        }
+
+        String text = new String(tail, StandardCharsets.UTF_8);
+        if (startsMidFile) {
+            int firstNewline = text.indexOf('\n');
+            text = firstNewline < 0 ? "" : text.substring(firstNewline + 1);
+        }
+        String[] lines = text.split("\\R");
+        List<String> relevant = new ArrayList<>();
+        int stackContinuationRemaining = 0;
+        for (String line : lines) {
+            boolean directlyRelevant = isRelevant(line);
+            boolean stackContinuation = stackContinuationRemaining > 0
+                    && isStackTraceContinuation(line);
+            if (!directlyRelevant && !stackContinuation) {
+                stackContinuationRemaining = 0;
+                continue;
+            }
+            String sanitized = sanitize(line);
+            if (!sanitized.isBlank()) relevant.add(sanitized);
+            if (directlyRelevant) {
+                stackContinuationRemaining = MAX_STACK_CONTINUATION_LINES;
+            } else {
+                stackContinuationRemaining--;
+            }
+        }
+        int from = Math.max(0, relevant.size() - maxLines);
+        return List.copyOf(relevant.subList(from, relevant.size()));
+    }
+
+    private static boolean isRelevant(String line) {
+        if (line == null || line.isBlank()) return false;
+        String lower = line.toLowerCase(Locale.ROOT);
+        return lower.contains("waypointer")
+                || lower.contains("exception")
+                || lower.contains("caused by:")
+                || lower.contains("[error]")
+                || lower.contains("[warn]")
+                || isThrowableHeader(line);
+    }
+
+    private static boolean isStackTraceContinuation(String line) {
+        if (line == null || line.isBlank()) return false;
+        String trimmed = line.stripLeading();
+        return trimmed.startsWith("at ")
+                || trimmed.startsWith("Caused by:")
+                || trimmed.startsWith("Suppressed:")
+                || (trimmed.startsWith("...") && trimmed.endsWith(" more"))
+                || isThrowableHeader(trimmed);
+    }
+
+    private static boolean isThrowableHeader(String line) {
+        if (line == null) return false;
+        String trimmed = line.strip();
+        int separator = trimmed.indexOf(':');
+        String type = separator < 0 ? trimmed : trimmed.substring(0, separator);
+        return type.indexOf(' ') < 0
+                && type.indexOf('.') > 0
+                && (type.endsWith("Exception") || type.endsWith("Error"));
+    }
+
+    private static String sanitize(String line) {
+        StringBuilder sanitized = new StringBuilder(Math.min(line.length(), MAX_LINE_CHARS));
+        for (int i = 0; i < line.length() && sanitized.length() < MAX_LINE_CHARS; i++) {
+            char c = line.charAt(i);
+            sanitized.append(Character.isISOControl(c) ? ' ' : c);
+        }
+        if (line.length() > MAX_LINE_CHARS) sanitized.append("...");
+        return sanitized.toString().trim();
+    }
+}

--- a/src/client/java/com/babbur/waypointer/debug/DebugReportExport.java
+++ b/src/client/java/com/babbur/waypointer/debug/DebugReportExport.java
@@ -1,0 +1,130 @@
+package com.babbur.waypointer.debug;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Privacy-aware plain-text export for the {@code /wp debug} report.
+ *
+ * <p>Every report section has exactly one disclosure category. The screen may
+ * render all captured data locally, but the clipboard export only includes the
+ * categories the user confirms. Excluded section bodies are replaced with the
+ * same explicit marker so support can distinguish missing telemetry from a
+ * capture failure.
+ */
+public final class DebugReportExport {
+
+    public static final String REDACTED = "[User redacted]";
+    private static final int MAX_EXPORTED_LINE_CHARS = 4_000;
+
+    /** User-facing disclosure groups shown in the copy confirmation screen. */
+    public enum Category {
+        CORE("", ""),
+        PC_SPECS("PC Specs",
+                "OS, Java, CPU, memory, GPU, and display."),
+        ACTIVE_MODS("Active Mods and Versions",
+                "Loaded mod names, IDs, and versions."),
+        SERVER_CONTEXT("Server, Player, and Location",
+                "Server, zone, position, and dungeon."),
+        ROUTES_AND_WAYPOINTS("Routes, Waypoints, and Coordinates",
+                "Routes, waypoints, coords, and clipboard."),
+        SETTINGS_AND_CHANGES("Settings and Recent Changes",
+                "All settings and this session's changes."),
+        RECENT_LOGS_AND_ACTIVITY("Recent Logs and Activity",
+                "Relevant logs and recent UI activity.");
+
+        private final String label;
+        private final String description;
+
+        Category(String label, String description) {
+            this.label = label;
+            this.description = description;
+        }
+
+        public String label() {
+            return label;
+        }
+
+        public String description() {
+            return description;
+        }
+
+        public boolean userControlled() {
+            return this != CORE;
+        }
+
+        public static List<Category> userControlledValues() {
+            List<Category> categories = new ArrayList<>();
+            for (Category category : values()) {
+                if (category.userControlled()) categories.add(category);
+            }
+            return List.copyOf(categories);
+        }
+    }
+
+    /** One export section with already formatted body lines. */
+    public record Section(String heading, Category category, List<String> lines) {
+        public Section {
+            heading = sanitizeLine(heading).trim();
+            category = Objects.requireNonNullElse(category, Category.CORE);
+            lines = lines == null ? List.of() : List.copyOf(lines);
+        }
+    }
+
+    /** Immutable set of user-approved categories. Core diagnostics are always included. */
+    public record Options(Set<Category> included) {
+        public Options {
+            EnumSet<Category> copy = included == null || included.isEmpty()
+                    ? EnumSet.noneOf(Category.class)
+                    : EnumSet.copyOf(included);
+            copy.add(Category.CORE);
+            included = Set.copyOf(copy);
+        }
+
+        public static Options allEnabled() {
+            return new Options(EnumSet.allOf(Category.class));
+        }
+
+        public boolean includes(Category category) {
+            return category == Category.CORE || included.contains(category);
+        }
+    }
+
+    private DebugReportExport() {
+    }
+
+    /** Formats a deterministic, readable report suitable for chat, issues, or support DMs. */
+    public static String format(List<Section> sections, Options options) {
+        Options approved = options == null ? Options.allEnabled() : options;
+        StringBuilder report = new StringBuilder();
+        if (sections == null) return "";
+
+        for (Section section : sections) {
+            if (section == null) continue;
+            if (!report.isEmpty()) report.append('\n');
+            report.append("== ").append(section.heading()).append(" ==\n");
+            if (!approved.includes(section.category())) {
+                report.append("  ").append(REDACTED).append('\n');
+                continue;
+            }
+            for (String line : section.lines()) {
+                report.append(sanitizeLine(line)).append('\n');
+            }
+        }
+        return report.toString();
+    }
+
+    private static String sanitizeLine(String value) {
+        String source = Objects.requireNonNullElse(value, "");
+        StringBuilder sanitized = new StringBuilder(Math.min(source.length(), MAX_EXPORTED_LINE_CHARS));
+        for (int i = 0; i < source.length() && sanitized.length() < MAX_EXPORTED_LINE_CHARS; i++) {
+            char c = source.charAt(i);
+            sanitized.append(Character.isISOControl(c) ? ' ' : c);
+        }
+        if (source.length() > MAX_EXPORTED_LINE_CHARS) sanitized.append("...");
+        return sanitized.toString();
+    }
+}

--- a/src/client/java/com/babbur/waypointer/input/WaypointerKeybinds.java
+++ b/src/client/java/com/babbur/waypointer/input/WaypointerKeybinds.java
@@ -32,6 +32,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 import org.lwjgl.glfw.GLFW;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -209,6 +210,41 @@ public final class WaypointerKeybinds {
                 return false;
             });
         });
+    }
+
+    /** Live bindings and conflicts for the troubleshooting report. */
+    public List<DebugBinding> debugSnapshot() {
+        List<KeyMapping> mappings = List.of(
+                openEditor,
+                addWaypointHere,
+                addNamedWaypointHere,
+                addTempWaypointHere,
+                skipWaypoint,
+                previousWaypoint,
+                enterEditMode,
+                exitEditMode,
+                toggleEditMode,
+                addWaypointWhereLooking);
+        List<DebugBinding> snapshot = new ArrayList<>(mappings.size());
+        KeyMapping[] allMappings = Minecraft.getInstance().options.keyMappings;
+        for (KeyMapping mapping : mappings) {
+            List<String> conflicts = new ArrayList<>();
+            for (KeyMapping candidate : allMappings) {
+                if (candidate != mapping && mapping.same(candidate)) {
+                    conflicts.add(candidate.getName());
+                }
+            }
+            snapshot.add(new DebugBinding(
+                    mapping.getName(),
+                    mapping.isUnbound() ? "Unbound" : mapping.getTranslatedKeyMessage().getString(),
+                    mapping.isUnbound(),
+                    List.copyOf(conflicts)));
+        }
+        return List.copyOf(snapshot);
+    }
+
+    public record DebugBinding(String translationKey, String boundKey,
+                               boolean unbound, List<String> conflicts) {
     }
 
     static boolean isOpenEditorKey(KeyEvent event) {

--- a/src/client/java/com/babbur/waypointer/render/GroundPathfinder.java
+++ b/src/client/java/com/babbur/waypointer/render/GroundPathfinder.java
@@ -32,6 +32,42 @@ final class GroundPathfinder {
         boolean walkable(int x, int y, int z);
     }
 
+    enum FailureReason {
+        NONE("path found"),
+        INVALID_START_OR_GOAL("invalid start or goal"),
+        INVALID_SEARCH_LIMITS("invalid pathfinding limits"),
+        NO_PASSABLE_START("no passable start"),
+        NO_PASSABLE_GOAL("no passable goal"),
+        OUTSIDE_DISTANCE_LIMIT("outside pathfinding distance limit"),
+        EXPANSION_LIMIT_EXHAUSTED("expansion limit exhausted"),
+        NO_ROUTE_WITHIN_BOUNDS("no route within search bounds");
+
+        private final String description;
+
+        FailureReason(String description) {
+            this.description = description;
+        }
+
+        String description() {
+            return description;
+        }
+    }
+
+    record Diagnostics(BlockPos rawStart, BlockPos rawGoal,
+                       BlockPos resolvedStart, BlockPos resolvedGoal,
+                       FailureReason reason, int expansions, int expansionLimit,
+                       long computeTimeNanos) {
+        boolean success() {
+            return reason == FailureReason.NONE;
+        }
+    }
+
+    record PathResult(List<Vec3> points, Diagnostics diagnostics) {
+    }
+
+    record GridPathResult(List<BlockPos> cells, Diagnostics diagnostics) {
+    }
+
     static BlockPos floorPos(Vec3 pos) {
         if (pos == null) return null;
         return floorPos(pos.x, pos.y, pos.z);
@@ -63,19 +99,51 @@ final class GroundPathfinder {
     static List<Vec3> findPath(ClientLevel level, Vec3 playerPos, Waypoint target,
                                int maxDistance, int maxExpansions,
                                int searchPadding, int searchVerticalPadding) {
-        if (level == null || playerPos == null || target == null) return List.of();
+        return findPathResult(level, playerPos, target, maxDistance, maxExpansions,
+                searchPadding, searchVerticalPadding).points();
+    }
 
+    static PathResult findPathResult(ClientLevel level, Vec3 playerPos, Waypoint target,
+                                     int maxDistance, int maxExpansions,
+                                     int searchPadding, int searchVerticalPadding) {
+        long startedAtNanos = System.nanoTime();
         BlockPos rawStart = floorPos(playerPos);
         BlockPos rawGoal = targetBlock(target);
+        if (level == null || rawStart == null || rawGoal == null) {
+            return emptyPathResult(rawStart, rawGoal, null, null,
+                    FailureReason.INVALID_START_OR_GOAL, 0, maxExpansions, startedAtNanos);
+        }
+        if (maxDistance < 0 || maxExpansions <= 0) {
+            return emptyPathResult(rawStart, rawGoal, null, null,
+                    FailureReason.INVALID_SEARCH_LIMITS, 0, maxExpansions, startedAtNanos);
+        }
+
         BlockPos start = nearestPassable(level, rawStart, 1, 2);
         BlockPos goal = nearestPassable(level, rawGoal, TARGET_SEARCH_RADIUS, TARGET_SEARCH_RADIUS);
-        if (start == null || goal == null) return List.of();
+        if (start == null) {
+            return emptyPathResult(rawStart, rawGoal, null, goal,
+                    FailureReason.NO_PASSABLE_START, 0, maxExpansions, startedAtNanos);
+        }
+        if (goal == null) {
+            return emptyPathResult(rawStart, rawGoal, start, null,
+                    FailureReason.NO_PASSABLE_GOAL, 0, maxExpansions, startedAtNanos);
+        }
 
         Grid grid = (x, y, z) -> isWalkableForPlayer(level, x, y, z);
-        List<BlockPos> cells = findPath(grid, start, goal, maxDistance, maxExpansions,
+        GridPathResult search = findPathResult(grid, start, goal, maxDistance, maxExpansions,
                 searchPadding, searchVerticalPadding);
-        if (cells.isEmpty()) return List.of();
-        return toLinePoints(playerPos, target, cells);
+        Diagnostics searchDiagnostics = search.diagnostics();
+        Diagnostics diagnostics = diagnostics(
+                rawStart,
+                rawGoal,
+                start,
+                goal,
+                searchDiagnostics.reason(),
+                searchDiagnostics.expansions(),
+                maxExpansions,
+                startedAtNanos);
+        if (search.cells().isEmpty()) return new PathResult(List.of(), diagnostics);
+        return new PathResult(toLinePoints(playerPos, target, search.cells()), diagnostics);
     }
 
     static List<BlockPos> findPath(Grid grid, BlockPos start, BlockPos goal,
@@ -87,18 +155,45 @@ final class GroundPathfinder {
     static List<BlockPos> findPath(Grid grid, BlockPos start, BlockPos goal,
                                    int maxDistance, int maxExpansions,
                                    int searchPadding, int searchVerticalPadding) {
-        if (grid == null || start == null || goal == null) return List.of();
-        if (maxDistance < 0 || maxExpansions <= 0) return List.of();
-        if (!grid.walkable(start.getX(), start.getY(), start.getZ())) return List.of();
-        if (!grid.walkable(goal.getX(), goal.getY(), goal.getZ())) return List.of();
+        return findPathResult(grid, start, goal, maxDistance, maxExpansions,
+                searchPadding, searchVerticalPadding).cells();
+    }
+
+    static GridPathResult findPathResult(Grid grid, BlockPos start, BlockPos goal,
+                                         int maxDistance, int maxExpansions,
+                                         int searchPadding, int searchVerticalPadding) {
+        long startedAtNanos = System.nanoTime();
+        if (grid == null || start == null || goal == null) {
+            return emptyGridResult(start, goal, FailureReason.INVALID_START_OR_GOAL,
+                    0, maxExpansions, startedAtNanos);
+        }
+        if (maxDistance < 0 || maxExpansions <= 0) {
+            return emptyGridResult(start, goal, FailureReason.INVALID_SEARCH_LIMITS,
+                    0, maxExpansions, startedAtNanos);
+        }
+        if (!grid.walkable(start.getX(), start.getY(), start.getZ())) {
+            return emptyGridResult(start, goal, FailureReason.NO_PASSABLE_START,
+                    0, maxExpansions, startedAtNanos);
+        }
+        if (!grid.walkable(goal.getX(), goal.getY(), goal.getZ())) {
+            return emptyGridResult(start, goal, FailureReason.NO_PASSABLE_GOAL,
+                    0, maxExpansions, startedAtNanos);
+        }
 
         Cell startCell = new Cell(start.getX(), start.getY(), start.getZ());
         Cell goalCell = new Cell(goal.getX(), goal.getY(), goal.getZ());
-        if (startCell.equals(goalCell)) return List.of(start);
+        if (startCell.equals(goalCell)) {
+            return successfulGridResult(List.of(start), start, goal, 0,
+                    maxExpansions, startedAtNanos);
+        }
         double maxDistanceSq = (double) maxDistance * maxDistance;
-        if (distanceSquared(startCell, goalCell) > maxDistanceSq) return List.of();
+        if (distanceSquared(startCell, goalCell) > maxDistanceSq) {
+            return emptyGridResult(start, goal, FailureReason.OUTSIDE_DISTANCE_LIMIT,
+                    0, maxExpansions, startedAtNanos);
+        }
         if (lineClear(grid, startCell, goalCell)) {
-            return List.of(start, goal);
+            return successfulGridResult(List.of(start, goal), start, goal, 0,
+                    maxExpansions, startedAtNanos);
         }
 
         int horizontalPadding = Math.max(0, searchPadding);
@@ -117,12 +212,14 @@ final class GroundPathfinder {
         best.put(startCell, 0.0D);
 
         int expansions = 0;
-        while (!open.isEmpty() && expansions++ < maxExpansions) {
+        while (!open.isEmpty() && expansions < maxExpansions) {
+            expansions++;
             Node current = open.poll();
             Double knownBest = best.get(current.cell);
             if (knownBest == null || current.cost > knownBest + 1.0E-6D) continue;
             if (current.cell.equals(goalCell)) {
-                return simplifyBySight(grid, reconstruct(current));
+                return successfulGridResult(simplifyBySight(grid, reconstruct(current)),
+                        start, goal, expansions, maxExpansions, startedAtNanos);
             }
 
             for (int[] neighbor : NEIGHBORS) {
@@ -144,7 +241,50 @@ final class GroundPathfinder {
                 open.add(new Node(next, current, nextCost, nextCost + heuristic(next, goalCell)));
             }
         }
-        return List.of();
+        FailureReason reason = open.isEmpty()
+                ? FailureReason.NO_ROUTE_WITHIN_BOUNDS
+                : FailureReason.EXPANSION_LIMIT_EXHAUSTED;
+        return emptyGridResult(start, goal, reason, expansions, maxExpansions, startedAtNanos);
+    }
+
+    private static PathResult emptyPathResult(BlockPos rawStart, BlockPos rawGoal,
+                                              BlockPos resolvedStart, BlockPos resolvedGoal,
+                                              FailureReason reason, int expansions,
+                                              int expansionLimit, long startedAtNanos) {
+        return new PathResult(List.of(), diagnostics(
+                rawStart, rawGoal, resolvedStart, resolvedGoal,
+                reason, expansions, expansionLimit, startedAtNanos));
+    }
+
+    private static GridPathResult emptyGridResult(BlockPos start, BlockPos goal,
+                                                  FailureReason reason, int expansions,
+                                                  int expansionLimit, long startedAtNanos) {
+        return new GridPathResult(List.of(), diagnostics(
+                start, goal, start, goal, reason, expansions, expansionLimit, startedAtNanos));
+    }
+
+    private static GridPathResult successfulGridResult(List<BlockPos> cells,
+                                                       BlockPos start, BlockPos goal,
+                                                       int expansions, int expansionLimit,
+                                                       long startedAtNanos) {
+        return new GridPathResult(cells, diagnostics(
+                start, goal, start, goal, FailureReason.NONE,
+                expansions, expansionLimit, startedAtNanos));
+    }
+
+    private static Diagnostics diagnostics(BlockPos rawStart, BlockPos rawGoal,
+                                           BlockPos resolvedStart, BlockPos resolvedGoal,
+                                           FailureReason reason, int expansions,
+                                           int expansionLimit, long startedAtNanos) {
+        return new Diagnostics(
+                rawStart,
+                rawGoal,
+                resolvedStart,
+                resolvedGoal,
+                reason,
+                Math.max(0, expansions),
+                Math.max(0, expansionLimit),
+                Math.max(0L, System.nanoTime() - startedAtNanos));
     }
 
     private static BlockPos nearestPassable(ClientLevel level, BlockPos center,

--- a/src/client/java/com/babbur/waypointer/render/GroundPathfinder.java
+++ b/src/client/java/com/babbur/waypointer/render/GroundPathfinder.java
@@ -40,7 +40,8 @@ final class GroundPathfinder {
         NO_PASSABLE_GOAL("no passable goal"),
         OUTSIDE_DISTANCE_LIMIT("outside pathfinding distance limit"),
         EXPANSION_LIMIT_EXHAUSTED("expansion limit exhausted"),
-        NO_ROUTE_WITHIN_BOUNDS("no route within search bounds");
+        NO_ROUTE_WITHIN_BOUNDS("no route within search bounds"),
+        CALCULATION_FAILED("path calculation failed");
 
         private final String description;
 

--- a/src/client/java/com/babbur/waypointer/render/RenderDiagnostics.java
+++ b/src/client/java/com/babbur/waypointer/render/RenderDiagnostics.java
@@ -1,0 +1,372 @@
+package com.babbur.waypointer.render;
+
+import com.babbur.waypointer.config.WaypointerConfig;
+import com.babbur.waypointer.core.Waypoint;
+import com.babbur.waypointer.core.WaypointGroup;
+import com.babbur.waypointer.dungeon.data.DungeonRoomData;
+import net.minecraft.core.BlockPos;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Last-frame renderer decisions exposed to the debug report.
+ *
+ * <p>The waypoint and tracer renderers are separate Fabric callbacks. Keeping the
+ * decision state here lets the tracer suppress itself only after the waypoint
+ * renderer has actually submitted a drawable dungeon path, while also giving
+ * troubleshooting reports a single immutable view of what happened.</p>
+ */
+public final class RenderDiagnostics {
+
+    private static final String PENDING_OUTCOME = "pending renderer decision";
+    private static final Map<String, MutableGroupSnapshot> GROUPS = new LinkedHashMap<>();
+    private static final Set<WaypointGroup> SUBMITTED_DUNGEON_PATHS =
+            Collections.newSetFromMap(new IdentityHashMap<>());
+
+    private static TracerSettings tracerSettings = new TracerSettings(
+            false, 0.0, 0.0, false, false, 0.0, false, false, false);
+    private static DungeonPathSettings dungeonPathSettings = new DungeonPathSettings(false, false);
+    private static volatile boolean detailedCaptureEnabled;
+    private static volatile boolean irisHudFallbackActive;
+    private static volatile long updatedAtEpochMillis;
+
+    private RenderDiagnostics() {
+    }
+
+    /** Enables detailed per-frame snapshots only while the troubleshooting screen is open. */
+    public static synchronized void setDetailedCaptureEnabled(boolean enabled) {
+        detailedCaptureEnabled = enabled;
+        GROUPS.clear();
+        tracerSettings = new TracerSettings(
+                false, 0.0, 0.0, false, false, 0.0, false, false, false);
+        dungeonPathSettings = new DungeonPathSettings(false, false);
+        updatedAtEpochMillis = 0L;
+    }
+
+    public static long lastUpdatedAtEpochMillis() {
+        return updatedAtEpochMillis;
+    }
+
+    /** Returns an immutable copy safe for report formatting off the render callback. */
+    public static synchronized Snapshot snapshot() {
+        List<GroupSnapshot> groups = new ArrayList<>(GROUPS.size());
+        for (MutableGroupSnapshot group : GROUPS.values()) {
+            groups.add(group.snapshot());
+        }
+        return new Snapshot(
+                updatedAtEpochMillis,
+                tracerSettings,
+                dungeonPathSettings,
+                List.copyOf(groups));
+    }
+
+    static void beginFrame(Iterable<WaypointGroup> groups,
+                           WaypointerConfig config,
+                           boolean irisHudFallbackActiveNow) {
+        SUBMITTED_DUNGEON_PATHS.clear();
+        irisHudFallbackActive = irisHudFallbackActiveNow;
+        if (!detailedCaptureEnabled) return;
+
+        synchronized (RenderDiagnostics.class) {
+            if (!detailedCaptureEnabled) return;
+            updatedAtEpochMillis = System.currentTimeMillis();
+            tracerSettings = new TracerSettings(
+                    config.showTracer(),
+                    config.tracerOpacity(),
+                    config.tracerThickness(),
+                    config.matchTracerToWaypointColor(),
+                    config.hideWaypointsNearPlayer(),
+                    config.hideWaypointsNearRadius(),
+                    config.hideTracerOnStaticRoutes(),
+                    config.irisShaderHudFallback(),
+                    irisHudFallbackActiveNow);
+            dungeonPathSettings = new DungeonPathSettings(
+                    config.showDungeonEntryPathToFirstWaypoint(),
+                    config.showDungeonEntryPathToFollowingWaypoints());
+
+            GROUPS.clear();
+            if (groups == null) return;
+            for (WaypointGroup group : groups) {
+                if (group == null || DungeonRoomData.definition(group.zoneId()) == null) continue;
+                boolean eligible = WaypointRenderer.shouldRenderDungeonEntryPath(
+                        group, config.showDungeonEntryPathToFollowingWaypoints());
+                GROUPS.put(group.id(), MutableGroupSnapshot.from(group, eligible));
+            }
+        }
+    }
+
+    static void recordPathLookup(WaypointGroup group,
+                                 GroundPathfinder.PathResult result,
+                                 boolean cacheHit,
+                                 long cacheAgeNanos) {
+        if (!detailedCaptureEnabled) return;
+        synchronized (RenderDiagnostics.class) {
+            MutableGroupSnapshot state = state(group);
+            if (state == null || result == null) return;
+
+            GroundPathfinder.Diagnostics diagnostics = result.diagnostics();
+            int pointCount = result.points().size();
+            boolean drawableSuccess = diagnostics.success() && pointCount >= 2;
+            String reason = diagnostics.reason().description();
+            if (diagnostics.success() && pointCount < 2) {
+                reason = "fewer than 2 drawable points";
+            }
+            state.path = new PathSnapshot(
+                    cacheHit ? "hit" : "miss",
+                    Math.max(0L, cacheAgeNanos) / 1_000_000.0,
+                    drawableSuccess ? "success" : "empty",
+                    pointCount,
+                    diagnostics.computeTimeNanos() / 1_000_000.0,
+                    BlockPosition.from(diagnostics.rawStart()),
+                    BlockPosition.from(diagnostics.rawGoal()),
+                    BlockPosition.from(diagnostics.resolvedStart()),
+                    BlockPosition.from(diagnostics.resolvedGoal()),
+                    diagnostics.expansions(),
+                    diagnostics.expansionLimit(),
+                    reason);
+            if (!drawableSuccess) {
+                state.finalOutcome = "nothing submitted: dungeon path empty";
+            }
+        }
+    }
+
+    static void recordDungeonPathSubmission(WaypointGroup group, boolean submitted) {
+        if (group == null) return;
+        if (submitted) {
+            SUBMITTED_DUNGEON_PATHS.add(group);
+        } else {
+            SUBMITTED_DUNGEON_PATHS.remove(group);
+        }
+        if (!detailedCaptureEnabled) return;
+        synchronized (RenderDiagnostics.class) {
+            MutableGroupSnapshot state = state(group);
+            if (state == null) return;
+            state.dungeonPathSubmitted = submitted;
+            if (submitted) {
+                state.finalOutcome = "replaced by dungeon path";
+            } else if ("empty".equals(state.path.result())) {
+                state.finalOutcome = "nothing submitted: dungeon path empty";
+            }
+        }
+    }
+
+    static boolean shouldSuppressStraightTracer(WaypointGroup group) {
+        return group != null && shouldSuppressStraightTracer(
+                irisHudFallbackActive, SUBMITTED_DUNGEON_PATHS.contains(group));
+    }
+
+    static boolean shouldSuppressStraightTracer(boolean irisHudFallbackActive,
+                                                boolean dungeonPathSubmitted) {
+        return dungeonPathSubmitted && !irisHudFallbackActive;
+    }
+
+    static void recordStraightTracerSuppressed(WaypointGroup group) {
+        if (!detailedCaptureEnabled) return;
+        synchronized (RenderDiagnostics.class) {
+            MutableGroupSnapshot state = state(group);
+            if (state == null) return;
+            state.straightTracerSuppressed = true;
+            state.finalOutcome = "replaced by dungeon path";
+        }
+    }
+
+    static void recordStraightTracerSubmitted(WaypointGroup group) {
+        if (!detailedCaptureEnabled) return;
+        synchronized (RenderDiagnostics.class) {
+            MutableGroupSnapshot state = state(group);
+            if (state == null) return;
+            state.straightTracerSubmitted = true;
+            state.straightTracerSuppressed = false;
+            state.finalOutcome = "straight tracer submitted";
+        }
+    }
+
+    static void recordNoStraightTracer(Iterable<WaypointGroup> groups, String reason) {
+        if (!detailedCaptureEnabled || groups == null) return;
+        synchronized (RenderDiagnostics.class) {
+            for (WaypointGroup group : groups) {
+                MutableGroupSnapshot state = state(group);
+                if (state == null || state.dungeonPathSubmitted) continue;
+                if ("empty".equals(state.path.result())) {
+                    state.finalOutcome = "nothing submitted: dungeon path empty; " + reason;
+                } else {
+                    state.finalOutcome = "nothing submitted: " + reason;
+                }
+            }
+        }
+    }
+
+    static void recordNoStraightTracer(WaypointGroup group, String reason) {
+        if (!detailedCaptureEnabled) return;
+        synchronized (RenderDiagnostics.class) {
+            MutableGroupSnapshot state = state(group);
+            if (state == null || state.dungeonPathSubmitted) return;
+            if ("empty".equals(state.path.result())) {
+                state.finalOutcome = "nothing submitted: dungeon path empty; " + reason;
+            } else {
+                state.finalOutcome = "nothing submitted: " + reason;
+            }
+        }
+    }
+
+    private static MutableGroupSnapshot state(WaypointGroup group) {
+        return group == null ? null : GROUPS.get(group.id());
+    }
+
+    public record Snapshot(long updatedAtEpochMillis,
+                           TracerSettings tracer,
+                           DungeonPathSettings dungeonPath,
+                           List<GroupSnapshot> groups) {
+        public Snapshot {
+            groups = groups == null ? List.of() : List.copyOf(groups);
+        }
+    }
+
+    public record TracerSettings(boolean enabled,
+                                 double opacity,
+                                 double thickness,
+                                 boolean inheritsWaypointColor,
+                                 boolean hideNearPlayer,
+                                 double hideNearPlayerRadius,
+                                 boolean hideOnStaticRoutes,
+                                 boolean irisHudFallbackConfigured,
+                                 boolean irisHudFallbackActive) {
+    }
+
+    public record DungeonPathSettings(boolean entryPathToFirstWaypoint,
+                                      boolean continueAfterFirstWaypoint) {
+    }
+
+    public record GroupSnapshot(String groupId,
+                                String groupName,
+                                String zoneId,
+                                String loadMode,
+                                int currentIndex,
+                                TargetSnapshot currentTarget,
+                                boolean entryPathEligible,
+                                boolean straightTracerSuppressed,
+                                boolean straightTracerSubmitted,
+                                boolean dungeonPathSubmitted,
+                                PathSnapshot path,
+                                String finalOutcome) {
+    }
+
+    public record TargetSnapshot(String name,
+                                 int blockX,
+                                 int blockY,
+                                 int blockZ,
+                                 double worldX,
+                                 double worldY,
+                                 double worldZ) {
+        private static TargetSnapshot from(Waypoint waypoint) {
+            if (waypoint == null) return null;
+            return new TargetSnapshot(
+                    waypoint.name(),
+                    waypoint.x(),
+                    waypoint.y(),
+                    waypoint.z(),
+                    waypoint.centerX(),
+                    waypoint.centerY(),
+                    waypoint.centerZ());
+        }
+    }
+
+    public record PathSnapshot(String cacheStatus,
+                               double cacheAgeMillis,
+                               String result,
+                               int pointCount,
+                               double computeTimeMillis,
+                               BlockPosition rawStart,
+                               BlockPosition rawGoal,
+                               BlockPosition resolvedStart,
+                               BlockPosition resolvedGoal,
+                               int expansions,
+                               int expansionLimit,
+                               String reason) {
+        private static PathSnapshot notAttempted() {
+            return new PathSnapshot(
+                    "not attempted",
+                    0.0,
+                    "not attempted",
+                    0,
+                    0.0,
+                    null,
+                    null,
+                    null,
+                    null,
+                    0,
+                    0,
+                    "path not attempted this frame");
+        }
+    }
+
+    public record BlockPosition(int x, int y, int z) {
+        private static BlockPosition from(BlockPos position) {
+            return position == null
+                    ? null
+                    : new BlockPosition(position.getX(), position.getY(), position.getZ());
+        }
+    }
+
+    private static final class MutableGroupSnapshot {
+        private final String groupId;
+        private final String groupName;
+        private final String zoneId;
+        private final String loadMode;
+        private final int currentIndex;
+        private final TargetSnapshot currentTarget;
+        private final boolean entryPathEligible;
+        private boolean straightTracerSuppressed;
+        private boolean straightTracerSubmitted;
+        private boolean dungeonPathSubmitted;
+        private PathSnapshot path = PathSnapshot.notAttempted();
+        private String finalOutcome = PENDING_OUTCOME;
+
+        private MutableGroupSnapshot(String groupId, String groupName, String zoneId,
+                                     String loadMode, int currentIndex,
+                                     TargetSnapshot currentTarget,
+                                     boolean entryPathEligible) {
+            this.groupId = groupId;
+            this.groupName = groupName;
+            this.zoneId = zoneId;
+            this.loadMode = loadMode;
+            this.currentIndex = currentIndex;
+            this.currentTarget = currentTarget;
+            this.entryPathEligible = entryPathEligible;
+        }
+
+        private static MutableGroupSnapshot from(WaypointGroup group,
+                                                 boolean entryPathEligible) {
+            return new MutableGroupSnapshot(
+                    group.id(),
+                    group.name(),
+                    group.zoneId(),
+                    group.loadMode().name(),
+                    group.currentIndex(),
+                    TargetSnapshot.from(group.current()),
+                    entryPathEligible);
+        }
+
+        private GroupSnapshot snapshot() {
+            return new GroupSnapshot(
+                    groupId,
+                    groupName,
+                    zoneId,
+                    loadMode,
+                    currentIndex,
+                    currentTarget,
+                    entryPathEligible,
+                    straightTracerSuppressed,
+                    straightTracerSubmitted,
+                    dungeonPathSubmitted,
+                    path,
+                    finalOutcome);
+        }
+    }
+}

--- a/src/client/java/com/babbur/waypointer/render/TracerRenderer.java
+++ b/src/client/java/com/babbur/waypointer/render/TracerRenderer.java
@@ -82,15 +82,24 @@ public final class TracerRenderer implements HudElement {
         var groups = manager.activeGroups();
         if (groups.isEmpty()) return;
         boolean tempFocus = manager.tempWaypointFocusActive();
-        if (!tempFocus && !config.showTracer()) return;
+        if (!tempFocus && !config.showTracer()) {
+            RenderDiagnostics.recordNoStraightTracer(groups, "tracer disabled");
+            return;
+        }
         float alpha = (float) config.tracerOpacity();
         if (tempFocus) {
             alpha = Math.max(alpha, TEMP_FOCUS_TRACER_ALPHA_FLOOR);
         }
-        if (alpha <= 0.0f) return;
+        if (alpha <= 0.0f) {
+            RenderDiagnostics.recordNoStraightTracer(groups, "tracer opacity is zero");
+            return;
+        }
 
         PoseStack ps = ctx.poseStack();
-        if (ps == null) return;
+        if (ps == null) {
+            RenderDiagnostics.recordNoStraightTracer(groups, "world pose unavailable");
+            return;
+        }
         Minecraft mc = Minecraft.getInstance();
         Camera cam = MinecraftCompat.mainCamera(mc.gameRenderer);
         Vec3 camPos = cam.position();
@@ -116,31 +125,70 @@ public final class TracerRenderer implements HudElement {
         int overrideColor = config.tracerColor();
         float thickness = (float) config.tracerThickness();
         float renderAlpha = alpha;
-        RenderType lineType = WaypointerRenderPipelines.linesThroughWalls();
-        RenderSubmission.submit(ctx, ps, lineType, (lines, submittedPose) -> {
-            for (WaypointGroup g : groups) {
-                if (config.showDungeonEntryPathToFirstWaypoint()
-                        && WaypointRenderer.shouldRenderDungeonEntryPath(g,
-                        config.showDungeonEntryPathToFollowingWaypoints())) {
-                    continue;
-                }
-                if (!tempFocus
-                        && config.hideTracerOnStaticRoutes()
-                        && g.loadMode() == WaypointGroup.LoadMode.STATIC) {
-                    continue;
-                }
-                Waypoint target = g.current();
-                if (target == null) continue;
-                if (shouldHideNearPlayer(target, player, nearHideDistanceSq)) continue;
-                int color = matchWaypoint ? target.color() : overrideColor;
-                RenderHelpers.emitLine(lines, submittedPose,
-                        fromX, fromY, fromZ,
-                        (float) target.centerX(), (float) target.centerY(), (float) target.centerZ(),
-                        color, renderAlpha, thickness);
+        boolean hasTracerLines = false;
+        for (WaypointGroup group : groups) {
+            if (straightTracerTarget(group, tempFocus, player, nearHideDistanceSq, true) != null) {
+                hasTracerLines = true;
             }
-        });
+        }
+
+        if (hasTracerLines) {
+            RenderType lineType = WaypointerRenderPipelines.linesThroughWalls();
+            boolean submitted = RenderSubmission.submit(ctx, ps, lineType, (lines, submittedPose) -> {
+                for (WaypointGroup group : groups) {
+                    Waypoint target = straightTracerTarget(
+                            group, tempFocus, player, nearHideDistanceSq, false);
+                    if (target == null) continue;
+                    int color = matchWaypoint ? target.color() : overrideColor;
+                    RenderHelpers.emitLine(lines, submittedPose,
+                            fromX, fromY, fromZ,
+                            (float) target.centerX(), (float) target.centerY(), (float) target.centerZ(),
+                            color, renderAlpha, thickness);
+                }
+            });
+            for (WaypointGroup group : groups) {
+                if (straightTracerTarget(group, tempFocus, player, nearHideDistanceSq, false) == null) {
+                    continue;
+                }
+                if (submitted) {
+                    RenderDiagnostics.recordStraightTracerSubmitted(group);
+                } else {
+                    RenderDiagnostics.recordNoStraightTracer(
+                            group, "world render submission failed");
+                }
+            }
+        }
 
         ps.popPose();
+    }
+
+    private Waypoint straightTracerTarget(WaypointGroup group, boolean tempFocus,
+                                          LocalPlayer player, double nearHideDistanceSq,
+                                          boolean recordDecision) {
+        if (RenderDiagnostics.shouldSuppressStraightTracer(group)) {
+            if (recordDecision) RenderDiagnostics.recordStraightTracerSuppressed(group);
+            return null;
+        }
+        if (!tempFocus
+                && config.hideTracerOnStaticRoutes()
+                && group.loadMode() == WaypointGroup.LoadMode.STATIC) {
+            if (recordDecision) {
+                RenderDiagnostics.recordNoStraightTracer(group, "static-route tracers hidden");
+            }
+            return null;
+        }
+        Waypoint target = group.current();
+        if (target == null) {
+            if (recordDecision) RenderDiagnostics.recordNoStraightTracer(group, "no current target");
+            return null;
+        }
+        if (shouldHideNearPlayer(target, player, nearHideDistanceSq)) {
+            if (recordDecision) {
+                RenderDiagnostics.recordNoStraightTracer(group, "straight tracer hidden near player");
+            }
+            return null;
+        }
+        return target;
     }
 
     @Override
@@ -148,9 +196,13 @@ public final class TracerRenderer implements HudElement {
         if (!IrisShaderFallback.shouldUse(config)) return;
 
         var groups = manager.activeGroups();
+        RenderDiagnostics.beginFrame(groups, config, true);
         if (groups.isEmpty()) return;
         boolean tempFocus = manager.tempWaypointFocusActive();
-        if (!tempFocus && !config.showTracer()) return;
+        if (!tempFocus && !config.showTracer()) {
+            RenderDiagnostics.recordNoStraightTracer(groups, "tracer disabled");
+            return;
+        }
 
         Minecraft mc = Minecraft.getInstance();
         LocalPlayer player = mc.player;
@@ -167,27 +219,32 @@ public final class TracerRenderer implements HudElement {
         if (tempFocus) {
             alpha = Math.max(alpha, TEMP_FOCUS_TRACER_ALPHA_FLOOR);
         }
-        if (alpha <= 0.0f) return;
+        if (alpha <= 0.0f) {
+            RenderDiagnostics.recordNoStraightTracer(groups, "tracer opacity is zero");
+            return;
+        }
         double nearHideDistanceSq = nearHideDistanceSq();
         boolean matchWaypoint = config.matchTracerToWaypointColor();
         int overrideColor = config.tracerColor();
         double thickness = config.tracerThickness();
 
         for (WaypointGroup group : groups) {
-            if (config.showDungeonEntryPathToFirstWaypoint()
-                    && WaypointRenderer.shouldRenderDungeonEntryPath(group,
-                    config.showDungeonEntryPathToFollowingWaypoints())) {
-                continue;
-            }
             if (!tempFocus
                     && config.hideTracerOnStaticRoutes()
                     && group.loadMode() == WaypointGroup.LoadMode.STATIC) {
+                RenderDiagnostics.recordNoStraightTracer(group, "static-route tracers hidden");
                 continue;
             }
 
             Waypoint target = group.current();
-            if (target == null) continue;
-            if (shouldHideNearPlayer(target, player, nearHideDistanceSq)) continue;
+            if (target == null) {
+                RenderDiagnostics.recordNoStraightTracer(group, "no current target");
+                continue;
+            }
+            if (shouldHideNearPlayer(target, player, nearHideDistanceSq)) {
+                RenderDiagnostics.recordNoStraightTracer(group, "straight tracer hidden near player");
+                continue;
+            }
             if (!projector.project(target.centerX(), target.centerY(), target.centerZ(),
                     screenW, screenH, screenScratch)) {
                 projectOffscreenTarget(camera, target, screenW, screenH, screenScratch);
@@ -197,6 +254,7 @@ public final class TracerRenderer implements HudElement {
             int argb = RenderHelpers.withAlpha(0xFF000000 | (color & 0xFFFFFF), alpha);
             WaypointRenderer.drawScreenLine(g, fromX, fromY,
                     screenScratch[0], screenScratch[1], argb, thickness);
+            RenderDiagnostics.recordStraightTracerSubmitted(group);
         }
     }
 

--- a/src/client/java/com/babbur/waypointer/render/WaypointRenderer.java
+++ b/src/client/java/com/babbur/waypointer/render/WaypointRenderer.java
@@ -505,14 +505,29 @@ public final class WaypointRenderer implements HudElement {
                     cached.result(), true, Math.max(0L, now - cached.computedAtNanos()));
         }
 
-        GroundPathfinder.PathResult result = GroundPathfinder.findPathResult(
-                level,
-                playerPos,
-                target,
-                GroundPathfinder.NO_DISTANCE_LIMIT,
-                DUNGEON_ENTRY_MAX_EXPANSIONS,
-                DUNGEON_ENTRY_SEARCH_PADDING,
-                DUNGEON_ENTRY_SEARCH_PADDING);
+        long startedAtNanos = System.nanoTime();
+        GroundPathfinder.PathResult result;
+        try {
+            result = GroundPathfinder.findPathResult(
+                    level,
+                    playerPos,
+                    target,
+                    GroundPathfinder.NO_DISTANCE_LIMIT,
+                    DUNGEON_ENTRY_MAX_EXPANSIONS,
+                    DUNGEON_ENTRY_SEARCH_PADDING,
+                    DUNGEON_ENTRY_SEARCH_PADDING);
+        } catch (RuntimeException error) {
+            Waypointer.LOGGER.warn("Dungeon entry path calculation failed; using tracer fallback", error);
+            result = new GroundPathfinder.PathResult(List.of(), new GroundPathfinder.Diagnostics(
+                    start,
+                    GroundPathfinder.targetBlock(target),
+                    null,
+                    null,
+                    GroundPathfinder.FailureReason.CALCULATION_FAILED,
+                    0,
+                    DUNGEON_ENTRY_MAX_EXPANSIONS,
+                    Math.max(0L, System.nanoTime() - startedAtNanos)));
+        }
         dungeonEntryPathCache.put(targetKey, new DungeonEntryPath(start, result, now));
         return new DungeonEntryPathLookup(result, false, 0L);
     }

--- a/src/client/java/com/babbur/waypointer/render/WaypointRenderer.java
+++ b/src/client/java/com/babbur/waypointer/render/WaypointRenderer.java
@@ -250,9 +250,11 @@ public final class WaypointRenderer implements HudElement {
     private static final int DEFAULT_MAX_BUILD_Y = 320;
 
     private void onWorldRender(LevelRenderContext ctx) {
-        if (IrisShaderFallback.shouldUse(config)) return;
-
         var groups = manager.activeGroups();
+        boolean irisHudFallbackActive = IrisShaderFallback.shouldUse(config);
+        RenderDiagnostics.beginFrame(groups, config, irisHudFallbackActive);
+        if (irisHudFallbackActive) return;
+
         if (groups.isEmpty()) return;
 
         WaypointerConfig.BoxStyle style = config.boxStyle();
@@ -398,9 +400,12 @@ public final class WaypointRenderer implements HudElement {
         }
         if ((drawLines || drawRouteLines || drawDungeonEntryPaths) && hasThroughWallWaypoints) {
             RenderType lineType = WaypointerRenderPipelines.linesThroughWalls();
-            RenderSubmission.submit(ctx, ps, lineType, (lines, submittedPose) -> {
+            List<DungeonEntryPathSubmission> dungeonEntryPaths = drawDungeonEntryPaths
+                    ? prepareDungeonEntryPaths(groups, playerPos, level)
+                    : List.of();
+            boolean submitted = RenderSubmission.submit(ctx, ps, lineType, (lines, submittedPose) -> {
                 if (drawDungeonEntryPaths) {
-                    emitDungeonEntryPaths(submittedPose, lines, groups, playerPos, level);
+                    emitDungeonEntryPaths(submittedPose, lines, dungeonEntryPaths);
                 }
                 if (drawRouteLines) {
                     for (WaypointGroup g : groups) {
@@ -417,6 +422,10 @@ public final class WaypointRenderer implements HudElement {
                     }
                 }
             });
+            for (DungeonEntryPathSubmission path : dungeonEntryPaths) {
+                RenderDiagnostics.recordDungeonPathSubmission(
+                        path.group(), submitted && isDrawableDungeonEntryPath(path.points()));
+            }
         }
         if ((drawLines || drawRouteLines) && hasDepthCheckedWaypoints) {
             RenderType lineType = WaypointerRenderPipelines.linesDepthTested();
@@ -441,20 +450,13 @@ public final class WaypointRenderer implements HudElement {
         ps.popPose();
     }
 
-    private void emitDungeonEntryPaths(PoseStack ps, VertexConsumer lines, Iterable<WaypointGroup> groups,
-                                       Vec3 playerPos, ClientLevel level) {
-        if (playerPos == null || level == null) return;
-
+    private void emitDungeonEntryPaths(PoseStack ps, VertexConsumer lines,
+                                       Iterable<DungeonEntryPathSubmission> paths) {
         float alpha = DUNGEON_ENTRY_PATH_ALPHA;
         float width = effectiveOutlineThickness();
         int color = config.dungeonEntryPathColor();
-        for (WaypointGroup group : groups) {
-            if (!shouldRenderDungeonEntryPath(group,
-                    config.showDungeonEntryPathToFollowingWaypoints())) continue;
-
-            Waypoint target = group.current();
-            if (target == null) continue;
-            List<Vec3> points = dungeonEntryPathPoints(level, playerPos, target);
+        for (DungeonEntryPathSubmission path : paths) {
+            List<Vec3> points = path.points();
             for (int i = 1; i < points.size(); i++) {
                 Vec3 a = points.get(i - 1);
                 Vec3 b = points.get(i);
@@ -466,7 +468,27 @@ public final class WaypointRenderer implements HudElement {
         }
     }
 
-    private List<Vec3> dungeonEntryPathPoints(ClientLevel level, Vec3 playerPos, Waypoint target) {
+    private List<DungeonEntryPathSubmission> prepareDungeonEntryPaths(
+            Iterable<WaypointGroup> groups, Vec3 playerPos, ClientLevel level) {
+        if (playerPos == null || level == null) return List.of();
+
+        List<DungeonEntryPathSubmission> paths = new ArrayList<>();
+        for (WaypointGroup group : groups) {
+            if (!shouldRenderDungeonEntryPath(group,
+                    config.showDungeonEntryPathToFollowingWaypoints())) continue;
+
+            Waypoint target = group.current();
+            if (target == null) continue;
+            DungeonEntryPathLookup lookup = dungeonEntryPathPoints(level, playerPos, target);
+            RenderDiagnostics.recordPathLookup(
+                    group, lookup.result(), lookup.cacheHit(), lookup.cacheAgeNanos());
+            paths.add(new DungeonEntryPathSubmission(group, lookup.result().points()));
+        }
+        return paths;
+    }
+
+    private DungeonEntryPathLookup dungeonEntryPathPoints(ClientLevel level, Vec3 playerPos,
+                                                          Waypoint target) {
         BlockPos start = GroundPathfinder.floorPos(playerPos);
         DungeonEntryPathTarget targetKey = DungeonEntryPathTarget.from(target);
         long now = System.nanoTime();
@@ -478,11 +500,12 @@ public final class WaypointRenderer implements HudElement {
         DungeonEntryPath cached = dungeonEntryPathCache.get(targetKey);
         if (cached != null
                 && shouldReuseDungeonEntryPath(cached.start(), cached.computedAtNanos(), start, now)) {
-            GroundPathfinder.moveLineStart(cached.points(), playerPos);
-            return cached.points();
+            GroundPathfinder.moveLineStart(cached.result().points(), playerPos);
+            return new DungeonEntryPathLookup(
+                    cached.result(), true, Math.max(0L, now - cached.computedAtNanos()));
         }
 
-        List<Vec3> points = GroundPathfinder.findPath(
+        GroundPathfinder.PathResult result = GroundPathfinder.findPathResult(
                 level,
                 playerPos,
                 target,
@@ -490,8 +513,8 @@ public final class WaypointRenderer implements HudElement {
                 DUNGEON_ENTRY_MAX_EXPANSIONS,
                 DUNGEON_ENTRY_SEARCH_PADDING,
                 DUNGEON_ENTRY_SEARCH_PADDING);
-        dungeonEntryPathCache.put(targetKey, new DungeonEntryPath(start, points, now));
-        return points;
+        dungeonEntryPathCache.put(targetKey, new DungeonEntryPath(start, result, now));
+        return new DungeonEntryPathLookup(result, false, 0L);
     }
 
     static boolean shouldReuseDungeonEntryPath(BlockPos cachedStart, long computedAtNanos,
@@ -510,7 +533,19 @@ public final class WaypointRenderer implements HudElement {
         }
     }
 
-    private record DungeonEntryPath(BlockPos start, List<Vec3> points, long computedAtNanos) {
+    static boolean isDrawableDungeonEntryPath(List<Vec3> points) {
+        return points != null && points.size() >= 2;
+    }
+
+    private record DungeonEntryPath(BlockPos start, GroundPathfinder.PathResult result,
+                                    long computedAtNanos) {
+    }
+
+    private record DungeonEntryPathLookup(GroundPathfinder.PathResult result,
+                                          boolean cacheHit, long cacheAgeNanos) {
+    }
+
+    private record DungeonEntryPathSubmission(WaypointGroup group, List<Vec3> points) {
     }
 
     static boolean shouldRenderDungeonEntryPath(WaypointGroup group, boolean includeFollowingWaypoints) {

--- a/src/client/java/com/babbur/waypointer/screen/DebugInspectScreen.java
+++ b/src/client/java/com/babbur/waypointer/screen/DebugInspectScreen.java
@@ -1,16 +1,27 @@
 package com.babbur.waypointer.screen;
 
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.babbur.waypointer.Waypointer;
 import com.babbur.waypointer.compat.MinecraftCompat;
 import com.babbur.waypointer.WaypointerClient;
 import com.babbur.waypointer.codec.DecodeDebug;
 import com.babbur.waypointer.codec.WaypointCodec;
+import com.babbur.waypointer.config.Storage;
 import com.babbur.waypointer.config.WaypointerConfig;
 import com.babbur.waypointer.core.ActiveGroupManager;
+import com.babbur.waypointer.core.Waypoint;
 import com.babbur.waypointer.core.WaypointGroup;
+import com.babbur.waypointer.debug.ConfigChangeHistory;
 import com.babbur.waypointer.debug.DebugEventLog;
+import com.babbur.waypointer.debug.DebugLogTail;
+import com.babbur.waypointer.debug.DebugReportExport;
 import com.babbur.waypointer.debug.DebugSignals;
 import com.babbur.waypointer.debug.PerformanceStats;
+import com.babbur.waypointer.dungeon.config.DungeonConfig;
+import com.babbur.waypointer.input.WaypointerKeybinds;
+import com.babbur.waypointer.render.RenderDiagnostics;
 import com.babbur.waypointer.screen.settings.SettingsCatalog;
+import com.babbur.waypointer.screen.settings.Setting;
 import com.babbur.waypointer.dungeon.DungeonCoreSignature;
 import com.babbur.waypointer.dungeon.DungeonRoom;
 import com.babbur.waypointer.dungeon.DungeonRoomZoneBridge;
@@ -23,10 +34,15 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.Mth;
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static com.babbur.waypointer.screen.GuiTokens.ACCENT;
 import static com.babbur.waypointer.screen.GuiTokens.BORDER;
@@ -46,7 +62,7 @@ import static com.babbur.waypointer.screen.GuiTokens.TEXT_DIM;
 import static com.babbur.waypointer.screen.GuiTokens.TEXT_MUTED;
 
 /**
- * Wire-level inspector for Waypointer codec strings. Mirrors the clinical sidebar/main
+ * All-in-one troubleshooting report for Waypointer. Mirrors the clinical sidebar/main
  * shape used by the other screens: a jump-list of sections on the left, a
  * structured, column-aligned report on the right. Never mutates the user's
  * groups or config -- read-only diagnostic surface for {@code /wp debug}.
@@ -66,7 +82,7 @@ public final class DebugInspectScreen extends Screen {
     // an integer row index; breathing room above sections is a Blank row, not a tall row.
 
     private sealed interface Row {
-        record Section(String title) implements Row {}
+        record Section(String title, DebugReportExport.Category category) implements Row {}
         record KV(String key, String value) implements Row {}
         record KVDim(String key, String value) implements Row {}
         record KVWarn(String key, String value) implements Row {}
@@ -115,9 +131,13 @@ public final class DebugInspectScreen extends Screen {
     private final List<SectionAnchor> sections = new ArrayList<>();
     private int scrollRows;
     private int selectedSection;
+    private int sidebarScrollRows;
+    private int sidebarVisibleRows;
 
     private Button copyButton;
     private long copyFeedbackUntil;
+    private long rendererCaptureRequestedAt;
+    private boolean awaitingFreshRendererCapture;
 
     // Geometry recomputed each render(). Stashed so mouse handlers can hit-test.
     private int sidebarX1, sidebarX2, sidebarContentTop;
@@ -150,12 +170,18 @@ public final class DebugInspectScreen extends Screen {
 
     @Override
     protected void init() {
+        if (manager != null && config != null) {
+            RenderDiagnostics.setDetailedCaptureEnabled(true);
+            rendererCaptureRequestedAt = System.currentTimeMillis();
+            awaitingFreshRendererCapture = true;
+        }
         List<GuiTokens.ButtonSpec> left = new ArrayList<>();
         left.add(new GuiTokens.ButtonSpec("Refresh", this::loadCombinedReport));
         if (config != null) {
             left.add(new GuiTokens.ButtonSpec("Perf test", 88, this::openPerfStressTest));
         }
-        left.add(new GuiTokens.ButtonSpec("Copy report", this::copyReportToClipboard));
+        String copyLabel = copyFeedbackUntil > System.currentTimeMillis() ? "Copied" : "Copy Report";
+        left.add(new GuiTokens.ButtonSpec(copyLabel, this::openCopyConfirmation));
         GuiTokens.ButtonSpec back = new GuiTokens.ButtonSpec("Back", this::onClose);
 
         int footerY = height - FOOTER_H;
@@ -164,7 +190,8 @@ public final class DebugInspectScreen extends Screen {
             // Stash the Copy button so we can swap its label on the copy-confirmation flash.
             // Matching on the label string is ugly but the footer helper doesn't expose
             // a better hook and this screen builds exactly one button with that label.
-            if ("Copy report".contentEquals(b.getMessage().getString())) {
+            if ("Copy Report".contentEquals(b.getMessage().getString())
+                    || "Copied".contentEquals(b.getMessage().getString())) {
                 copyButton = b;
             }
             addRenderableWidget(b);
@@ -196,27 +223,56 @@ public final class DebugInspectScreen extends Screen {
         this.sections.clear();
         this.scrollRows = 0;
         this.selectedSection = 0;
+        this.sidebarScrollRows = 0;
     }
 
     private void loadCombinedReport() {
         resetReportState();
+
+        buildSafely("Report Summary", this::buildReportSummary);
+        buildSafely("PC Specs", DebugReportExport.Category.PC_SPECS, this::buildPcSpecsReport);
+        buildSafely("Active Mods and Versions", DebugReportExport.Category.ACTIVE_MODS,
+                this::buildActiveModsReport);
 
         if (manager == null || config == null) {
             addSection(rows, sections, "Performance Snapshot", "unavailable");
             rows.add(new Row.KVWarn("Unavailable",
                     "Open this screen through /wp debug to capture live Waypointer state."));
         } else {
-            var player = Minecraft.getInstance().player;
-            this.performanceStats = player == null
-                    ? PerformanceStats.capture(manager, config)
-                    : PerformanceStats.capture(manager, config,
-                    player.getX(), player.getY(), player.getZ());
-            buildPerformanceReport(this.performanceStats, config, rows, sections);
+            buildSafely("Server, Player, and Location", DebugReportExport.Category.SERVER_CONTEXT,
+                    this::buildServerContextReport);
+            buildSafely("Storage Health", this::buildStorageHealthReport);
+            buildSafely("Performance Snapshot", this::buildLivePerformanceReport);
+            buildSafely("Settings and Recent Changes", DebugReportExport.Category.SETTINGS_AND_CHANGES,
+                    this::buildSettingsReport);
+            buildSafely("Tracer and Dungeon Path Settings", DebugReportExport.Category.SETTINGS_AND_CHANGES,
+                    this::buildTracerAndPathSettingsReport);
+            buildSafely("Dungeon Entry Path Outcomes", DebugReportExport.Category.ROUTES_AND_WAYPOINTS,
+                    this::buildRenderDiagnosticsReport);
+            buildSafely("Keybinds", DebugReportExport.Category.SETTINGS_AND_CHANGES,
+                    this::buildKeybindReport);
+            buildSafely("Active Routes and Waypoints", DebugReportExport.Category.ROUTES_AND_WAYPOINTS,
+                    this::buildActiveRoutesReport);
         }
 
-        buildDungeonDiagnosticsReport(DebugSignals.dungeonDebugSnapshot(), rows, sections);
+        buildSafely("Dungeon Diagnostics", DebugReportExport.Category.SERVER_CONTEXT,
+                () -> buildDungeonDiagnosticsReport(DebugSignals.dungeonDebugSnapshot(), rows, sections));
+        buildSafely("Recent Settings Changes", DebugReportExport.Category.SETTINGS_AND_CHANGES,
+                this::buildRecentSettingsChangesReport);
+        buildSafely("Recent Logs and Activity", DebugReportExport.Category.RECENT_LOGS_AND_ACTIVITY,
+                this::buildRecentLogsAndActivityReport);
+        loadClipboardReport();
+    }
 
-        String text = minecraft.keyboardHandler.getClipboard();
+    private void loadClipboardReport() {
+        String text;
+        try {
+            text = minecraft.keyboardHandler.getClipboard();
+        } catch (Throwable error) {
+            this.codecError = "Clipboard could not be read: " + error.getClass().getSimpleName();
+            buildCodecClipboardReport(rows, sections, codecError);
+            return;
+        }
         if (text == null || text.isBlank()) {
             this.codecError = "Clipboard is empty. Copy a " + WaypointCodec.MAGIC
                     + " export to inspect its codec payload here.";
@@ -240,21 +296,542 @@ public final class DebugInspectScreen extends Screen {
         }
     }
 
-    private void copyReportToClipboard() {
-        if (rows.isEmpty() || copyButton == null) return;
-        StringBuilder sb = new StringBuilder();
-        for (Row r : rows) sb.append(rowAsPlainText(r)).append('\n');
-        minecraft.keyboardHandler.setClipboard(sb.toString());
+    @Override
+    public void tick() {
+        super.tick();
+        if (awaitingFreshRendererCapture
+                && RenderDiagnostics.lastUpdatedAtEpochMillis() >= rendererCaptureRequestedAt) {
+            awaitingFreshRendererCapture = false;
+            loadCombinedReport();
+        }
+    }
+
+    private void buildSafely(String label, Runnable builder) {
+        buildSafely(label, DebugReportExport.Category.CORE, builder);
+    }
+
+    private void buildSafely(String label, DebugReportExport.Category category, Runnable builder) {
+        try {
+            builder.run();
+        } catch (Throwable error) {
+            addSection(rows, sections, label + " (Unavailable)", "capture failed", category);
+            rows.add(new Row.KVWarn("Reason", error.getClass().getSimpleName()
+                    + (error.getMessage() == null ? "" : ": " + oneLine(error.getMessage()))));
+        }
+    }
+
+    private void buildReportSummary() {
+        addSection(rows, sections, "Troubleshooting Report", "schema 1");
+        rows.add(new Row.KV("Captured", java.time.Instant.now().toString()));
+        rows.add(new Row.KV("Report schema", "1"));
+        rows.add(new Row.KV("Waypointer", loadedModVersion(Waypointer.MOD_ID)));
+        rows.add(new Row.KV("Minecraft", loadedModVersion("minecraft")));
+        rows.add(new Row.KV("Fabric Loader", loadedModVersion("fabricloader")));
+        rows.add(new Row.KVDim("Command", "/wp debug"));
+        rows.add(new Row.KVDim("Privacy", "Sensitive sections require confirmation before copying."));
+    }
+
+    private void buildPcSpecsReport() {
+        addSection(rows, sections, "PC Specs", "review before sharing",
+                DebugReportExport.Category.PC_SPECS);
+        Runtime runtime = Runtime.getRuntime();
+        rows.add(new Row.KV("Operating system", oneLine(System.getProperty("os.name", "unknown")
+                + " " + System.getProperty("os.version", ""))));
+        rows.add(new Row.KV("Architecture", System.getProperty("os.arch", "unknown")));
+        rows.add(new Row.KV("Java", System.getProperty("java.version", "unknown")
+                + " (" + System.getProperty("java.vendor", "unknown") + ")"));
+        String cpuModel = System.getenv("PROCESSOR_IDENTIFIER");
+        rows.add(new Row.KV("CPU", cpuModel == null || cpuModel.isBlank()
+                ? "model unavailable; " + runtime.availableProcessors() + " logical processors"
+                : oneLine(cpuModel)));
+        rows.add(new Row.KV("Logical CPUs", String.valueOf(runtime.availableProcessors())));
+        try {
+            var operatingSystem = java.lang.management.ManagementFactory.getOperatingSystemMXBean();
+            if (operatingSystem instanceof com.sun.management.OperatingSystemMXBean extended) {
+                rows.add(new Row.KV("System memory", formatBytes(extended.getTotalMemorySize())));
+            }
+        } catch (Throwable ignored) {
+            rows.add(new Row.KVWarn("System memory", "Unavailable"));
+        }
+        rows.add(new Row.KV("JVM memory", formatBytes(runtime.totalMemory() - runtime.freeMemory())
+                + " used / " + formatBytes(runtime.maxMemory()) + " max"));
+
+        String gpuVendor = "unavailable";
+        String gpuBackend = "unavailable";
+        String gpuImplementation = "unavailable";
+        try {
+            var device = RenderSystem.tryGetDevice();
+            if (device != null) {
+                MinecraftCompat.GpuInfo gpu = MinecraftCompat.gpuInfo(device);
+                gpuVendor = oneLine(gpu.vendor());
+                gpuBackend = oneLine(gpu.backend());
+                gpuImplementation = oneLine(gpu.implementation());
+            }
+        } catch (Throwable ignored) {
+            // Optional render backend diagnostics must never break /wp debug.
+        }
+        rows.add(new Row.KV("GPU vendor", gpuVendor));
+        rows.add(new Row.KV("GPU backend", gpuBackend));
+        rows.add(new Row.KVDim("GPU", gpuImplementation));
+
+        try {
+            rows.add(new Row.KV("Window", minecraft.getWindow().getWidth() + "x"
+                    + minecraft.getWindow().getHeight() + " physical, "
+                    + minecraft.getWindow().getGuiScaledWidth() + "x"
+                    + minecraft.getWindow().getGuiScaledHeight() + " GUI"));
+            rows.add(new Row.KV("VSync", minecraft.options.enableVsync().get() ? "on" : "off"));
+            rows.add(new Row.KV("FPS limit", String.valueOf(minecraft.options.framerateLimit().get())));
+        } catch (Throwable ignored) {
+            rows.add(new Row.KVWarn("Video settings", "Unavailable"));
+        }
+    }
+
+    private void buildActiveModsReport() {
+        List<ModContainer> mods = new ArrayList<>(FabricLoader.getInstance().getAllMods());
+        mods.sort(Comparator
+                .comparing((ModContainer mod) -> mod.getMetadata().getId(), String.CASE_INSENSITIVE_ORDER)
+                .thenComparing(mod -> mod.getMetadata().getName(), String.CASE_INSENSITIVE_ORDER));
+        addSection(rows, sections, "Active Mods and Versions", mods.size() + " loaded",
+                DebugReportExport.Category.ACTIVE_MODS);
+        for (ModContainer mod : mods) {
+            String id = oneLine(mod.getMetadata().getId());
+            String name = oneLine(mod.getMetadata().getName());
+            String version = oneLine(mod.getMetadata().getVersion().getFriendlyString());
+            rows.add(new Row.KVDim(id, name + " — " + version));
+        }
+    }
+
+    private void buildServerContextReport() {
+        addSection(rows, sections, "Server, Player, and Location", "live context",
+                DebugReportExport.Category.SERVER_CONTEXT);
+        var server = minecraft.getCurrentServer();
+        rows.add(new Row.KV("Connection", server == null
+                ? (minecraft.level == null ? "Not connected" : "Local or address unavailable")
+                : oneLine(server.ip)));
+        rows.add(new Row.KV("World loaded", String.valueOf(minecraft.level != null)));
+
+        var zone = manager.currentZone();
+        rows.add(new Row.KV("Waypointer zone", zone == null
+                ? "(none)" : oneLine(zone.displayName()) + " (" + oneLine(zone.id()) + ")"));
+        var player = minecraft.player;
+        if (player == null) {
+            rows.add(new Row.KVWarn("Player", "Unavailable"));
+        } else {
+            rows.add(new Row.KV("Player position", String.format(Locale.ROOT,
+                    "%.3f, %.3f, %.3f", player.getX(), player.getY(), player.getZ())));
+            rows.add(new Row.KV("Player block", player.blockPosition().getX() + ", "
+                    + player.blockPosition().getY() + ", " + player.blockPosition().getZ()));
+            rows.add(new Row.KV("View", String.format(Locale.ROOT, "yaw %.1f, pitch %.1f",
+                    player.getYRot(), player.getXRot())));
+        }
+        rows.add(new Row.KVDim("Hypixel Mod API", DebugSignals.hypixelApiLine()));
+    }
+
+    private void buildLivePerformanceReport() {
+        var player = minecraft.player;
+        this.performanceStats = player == null
+                ? PerformanceStats.capture(manager, config)
+                : PerformanceStats.capture(manager, config,
+                player.getX(), player.getY(), player.getZ());
+        buildPerformanceReport(this.performanceStats, config, rows, sections);
+    }
+
+    private void buildStorageHealthReport() {
+        addSection(rows, sections, "Storage Health", null);
+        Path configDirectory = FabricLoader.getInstance().getConfigDir().resolve(Waypointer.MOD_ID);
+        addFileHealth("Main config", configDirectory.resolve("config.json"));
+        addFileHealth("Dungeon config", configDirectory.resolve("dungeon.json"));
+        Storage storage = WaypointerClient.storage();
+        if (storage == null) {
+            rows.add(new Row.KVWarn("Storage", "Unavailable"));
+            return;
+        }
+        Storage.DebugSnapshot snapshot = storage.debugSnapshot();
+        rows.add(new Row.KV("Route file", snapshot.fileName()));
+        rows.add(new Row.KV("Exists", String.valueOf(snapshot.exists())));
+        rows.add(new Row.KV("Size", snapshot.sizeBytes() < 0L
+                ? "unavailable" : formatBytes(snapshot.sizeBytes())));
+        rows.add(new Row.KVDim("Modified", snapshot.modifiedAtMillis() < 0L
+                ? "unavailable" : java.time.Instant.ofEpochMilli(snapshot.modifiedAtMillis()).toString()));
+        rows.add(new Row.KV("Saver attached", String.valueOf(snapshot.attached())));
+        rows.add(new Row.KV("Writes blocked", String.valueOf(snapshot.writesBlocked())));
+        rows.add(new Row.KV("Snapshot ready", String.valueOf(snapshot.snapshotReady())));
+        rows.add(new Row.KVDim("Session I/O", snapshot.snapshotsCaptured()
+                + " snapshots, " + snapshot.writesCompleted() + " writes"));
+        try (var files = Files.list(configDirectory)) {
+            long quarantined = files
+                    .filter(path -> path.getFileName().toString().startsWith("waypoints.json.invalid"))
+                    .count();
+            rows.add(new Row.KV("Invalid quarantines", String.valueOf(quarantined)));
+        } catch (Exception ignored) {
+            rows.add(new Row.KVWarn("Invalid quarantines", "Unavailable"));
+        }
+    }
+
+    private void addFileHealth(String label, Path file) {
+        try {
+            if (!Files.isRegularFile(file)) {
+                rows.add(new Row.KV(label, "missing (defaults may be in use)"));
+                return;
+            }
+            rows.add(new Row.KV(label, file.getFileName() + ", " + formatBytes(Files.size(file))
+                    + ", modified " + formatAge(Files.getLastModifiedTime(file).toMillis())));
+        } catch (Exception ignored) {
+            rows.add(new Row.KVWarn(label, "Metadata unavailable"));
+        }
+    }
+
+    private void buildSettingsReport() {
+        DungeonConfig dungeonConfig = WaypointerClient.dungeonConfig();
+        addSection(rows, sections, "All Settings", SettingsCatalog.allSettings().size() + " catalog entries",
+                DebugReportExport.Category.SETTINGS_AND_CHANGES);
+        for (SettingsCatalog.Category category : SettingsCatalog.categories()) {
+            rows.add(new Row.BitNote("[" + category.label() + "]"));
+            for (SettingsCatalog.Group group : category.groups()) {
+                for (Setting setting : group.settings()) {
+                    if (setting.store() == Setting.Store.NONE) continue;
+                    if (setting.store() == Setting.Store.DUNGEON && dungeonConfig == null) {
+                        rows.add(new Row.KVWarn(setting.id(), "Unavailable"));
+                        continue;
+                    }
+                    Object value = setting.get(config, dungeonConfig);
+                    rows.add(new Row.KV(setting.id(), oneLine(setting.formatValue(value))));
+                }
+            }
+        }
+        rows.add(new Row.BitNote("[Internal troubleshooting state]"));
+        rows.add(new Row.KV("configSchemaVersion", String.valueOf(config.configSchemaVersion())));
+        rows.add(new Row.KV("painterPalette", formatPalette(config.waypointPainterPalette())));
+        rows.add(new Row.KV("painterDefault", config.waypointPainterDefaultPaint() == null
+                ? "(none)" : "configured (hash " + config.waypointPainterDefaultPaint().hashCode() + ")"));
+        if (dungeonConfig != null) {
+            rows.add(new Row.KV("debugLogRoomChanges", String.valueOf(dungeonConfig.debugLogRoomChanges())));
+            rows.add(new Row.KV("routesPromptDismissed", String.valueOf(dungeonConfig.routesPromptDismissed())));
+            rows.add(new Row.KV("defaultDirection", dungeonConfig.defaultDirection()));
+        }
+    }
+
+    private void buildActiveRoutesReport() {
+        List<WaypointGroup> activeGroups = manager.activeGroups();
+        addSection(rows, sections, "Active Routes and Waypoints", activeGroups.size() + " active",
+                DebugReportExport.Category.ROUTES_AND_WAYPOINTS);
+        if (activeGroups.isEmpty()) {
+            rows.add(new Row.KVDim("Routes", "No routes are active in the current zone."));
+            return;
+        }
+
+        var player = minecraft.player;
+        for (int groupIndex = 0; groupIndex < activeGroups.size(); groupIndex++) {
+            WaypointGroup group = activeGroups.get(groupIndex);
+            rows.add(new Row.BitNote("Route " + (groupIndex + 1) + " of " + activeGroups.size()));
+            rows.add(new Row.KV("Name", oneLine(group.name().isBlank() ? "(unnamed)" : group.name())));
+            rows.add(new Row.KVDim("ID", oneLine(group.id())));
+            rows.add(new Row.KV("Zone", oneLine(group.zoneId())));
+            rows.add(new Row.KV("Source", routeSource(group)));
+            rows.add(new Row.KVDim("Coordinates", routeCoordinateSpace(group)));
+            rows.add(new Row.KV("State", "enabled=" + group.enabled()
+                    + ", mode=" + group.loadMode()
+                    + ", temp=" + group.temp()
+                    + ", runtimeOnly=" + group.runtimeOnly()));
+            rows.add(new Row.KV("Progress", "currentIndex=" + group.currentIndex()
+                    + ", currentMain=" + group.currentMainIndex()
+                    + ", mainOrdinal=" + group.currentMainOrdinal() + "/" + group.mainWaypointCount()
+                    + ", complete=" + group.isComplete()));
+            rows.add(new Row.KV("Route behavior", "skipAhead=" + group.skipAheadEnabled()
+                    + ", defaultRadius=" + formatRadius(group.defaultRadius())
+                    + ", activeSubParent=" + group.activeSubwaypointParentIndex()));
+            rows.add(new Row.KVDim("Best time", group.bestTimeMillis() < 0L
+                    ? "(none)" : group.bestTimeMillis() + " ms"));
+
+            List<Waypoint> waypoints = group.waypoints();
+            for (int i = 0; i < waypoints.size(); i++) {
+                Waypoint waypoint = waypoints.get(i);
+                StringBuilder value = new StringBuilder();
+                if (i == group.currentIndex()) value.append("CURRENT  ");
+                value.append("block=(").append(waypoint.x()).append(',').append(waypoint.y())
+                        .append(',').append(waypoint.z()).append(')');
+                value.append(String.format(Locale.ROOT, " world=(%.3f,%.3f,%.3f)",
+                        waypoint.centerX(), waypoint.centerY(), waypoint.centerZ()));
+                if (waypoint.hasName()) value.append(" name=\"").append(oneLine(waypoint.name())).append('"');
+                value.append(String.format(Locale.ROOT, " color=#%06X flags=0x%X",
+                        waypoint.color() & 0xFFFFFF, waypoint.flags()));
+                double radius = waypoint.customRadius() > 0.0
+                        ? waypoint.customRadius() : group.defaultRadius();
+                value.append(" radius=").append(formatRadius(radius));
+                if (waypoint.isTemp()) {
+                    value.append(" temp=").append(Waypoint.tempModeName(waypoint.tempMode()))
+                            .append(" expiresAt=").append(waypoint.expiresAtMillis());
+                }
+                if (player != null) {
+                    double dx = waypoint.centerX() - player.getX();
+                    double dy = waypoint.centerY() - player.getY();
+                    double dz = waypoint.centerZ() - player.getZ();
+                    value.append(String.format(Locale.ROOT, " distance=%.2f", Math.sqrt(dx * dx + dy * dy + dz * dz)));
+                }
+                rows.add(new Row.KVDim(group.displayIndexLabel(i), value.toString()));
+            }
+        }
+    }
+
+    private void buildTracerAndPathSettingsReport() {
+        addSection(rows, sections, "Tracer and Dungeon Path Settings", null,
+                DebugReportExport.Category.SETTINGS_AND_CHANGES);
+        rows.add(new Row.KV("Tracer", config.showTracer() ? "on" : "off"));
+        rows.add(new Row.KV("Tracer opacity", formatRadius(config.tracerOpacity())));
+        rows.add(new Row.KV("Tracer thickness", formatRadius(config.tracerThickness()) + " px"));
+        rows.add(new Row.KV("Inherits color", String.valueOf(config.matchTracerToWaypointColor())));
+        rows.add(new Row.KV("Hide static tracer", String.valueOf(config.hideTracerOnStaticRoutes())));
+        rows.add(new Row.KV("Hide near player", String.valueOf(config.hideWaypointsNearPlayer())));
+        rows.add(new Row.KV("Near-player radius", formatRadius(config.hideWaypointsNearRadius()) + " blocks"));
+        rows.add(new Row.KV("Iris HUD fallback", String.valueOf(config.irisShaderHudFallback())));
+        rows.add(new Row.KV("Dungeon entry path to first waypoint", String.valueOf(
+                config.showDungeonEntryPathToFirstWaypoint())));
+        rows.add(new Row.KV("Continue dungeon path after first", String.valueOf(
+                config.showDungeonEntryPathToFollowingWaypoints())));
+    }
+
+    private void buildKeybindReport() {
+        WaypointerKeybinds keybinds = WaypointerClient.keybinds();
+        addSection(rows, sections, "Keybinds", keybinds == null ? "unavailable" : "live bindings",
+                DebugReportExport.Category.SETTINGS_AND_CHANGES);
+        if (keybinds == null) {
+            rows.add(new Row.KVWarn("Bindings", "Unavailable"));
+            return;
+        }
+        for (WaypointerKeybinds.DebugBinding binding : keybinds.debugSnapshot()) {
+            String value = binding.boundKey();
+            if (!binding.conflicts().isEmpty()) {
+                value += " — conflicts with " + String.join(", ", binding.conflicts());
+            }
+            rows.add(binding.conflicts().isEmpty()
+                    ? new Row.KVDim(binding.translationKey(), oneLine(value))
+                    : new Row.KVWarn(binding.translationKey(), oneLine(value)));
+        }
+    }
+
+    private void buildRenderDiagnosticsReport() {
+        RenderDiagnostics.Snapshot snapshot = RenderDiagnostics.snapshot();
+        RenderDiagnostics.TracerSettings tracer = snapshot.tracer();
+        RenderDiagnostics.DungeonPathSettings pathSettings = snapshot.dungeonPath();
+
+        addSection(rows, sections, "Live Tracer Renderer State",
+                snapshot.updatedAtEpochMillis() <= 0L
+                        ? "not captured" : formatAge(snapshot.updatedAtEpochMillis()),
+                DebugReportExport.Category.SETTINGS_AND_CHANGES);
+        rows.add(new Row.KV("Tracer enabled", String.valueOf(tracer.enabled())));
+        rows.add(new Row.KV("Opacity / thickness", formatRadius(tracer.opacity())
+                + " / " + formatRadius(tracer.thickness()) + " px"));
+        rows.add(new Row.KV("Inherits color", String.valueOf(tracer.inheritsWaypointColor())));
+        rows.add(new Row.KV("Hide near player", tracer.hideNearPlayer()
+                + " (radius " + formatRadius(tracer.hideNearPlayerRadius()) + ")"));
+        rows.add(new Row.KV("Hide static tracer", String.valueOf(tracer.hideOnStaticRoutes())));
+        rows.add(new Row.KV("Iris HUD configured", String.valueOf(tracer.irisHudFallbackConfigured())));
+        rows.add(new Row.KV("Iris HUD active", String.valueOf(tracer.irisHudFallbackActive())));
+        rows.add(new Row.KV("Entry path to first", String.valueOf(pathSettings.entryPathToFirstWaypoint())));
+        rows.add(new Row.KV("Continue after first", String.valueOf(pathSettings.continueAfterFirstWaypoint())));
+
+        addSection(rows, sections, "Dungeon Entry Path Outcomes", snapshot.groups().size() + " groups",
+                DebugReportExport.Category.ROUTES_AND_WAYPOINTS);
+        if (snapshot.groups().isEmpty()) {
+            rows.add(new Row.KVDim("Groups", "No active DungeonRoomData route groups were rendered."));
+            return;
+        }
+        for (int i = 0; i < snapshot.groups().size(); i++) {
+            RenderDiagnostics.GroupSnapshot group = snapshot.groups().get(i);
+            rows.add(new Row.BitNote("Dungeon group " + (i + 1) + " of " + snapshot.groups().size()));
+            rows.add(new Row.KV("Group", oneLine(group.groupName().isBlank()
+                    ? "(unnamed)" : group.groupName())));
+            rows.add(new Row.KVDim("Group ID / zone", oneLine(group.groupId())
+                    + " / " + oneLine(group.zoneId())));
+            rows.add(new Row.KV("Load / index", group.loadMode() + " / " + group.currentIndex()));
+            RenderDiagnostics.TargetSnapshot target = group.currentTarget();
+            if (target == null) {
+                rows.add(new Row.KVWarn("Current target", "(none)"));
+            } else {
+                rows.add(new Row.KV("Target block", target.blockX() + ", "
+                        + target.blockY() + ", " + target.blockZ()));
+                rows.add(new Row.KV("Target world", String.format(Locale.ROOT, "%.3f, %.3f, %.3f",
+                        target.worldX(), target.worldY(), target.worldZ())));
+                rows.add(new Row.KVDim("Target name", oneLine(target.name().isBlank()
+                        ? "(unnamed)" : target.name())));
+            }
+            rows.add(new Row.KV("Entry-path eligible", String.valueOf(group.entryPathEligible())));
+            rows.add(new Row.KV("Straight suppressed", String.valueOf(group.straightTracerSuppressed())));
+            rows.add(new Row.KV("Straight submitted", String.valueOf(group.straightTracerSubmitted())));
+            rows.add(new Row.KV("Path submitted", String.valueOf(group.dungeonPathSubmitted())));
+
+            RenderDiagnostics.PathSnapshot path = group.path();
+            rows.add(new Row.KV("Path cache", path.cacheStatus() + ", age "
+                    + String.format(Locale.ROOT, "%.2f ms", path.cacheAgeMillis())));
+            rows.add(new Row.KV("Path result", path.result() + ", " + path.pointCount() + " points"));
+            rows.add(new Row.KV("Compute time", String.format(Locale.ROOT, "%.3f ms",
+                    path.computeTimeMillis())));
+            rows.add(new Row.KVDim("Raw start / goal", formatBlockPosition(path.rawStart())
+                    + " -> " + formatBlockPosition(path.rawGoal())));
+            rows.add(new Row.KVDim("Resolved start / goal", formatBlockPosition(path.resolvedStart())
+                    + " -> " + formatBlockPosition(path.resolvedGoal())));
+            rows.add(new Row.KV("Expansions", path.expansions() + " / " + path.expansionLimit()));
+            rows.add(new Row.KVDim("Path reason", oneLine(path.reason())));
+            rows.add(new Row.KVWarn("Final outcome", oneLine(group.finalOutcome())));
+        }
+    }
+
+    private static String formatBlockPosition(RenderDiagnostics.BlockPosition position) {
+        return position == null ? "(none)" : position.x() + "," + position.y() + "," + position.z();
+    }
+
+    private void buildRecentSettingsChangesReport() {
+        List<ConfigChangeHistory.Entry> changes = ConfigChangeHistory.snapshot();
+        addSection(rows, sections, "Recent Settings Changes", changes.size() + " this session",
+                DebugReportExport.Category.SETTINGS_AND_CHANGES);
+        rows.add(new Row.KVDim("Scope", "Settings UI changes in this game session only."));
+        if (changes.isEmpty()) {
+            rows.add(new Row.KVDim("History", "No settings changes recorded this session."));
+            return;
+        }
+        for (ConfigChangeHistory.Entry change : changes) {
+            String value = change.kind().equals("bulk")
+                    ? change.subject()
+                    : change.subject() + ": " + change.before() + " -> " + change.after();
+            rows.add(new Row.KVDim(formatAge(change.capturedAtMillis()), oneLine(value)));
+        }
+    }
+
+    private void buildRecentLogsAndActivityReport() {
+        List<DebugEventLog.Entry> events = DebugEventLog.snapshot();
+        addSection(rows, sections, "Recent UI and Input Activity", events.size() + " events",
+                DebugReportExport.Category.RECENT_LOGS_AND_ACTIVITY);
+        if (events.isEmpty()) {
+            rows.add(new Row.KVDim("Activity", "No recent Waypointer UI/input events recorded."));
+        } else {
+            for (DebugEventLog.Entry event : events) {
+                rows.add(new Row.KVDim("Event", oneLine(event.plainText())));
+            }
+        }
+
+        var monitor = WaypointerClient.developerModeMonitor();
+        if (monitor != null) {
+            rows.add(new Row.KVDim("Dev monitor", "enabled=" + monitor.enabled()
+                    + ", visits=" + monitor.roomVisits()
+                    + ", uniqueRooms=" + monitor.uniqueRoomCount()
+                    + ", anomalies=" + monitor.anomalyCount()
+                    + (monitor.writeFailure().isBlank() ? "" : ", writeError=" + oneLine(monitor.writeFailure()))));
+        }
+
+        List<String> logs = DebugLogTail.capture(60);
+        addSection(rows, sections, "Recent Relevant Log Lines", logs.size() + " lines",
+                DebugReportExport.Category.RECENT_LOGS_AND_ACTIVITY);
+        if (logs.isEmpty()) {
+            rows.add(new Row.KVDim("latest.log", "No recent relevant lines found or log unavailable."));
+        } else {
+            for (String line : logs) rows.add(new Row.KVDim("Log", oneLine(line)));
+        }
+    }
+
+    private static String loadedModVersion(String id) {
+        return FabricLoader.getInstance().getModContainer(id)
+                .map(container -> container.getMetadata().getVersion().getFriendlyString())
+                .orElse("unknown");
+    }
+
+    private static String routeSource(WaypointGroup group) {
+        if (group.temp()) return "temporary session route";
+        if (group.runtimeOnly() && group.id().startsWith("dungeon:auto:")) {
+            return "generated dungeon runtime mirror";
+        }
+        if (group.runtimeOnly()) return "runtime/API overlay";
+        return "persisted user route";
+    }
+
+    private static String routeCoordinateSpace(WaypointGroup group) {
+        if (group.runtimeOnly() && group.id().startsWith("dungeon:auto:")) {
+            return "transformed world coordinates";
+        }
+        if (com.babbur.waypointer.dungeon.data.DungeonRoomData.definition(group.zoneId()) != null) {
+            return "stored dungeon room-local coordinates";
+        }
+        return "world coordinates";
+    }
+
+    private static String formatPalette(int[] colors) {
+        if (colors == null || colors.length == 0) return "(empty)";
+        StringBuilder value = new StringBuilder();
+        for (int color : colors) {
+            if (!value.isEmpty()) value.append(' ');
+            value.append(String.format(Locale.ROOT, "#%06X", color & 0xFFFFFF));
+        }
+        return value.toString();
+    }
+
+    private static String oneLine(String value) {
+        if (value == null) return "(none)";
+        StringBuilder sanitized = new StringBuilder(Math.min(value.length(), 1_000));
+        for (int i = 0; i < value.length() && sanitized.length() < 1_000; i++) {
+            char c = value.charAt(i);
+            sanitized.append(Character.isISOControl(c) ? ' ' : c);
+        }
+        if (value.length() > 1_000) sanitized.append("...");
+        return sanitized.toString().trim();
+    }
+
+    private void openCopyConfirmation() {
+        if (rows.isEmpty()) return;
+        MinecraftCompat.setScreen(minecraft,
+                new DebugReportConsentScreen(this, this::copyReportToClipboard));
+    }
+
+    private void copyReportToClipboard(DebugReportExport.Options options) {
+        if (rows.isEmpty()) return;
+        String report = DebugReportExport.format(exportSections(), options);
+        minecraft.keyboardHandler.setClipboard(report);
         copyFeedbackUntil = System.currentTimeMillis() + FEEDBACK_MS;
         // Plain label swap -- no color. The design system reserves the one accent for
         // "the currently selected thing", not for ephemeral UI feedback.
-        copyButton.setMessage(Component.literal("Copied"));
+        if (copyButton != null) copyButton.setMessage(Component.literal("Copied"));
+    }
+
+    private List<DebugReportExport.Section> exportSections() {
+        List<DebugReportExport.Section> exported = new ArrayList<>();
+        String heading = null;
+        DebugReportExport.Category category = DebugReportExport.Category.CORE;
+        List<String> lines = new ArrayList<>();
+        for (Row row : rows) {
+            if (row instanceof Row.Section section) {
+                if (heading != null) {
+                    trimTrailingBlankLines(lines);
+                    exported.add(new DebugReportExport.Section(heading, category, lines));
+                }
+                heading = section.title();
+                category = section.category();
+                lines = new ArrayList<>();
+            } else if (heading != null) {
+                lines.add(rowAsPlainText(row));
+            }
+        }
+        if (heading != null) {
+            trimTrailingBlankLines(lines);
+            exported.add(new DebugReportExport.Section(heading, category, lines));
+        }
+        return List.copyOf(exported);
+    }
+
+    private static void trimTrailingBlankLines(List<String> lines) {
+        while (!lines.isEmpty() && lines.getLast().isBlank()) lines.removeLast();
     }
 
     // --- input -----------------------------------------------------------------------------
 
     @Override
     public boolean mouseScrolled(double mouseX, double mouseY, double horiz, double vert) {
+        if (mouseX >= sidebarX1 && mouseX <= sidebarX2
+                && mouseY >= sidebarContentTop && mouseY <= mainBottom
+                && !sections.isEmpty()) {
+            int maxSidebarScroll = Math.max(0, sections.size() - sidebarVisibleRows);
+            sidebarScrollRows = Mth.clamp(
+                    sidebarScrollRows - (int) (vert * SCROLL_ROWS_PER_NOTCH),
+                    0, maxSidebarScroll);
+            return true;
+        }
         if (mouseX >= mainX1 && mouseX <= mainX2 && mouseY >= mainTop && mouseY <= mainBottom
                 && !rows.isEmpty()) {
             int maxScroll = Math.max(0, rows.size() - visibleRowCount);
@@ -274,7 +851,7 @@ public final class DebugInspectScreen extends Screen {
         double my = event.y();
         if (mx < sidebarX1 || mx > sidebarX2 || my < sidebarContentTop) return false;
 
-        int rowIdx = (int) ((my - sidebarContentTop) / ROW_H);
+        int rowIdx = sidebarScrollRows + (int) ((my - sidebarContentTop) / ROW_H);
         if (rowIdx < 0 || rowIdx >= sections.size()) return false;
         jumpToSection(rowIdx);
         return true;
@@ -284,6 +861,7 @@ public final class DebugInspectScreen extends Screen {
         selectedSection = idx;
         int maxScroll = Math.max(0, rows.size() - visibleRowCount);
         scrollRows = Mth.clamp(sections.get(idx).rowIndex(), 0, maxScroll);
+        ensureSelectedSidebarVisible();
     }
 
     private void syncSelectedSectionWithScroll() {
@@ -296,6 +874,18 @@ public final class DebugInspectScreen extends Screen {
             else break;
         }
         selectedSection = best;
+        ensureSelectedSidebarVisible();
+    }
+
+    private void ensureSelectedSidebarVisible() {
+        if (sidebarVisibleRows <= 0) return;
+        if (selectedSection < sidebarScrollRows) {
+            sidebarScrollRows = selectedSection;
+        } else if (selectedSection >= sidebarScrollRows + sidebarVisibleRows) {
+            sidebarScrollRows = selectedSection - sidebarVisibleRows + 1;
+        }
+        sidebarScrollRows = Mth.clamp(sidebarScrollRows, 0,
+                Math.max(0, sections.size() - sidebarVisibleRows));
     }
 
     // --- rendering -------------------------------------------------------------------------
@@ -306,7 +896,7 @@ public final class DebugInspectScreen extends Screen {
 
         if (copyFeedbackUntil != 0 && System.currentTimeMillis() > copyFeedbackUntil) {
             copyFeedbackUntil = 0;
-            if (copyButton != null) copyButton.setMessage(Component.literal("Copy report"));
+            if (copyButton != null) copyButton.setMessage(Component.literal("Copy Report"));
         }
 
         // --- header (title + right-aligned compact summary) ------------------------------
@@ -376,17 +966,22 @@ public final class DebugInspectScreen extends Screen {
             return;
         }
 
+        sidebarVisibleRows = Math.max(1, (y2 - sidebarContentTop) / ROW_H);
+        sidebarScrollRows = Mth.clamp(sidebarScrollRows, 0,
+                Math.max(0, sections.size() - sidebarVisibleRows));
         int rowY = sidebarContentTop;
-        for (int i = 0; i < sections.size(); i++, rowY += ROW_H) {
-            // Quietly stop drawing if the list exceeds the sidebar; sidebar overflow is
-            // rare (few groups per payload) and the main panel stays scrollable regardless.
-            if (rowY + ROW_H > y2) break;
+        int end = Math.min(sections.size(), sidebarScrollRows + sidebarVisibleRows);
+        for (int i = sidebarScrollRows; i < end; i++, rowY += ROW_H) {
 
             SectionAnchor s = sections.get(i);
             boolean selected = i == selectedSection;
             boolean hovered = mouseX >= x1 && mouseX <= x2
                     && mouseY >= rowY && mouseY <= rowY + ROW_H;
             drawSidebarRow(g, x1, rowY, x2, s, selected, hovered);
+        }
+        if (sections.size() > sidebarVisibleRows) {
+            drawScrollbar(g, x2 - 4, sidebarContentTop + 2, y2 - 2,
+                    sidebarScrollRows, sidebarVisibleRows, sections.size());
         }
     }
 
@@ -566,7 +1161,7 @@ public final class DebugInspectScreen extends Screen {
 
     private void renderEmpty(GuiGraphicsExtractor g, int x1, int y1, int x2, int y2) {
         String a = "No payload loaded.";
-        String b = "Copy a " + WaypointCodec.MAGIC + " export string, then click \"Load from clipboard\".";
+        String b = "Copy a " + WaypointCodec.MAGIC + " export string, then click \"Refresh\".";
         int cy = y1 + (y2 - y1) / 2 - 8;
         int ax = x1 + ((x2 - x1) - font.width(a)) / 2;
         int bx = x1 + ((x2 - x1) - font.width(b)) / 2;
@@ -600,7 +1195,8 @@ public final class DebugInspectScreen extends Screen {
     // --- report building --------------------------------------------------------------------
 
     private static void buildReport(DecodeDebug d, List<Row> rows, List<SectionAnchor> sections) {
-        addSection(rows, sections, "Codec Pipeline", null);
+        addSection(rows, sections, "Codec Pipeline", null,
+                DebugReportExport.Category.ROUTES_AND_WAYPOINTS);
         rows.add(new Row.KV("Input",       d.inputChars() + " chars"));
         rows.add(new Row.KVDim("Prefix",   d.magic()));
         rows.add(new Row.KV("Payload",     d.payloadChars() + " chars"));
@@ -610,7 +1206,8 @@ public final class DebugInspectScreen extends Screen {
         rows.add(new Row.KV("Density",     String.format(Locale.ROOT, "%.2f chars / raw byte", d.charsPerRawByte())));
         rows.add(new Row.KV("Decode time", formatNanos(d.decodeNanos())));
 
-        addSection(rows, sections, "Codec Header", shortByte(d.headerByte()));
+        addSection(rows, sections, "Codec Header", shortByte(d.headerByte()),
+                DebugReportExport.Category.ROUTES_AND_WAYPOINTS);
         rows.add(new Row.KV("Byte",    formatByteFull(d.headerByte())));
         rows.add(new Row.KV("Version", "v" + d.version() + " (bits 0..3)"));
         if (d.version() == 9) {
@@ -645,14 +1242,16 @@ public final class DebugInspectScreen extends Screen {
         }
 
         String poolSub = d.stringPool().size() + (d.stringPool().size() == 1 ? " entry" : " entries");
-        addSection(rows, sections, "Codec String Pool", poolSub);
+        addSection(rows, sections, "Codec String Pool", poolSub,
+                DebugReportExport.Category.ROUTES_AND_WAYPOINTS);
         for (int i = 0; i < d.stringPool().size(); i++) {
             rows.add(new Row.PoolEntry(i, d.stringPool().get(i)));
         }
 
         for (DecodeDebug.GroupDebug gd : d.groups()) {
             String subtitle = gd.name().isEmpty() ? "(unnamed)" : gd.name();
-            addSection(rows, sections, "Codec Group " + gd.index(), subtitle);
+            addSection(rows, sections, "Codec Group " + gd.index(), subtitle,
+                    DebugReportExport.Category.ROUTES_AND_WAYPOINTS);
             WaypointGroup decodedGroup = d.decodedGroups().get(gd.index());
 
             rows.add(new Row.KV("Zone",          gd.zoneId().isEmpty() ? "(none)" : gd.zoneId()));
@@ -704,7 +1303,8 @@ public final class DebugInspectScreen extends Screen {
     private static void buildCodecClipboardReport(List<Row> rows,
                                                   List<SectionAnchor> sections,
                                                   String message) {
-        addSection(rows, sections, "Codec Clipboard", "not loaded");
+        addSection(rows, sections, "Codec Clipboard", "not loaded",
+                DebugReportExport.Category.ROUTES_AND_WAYPOINTS);
         rows.add(new Row.KVWarn("Status", message));
         rows.add(new Row.KVDim("Hint", "Copy a Waypointer export and hit Refresh."));
     }
@@ -714,7 +1314,8 @@ public final class DebugInspectScreen extends Screen {
                                                      List<SectionAnchor> sections) {
         DungeonStateTracker.DebugSnapshot tracker = snapshot == null ? null : snapshot.tracker;
         addSection(rows, sections, "Dungeon Overview",
-                tracker == null ? "not installed" : tracker.roomName);
+                tracker == null ? "not installed" : tracker.roomName,
+                DebugReportExport.Category.SERVER_CONTEXT);
         rows.add(new Row.KVDim("Config", DebugSignals.dungeonConfigLine()));
         rows.add(new Row.KVDim("Zone source", "Scoreboard sidebar"));
         if (tracker == null) {
@@ -732,7 +1333,8 @@ public final class DebugInspectScreen extends Screen {
             rows.add(new Row.KV("Segments", formatSegments(tracker.roomSegments)));
         }
 
-        addSection(rows, sections, "Room Detection", tracker == null ? "unavailable" : tracker.lastScanStage);
+        addSection(rows, sections, "Room Detection", tracker == null ? "unavailable" : tracker.lastScanStage,
+                DebugReportExport.Category.SERVER_CONTEXT);
         if (tracker == null) {
             rows.add(new Row.KVWarn("Unavailable", "No tracker snapshot is available."));
         } else {
@@ -750,7 +1352,8 @@ public final class DebugInspectScreen extends Screen {
         }
 
         DungeonRoomZoneBridge.DebugSnapshot bridge = snapshot == null ? null : snapshot.bridge;
-        addSection(rows, sections, "Zone Bridge", bridge == null ? "unavailable" : bridge.lastAction);
+        addSection(rows, sections, "Zone Bridge", bridge == null ? "unavailable" : bridge.lastAction,
+                DebugReportExport.Category.SERVER_CONTEXT);
         if (bridge == null) {
             rows.add(new Row.KVWarn("Unavailable", "No bridge snapshot is available."));
         } else {
@@ -764,7 +1367,11 @@ public final class DebugInspectScreen extends Screen {
         }
 
         DungeonRouteSession.DebugSnapshot route = snapshot == null ? null : snapshot.routeSession;
-        addSection(rows, sections, "Route Progress", route == null ? "unavailable" : route.roomKey);
+        addSection(rows, sections, "Built-in Dungeon Secret Progress",
+                route == null ? "unavailable" : route.roomKey,
+                DebugReportExport.Category.SERVER_CONTEXT);
+        rows.add(new Row.KVDim("Source", "DungeonRoomData built-in secret definitions"));
+        rows.add(new Row.KVDim("Lifetime", "Current dungeon run; not persisted user-route progress"));
         if (route == null) {
             rows.add(new Row.KVWarn("Unavailable", "Dungeon route session is not installed."));
         } else {
@@ -786,15 +1393,6 @@ public final class DebugInspectScreen extends Screen {
             rows.add(new Row.KVDim("Last reset", route.lastResetReason + " " + formatAge(route.lastResetAtMillis)));
         }
 
-        List<DebugEventLog.Entry> events = snapshot == null ? List.of() : snapshot.inputEvents;
-        addSection(rows, sections, "Trigger/Input", events.size() + " events");
-        if (events.isEmpty()) {
-            rows.add(new Row.KVDim("Input events", "No recent route-list or editor clicks recorded."));
-        } else {
-            for (DebugEventLog.Entry event : events) {
-                rows.add(new Row.KVDim("Event", event.plainText()));
-            }
-        }
     }
 
     private static void buildPerformanceReport(PerformanceStats stats,
@@ -803,13 +1401,10 @@ public final class DebugInspectScreen extends Screen {
                                                 List<SectionAnchor> sections) {
         addSection(rows, sections, "Performance Snapshot", null);
         rows.add(new Row.KV("Captured", stats.capturedAt().toString()));
-        rows.add(new Row.KV("Zone", stats.currentZoneName() + " (" + stats.currentZoneId() + ")"));
         rows.add(new Row.KVDim("Meaning", "counts before camera/distance culling unless noted"));
-        rows.add(new Row.KVDim("Java", System.getProperty("java.version", "(unknown)")));
-        rows.add(new Row.KVDim("Memory used", formatBytes(stats.usedMemoryBytes())
-                + " / " + formatBytes(stats.maxMemoryBytes())));
 
-        addSection(rows, sections, "Route Library", stats.totalWaypoints() + " pts");
+        addSection(rows, sections, "Route Library", stats.totalWaypoints() + " pts",
+                DebugReportExport.Category.ROUTES_AND_WAYPOINTS);
         rows.add(new Row.KV("Groups", stats.totalGroups() + " total, "
                 + stats.enabledGroups() + " enabled, " + stats.tempGroups() + " temp"));
         rows.add(new Row.KV("Zones", stats.knownZoneCount() + " known"));
@@ -819,7 +1414,8 @@ public final class DebugInspectScreen extends Screen {
                 + stats.sequenceGroups() + " sequence groups"));
         rows.add(new Row.KV("Largest group", groupSummary(stats.largestGroup())));
 
-        addSection(rows, sections, "Active Zone", stats.activeGroups() + " groups");
+        addSection(rows, sections, "Active Zone", stats.activeGroups() + " groups",
+                DebugReportExport.Category.ROUTES_AND_WAYPOINTS);
         rows.add(new Row.KV("Active points", stats.activeWaypoints() + " total"));
         rows.add(new Row.KV("Static points", String.valueOf(stats.activeStaticWaypoints())));
         rows.add(new Row.KV("Sequence points", String.valueOf(stats.activeSequenceWaypoints())));
@@ -827,7 +1423,8 @@ public final class DebugInspectScreen extends Screen {
         rows.add(new Row.KV("Label candidates", stats.activeLabelCandidates() + " before budget"));
         rows.add(new Row.KV("Largest active", groupSummary(stats.largestActiveGroup())));
 
-        addSection(rows, sections, "Render Estimate", null);
+        addSection(rows, sections, "Render Estimate", null,
+                DebugReportExport.Category.SETTINGS_AND_CHANGES);
         rows.add(new Row.KV("Box style", config.boxStyle().name()));
         rows.add(new Row.KV("Beacon mode", config.beaconBeamMode().name()));
         rows.add(new Row.KV("Line vertices", String.valueOf(stats.estimatedLineBoxVertices())));
@@ -839,21 +1436,24 @@ public final class DebugInspectScreen extends Screen {
                 ? "unlimited" : String.format(Locale.ROOT, "%.1f blocks",
                 config.maxStaticWaypointRenderDistance())));
 
-        addSection(rows, sections, "Tick Estimate", null);
+        addSection(rows, sections, "Tick Estimate", null,
+                DebugReportExport.Category.SETTINGS_AND_CHANGES);
         rows.add(new Row.KV("Proximity visits", stats.estimatedProximityIndexVisitsPerTick()
                 + " nearby candidates/tick"));
         rows.add(new Row.KVDim("Skip-ahead", config.skipAheadMechanicEnabled() ? "enabled" : "disabled"));
         rows.add(new Row.KVDim("Static reached hide",
                 config.hideReachedStaticWaypointsUntilCycleComplete() ? "enabled" : "disabled"));
 
-        addSection(rows, sections, "Config Toggles", null);
+        addSection(rows, sections, "Config Toggles", null,
+                DebugReportExport.Category.SETTINGS_AND_CHANGES);
         rows.add(new Row.KV("Names", config.showWaypointNames() ? "on" : "off"));
         rows.add(new Row.KV("Distances", config.showWaypointDistances() ? "on" : "off"));
         rows.add(new Row.KV("Backdrop", config.showLabelBackdrop() ? "on" : "off"));
         rows.add(new Row.KV("Tracer", config.showTracer() ? "on" : "off"));
         rows.add(new Row.KV("Hide static tracer", config.hideTracerOnStaticRoutes() ? "on" : "off"));
 
-        addSection(rows, sections, "Active Groups", String.valueOf(stats.activeGroupStats().size()));
+        addSection(rows, sections, "Active Groups", String.valueOf(stats.activeGroupStats().size()),
+                DebugReportExport.Category.ROUTES_AND_WAYPOINTS);
         if (stats.activeGroupStats().isEmpty()) {
             rows.add(new Row.KVDim("None", "No active groups in the current zone."));
             return;
@@ -870,9 +1470,15 @@ public final class DebugInspectScreen extends Screen {
 
     private static void addSection(List<Row> rows, List<SectionAnchor> sections,
                                     String label, String subtitle) {
+        addSection(rows, sections, label, subtitle, DebugReportExport.Category.CORE);
+    }
+
+    private static void addSection(List<Row> rows, List<SectionAnchor> sections,
+                                   String label, String subtitle,
+                                   DebugReportExport.Category category) {
         if (!rows.isEmpty()) rows.add(new Row.Blank());
         sections.add(new SectionAnchor(label, subtitle, rows.size()));
-        rows.add(new Row.Section(label));
+        rows.add(new Row.Section(label, category));
     }
 
     // --- text formatting --------------------------------------------------------------------
@@ -909,14 +1515,17 @@ public final class DebugInspectScreen extends Screen {
     private static String rowAsPlainText(Row row) {
         return switch (row) {
             case Row.Section s -> "== " + s.title() + " ==";
-            case Row.KV kv -> String.format(Locale.ROOT, "  %-16s %s", kv.key() + ":", kv.value());
-            case Row.KVDim kv -> String.format(Locale.ROOT, "  %-16s %s", kv.key() + ":", kv.value());
-            case Row.KVWarn kv -> String.format(Locale.ROOT, "  %-16s %s", kv.key() + ":", kv.value());
+            case Row.KV kv -> String.format(Locale.ROOT, "  %-16s %s",
+                    oneLine(kv.key()) + ":", oneLine(kv.value()));
+            case Row.KVDim kv -> String.format(Locale.ROOT, "  %-16s %s",
+                    oneLine(kv.key()) + ":", oneLine(kv.value()));
+            case Row.KVWarn kv -> String.format(Locale.ROOT, "  %-16s %s",
+                    oneLine(kv.key()) + ":", oneLine(kv.value()));
             case Row.Bit b -> String.format(Locale.ROOT, "    bit %d  %-17s = %s",
-                    b.bit(), b.label(), b.set() ? "true" : "false");
-            case Row.BitNote n -> "    " + n.text();
+                    b.bit(), oneLine(b.label()), b.set() ? "true" : "false");
+            case Row.BitNote n -> "    " + oneLine(n.text());
             case Row.PoolEntry p -> String.format(Locale.ROOT, "  [%d] %s",
-                    p.index(), p.text().isEmpty() ? "\"\"" : "\"" + p.text() + "\"");
+                    p.index(), p.text().isEmpty() ? "\"\"" : "\"" + oneLine(p.text()) + "\"");
             case Row.WP wp -> formatWaypointPlain(wp.wp());
             case Row.Blank ignored -> "";
         };
@@ -924,7 +1533,7 @@ public final class DebugInspectScreen extends Screen {
 
     private static String groupSummary(PerformanceStats.GroupStats group) {
         if (group == null) return "(none)";
-        return shortGroupName(group) + " -- " + group.waypoints()
+        return oneLine(shortGroupName(group)) + " -- " + group.waypoints()
                 + " pts, " + group.loadMode().toLowerCase(Locale.ROOT);
     }
 
@@ -940,7 +1549,7 @@ public final class DebugInspectScreen extends Screen {
         StringBuilder sb = new StringBuilder();
         sb.append(String.format(Locale.ROOT, "  #%-2d (%6d,%4d,%6d)  flags=%s",
                 wp.index(), wp.x(), wp.y(), wp.z(), formatByteFull(wp.wpFlagsByte())));
-        if (wp.hasName())   sb.append("  name=\"").append(wp.name()).append('"');
+        if (wp.hasName())   sb.append("  name=\"").append(oneLine(wp.name())).append('"');
         if (wp.hasColor())  sb.append(String.format(Locale.ROOT, "  color=#%06X", wp.color() & 0xFFFFFF));
         if (wp.hasRadius()) sb.append("  r=").append(formatRadius(wp.customRadius()));
         if (wp.extended())  sb.append("  ext=").append(formatIntHex(wp.extendedFlags()));
@@ -998,4 +1607,10 @@ public final class DebugInspectScreen extends Screen {
 
     @Override
     public void onClose() { MinecraftCompat.setScreen(minecraft, parent); }
+
+    @Override
+    public void removed() {
+        RenderDiagnostics.setDetailedCaptureEnabled(false);
+        super.removed();
+    }
 }

--- a/src/client/java/com/babbur/waypointer/screen/DebugReportConsentScreen.java
+++ b/src/client/java/com/babbur/waypointer/screen/DebugReportConsentScreen.java
@@ -1,0 +1,179 @@
+package com.babbur.waypointer.screen;
+
+import com.babbur.waypointer.compat.MinecraftCompat;
+import com.babbur.waypointer.debug.DebugReportExport;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.Tooltip;
+import net.minecraft.client.input.MouseButtonEvent;
+import net.minecraft.network.chat.Component;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import static com.babbur.waypointer.screen.GuiTokens.ACCENT;
+import static com.babbur.waypointer.screen.GuiTokens.BORDER;
+import static com.babbur.waypointer.screen.GuiTokens.BTN_H;
+import static com.babbur.waypointer.screen.GuiTokens.GAP;
+import static com.babbur.waypointer.screen.GuiTokens.GAP_SECTION;
+import static com.babbur.waypointer.screen.GuiTokens.GAP_TIGHT;
+import static com.babbur.waypointer.screen.GuiTokens.SURFACE;
+import static com.babbur.waypointer.screen.GuiTokens.SURFACE_SUBTLE;
+import static com.babbur.waypointer.screen.GuiTokens.TEXT;
+import static com.babbur.waypointer.screen.GuiTokens.TEXT_DIM;
+import static com.babbur.waypointer.screen.GuiTokens.TEXT_MUTED;
+import static com.babbur.waypointer.screen.GuiTokens.styledButton;
+import static com.babbur.waypointer.screen.GuiTokens.styledCheckbox;
+
+/**
+ * Disclosure confirmation shown before a troubleshooting report reaches the
+ * clipboard. Every category starts enabled, and cancelling never copies data.
+ */
+public final class DebugReportConsentScreen extends net.minecraft.client.gui.screens.Screen {
+
+    private static final int PANEL_MAX_W = 460;
+    private static final int PANEL_MARGIN = 8;
+    private static final int CHECKBOX_SIZE = 16;
+    private static final int ENTRY_MIN_H = 19;
+    private static final int ENTRY_MAX_H = 31;
+
+    private final net.minecraft.client.gui.screens.Screen parent;
+    private final Consumer<DebugReportExport.Options> onConfirm;
+    private final List<DebugReportExport.Category> categories =
+            DebugReportExport.Category.userControlledValues();
+    private final Map<DebugReportExport.Category, Boolean> enabled =
+            new EnumMap<>(DebugReportExport.Category.class);
+    private final List<GuiTokens.StyledCheckbox> checkboxes = new ArrayList<>();
+
+    private int panelX;
+    private int panelY;
+    private int panelW;
+    private int panelH;
+    private int entriesTop;
+    private int entryH;
+
+    public DebugReportConsentScreen(net.minecraft.client.gui.screens.Screen parent,
+                                    Consumer<DebugReportExport.Options> onConfirm) {
+        super(Component.literal("Review Troubleshooting Report"));
+        this.parent = parent;
+        this.onConfirm = onConfirm;
+        for (DebugReportExport.Category category : categories) enabled.put(category, true);
+    }
+
+    @Override
+    protected void init() {
+        checkboxes.clear();
+        panelW = Math.min(PANEL_MAX_W, Math.max(260, width - PANEL_MARGIN * 2));
+        panelH = Math.min(height - PANEL_MARGIN * 2,
+                54 + categories.size() * ENTRY_MAX_H + BTN_H + GAP_SECTION);
+        panelX = (width - panelW) / 2;
+        panelY = (height - panelH) / 2;
+        entriesTop = panelY + 43;
+        int footerSpace = BTN_H + GAP + GAP_TIGHT;
+        entryH = Math.max(ENTRY_MIN_H, Math.min(ENTRY_MAX_H,
+                (panelH - (entriesTop - panelY) - footerSpace) / Math.max(1, categories.size())));
+
+        for (int i = 0; i < categories.size(); i++) {
+            DebugReportExport.Category category = categories.get(i);
+            int checkboxY = entriesTop + i * entryH + Math.max(0, (entryH - CHECKBOX_SIZE) / 2);
+            GuiTokens.StyledCheckbox checkbox = styledCheckbox(
+                    panelX + GAP_SECTION,
+                    checkboxY,
+                    CHECKBOX_SIZE,
+                    Component.literal(category.label()),
+                    Boolean.TRUE.equals(enabled.get(category)),
+                    selected -> enabled.put(category, selected),
+                    Tooltip.create(Component.literal(category.description())));
+            checkboxes.add(checkbox);
+            addRenderableWidget(checkbox);
+        }
+
+        int buttonY = panelY + panelH - BTN_H - GAP;
+        int confirmW = Math.max(112, font.width("Confirm & Copy") + 18);
+        int cancelW = Math.max(70, font.width("Cancel") + 18);
+        int buttonsW = confirmW + GAP + cancelW;
+        int buttonX = panelX + panelW - GAP_SECTION - buttonsW;
+        Button confirm = styledButton(buttonX, buttonY, confirmW, BTN_H,
+                Component.literal("Confirm & Copy"), ignored -> confirmAndCopy(), null);
+        Button cancel = styledButton(buttonX + confirmW + GAP, buttonY, cancelW, BTN_H,
+                Component.literal("Cancel"), ignored -> onClose(), null);
+        addRenderableWidget(confirm);
+        addRenderableWidget(cancel);
+    }
+
+    private void confirmAndCopy() {
+        Set<DebugReportExport.Category> included = EnumSet.of(DebugReportExport.Category.CORE);
+        for (DebugReportExport.Category category : categories) {
+            if (Boolean.TRUE.equals(enabled.get(category))) included.add(category);
+        }
+        if (onConfirm != null) onConfirm.accept(new DebugReportExport.Options(included));
+        MinecraftCompat.setScreen(minecraft, parent);
+    }
+
+    @Override
+    public void extractRenderState(GuiGraphicsExtractor g, int mouseX, int mouseY, float partial) {
+        g.fill(0, 0, width, height, 0x80000000);
+        g.fill(panelX, panelY, panelX + panelW, panelY + panelH, SURFACE);
+        g.fill(panelX, panelY, panelX + panelW, panelY + 1, BORDER);
+        g.fill(panelX, panelY + panelH - 1, panelX + panelW, panelY + panelH, BORDER);
+
+        int titleX = panelX + GAP_SECTION;
+        int titleY = panelY + GAP;
+        g.text(font, getTitle(), titleX, titleY, TEXT, false);
+        g.fill(titleX, titleY + font.lineHeight + GAP_TIGHT,
+                panelX + panelW - GAP_SECTION, titleY + font.lineHeight + GAP_TIGHT + 1, ACCENT);
+        String intro = font.plainSubstrByWidth(
+                "Choose what leaves your PC. Everything is included by default.",
+                panelW - GAP_SECTION * 2);
+        g.text(font, intro, titleX, titleY + font.lineHeight + GAP, TEXT_DIM, false);
+
+        for (int i = 0; i < categories.size(); i++) {
+            DebugReportExport.Category category = categories.get(i);
+            int rowY = entriesTop + i * entryH;
+            if ((i & 1) == 1) {
+                g.fill(panelX + GAP, rowY, panelX + panelW - GAP, rowY + entryH, SURFACE_SUBTLE);
+            }
+            int textX = panelX + GAP_SECTION + CHECKBOX_SIZE + GAP;
+            g.text(font, "• " + category.label(), textX, rowY + 2, TEXT, false);
+            if (entryH >= 23) {
+                String description = font.plainSubstrByWidth(category.description(),
+                        panelX + panelW - GAP_SECTION - textX);
+                g.text(font, description, textX, rowY + 13, TEXT_MUTED, false);
+            }
+        }
+        super.extractRenderState(g, mouseX, mouseY, partial);
+    }
+
+    @Override
+    public boolean mouseClicked(MouseButtonEvent event, boolean doubleClick) {
+        if (super.mouseClicked(event, doubleClick)) return true;
+        if (event.button() != 0
+                || event.x() < panelX + GAP
+                || event.x() > panelX + panelW - GAP
+                || event.y() < entriesTop) {
+            return false;
+        }
+        int index = (int) ((event.y() - entriesTop) / entryH);
+        if (index < 0 || index >= checkboxes.size()
+                || event.y() >= entriesTop + categories.size() * entryH) {
+            return false;
+        }
+        checkboxes.get(index).onPress(event);
+        return true;
+    }
+
+    @Override
+    public void onClose() {
+        MinecraftCompat.setScreen(minecraft, parent);
+    }
+
+    @Override
+    public boolean isPauseScreen() {
+        return false;
+    }
+}

--- a/src/client/java/com/babbur/waypointer/screen/SettingsScreen.java
+++ b/src/client/java/com/babbur/waypointer/screen/SettingsScreen.java
@@ -6,6 +6,7 @@ import com.mojang.blaze3d.platform.InputConstants;
 import com.mojang.blaze3d.platform.cursor.CursorTypes;
 import com.babbur.waypointer.config.WaypointerConfig;
 import com.babbur.waypointer.config.WaypointerConfigCodec;
+import com.babbur.waypointer.debug.ConfigChangeHistory;
 import com.babbur.waypointer.dungeon.config.DungeonConfig;
 import com.babbur.waypointer.screen.settings.PerfStressTestController;
 import com.babbur.waypointer.screen.settings.RecentSettings;
@@ -829,7 +830,10 @@ public final class SettingsScreen extends Screen {
      * tick-deferred: callbacks fire while the widget list is being iterated.
      */
     private void applySetting(Setting setting, Object value) {
+        String before = setting.formatValue(setting.get(config, dungeonConfig));
         setting.set(config, dungeonConfig, value);
+        String after = setting.formatValue(setting.get(config, dungeonConfig));
+        ConfigChangeHistory.recordSetting(setting.id(), before, after);
         RecentSettings.record(setting.id());
         if (STRUCTURAL_IDS.contains(setting.id())) {
             rebuildPending = true;
@@ -896,12 +900,14 @@ public final class SettingsScreen extends Screen {
 
     private void confirmedDisableAll() {
         config.disableAllSettings(dungeonConfig);
+        ConfigChangeHistory.recordBulk("Disabled all settings");
         afterBulkConfigChange();
     }
 
     private void confirmedResetDefaults() {
         config.resetToDefaults();
         dungeonConfig.resetToDefaults();
+        ConfigChangeHistory.recordBulk("Reset settings to defaults");
         afterBulkConfigChange();
     }
 
@@ -966,6 +972,7 @@ public final class SettingsScreen extends Screen {
 
     private void applyConfirmedConfigImport(WaypointerConfig decoded, int changedSettings) {
         config.replaceWith(decoded);
+        ConfigChangeHistory.recordBulk("Imported config code (" + changedSettings + " changed)");
         afterBulkConfigChange();
         String settingWord = changedSettings == 1 ? "setting" : "settings";
         setConfigCodeStatus(Component.literal("Config imported. " + changedSettings + " "
@@ -1003,6 +1010,7 @@ public final class SettingsScreen extends Screen {
         confirmPreset(name, SettingsCatalog.countChangedSettings(config, preset), confirmed -> {
             if (confirmed) {
                 config.replaceWith(preset);
+                ConfigChangeHistory.recordBulk("Applied " + name + " preset");
                 afterBulkConfigChange();
             }
         });

--- a/src/client/java/com/babbur/waypointer/screen/settings/SettingsCatalog.java
+++ b/src/client/java/com/babbur/waypointer/screen/settings/SettingsCatalog.java
@@ -572,11 +572,7 @@ public final class SettingsCatalog {
                                 "Restore every setting to its default value. Click twice within 3 seconds to confirm.")
                                 .aliases("reset")),
                 Group.plain("Diagnostics",
-                        Setting.action(ACTION_PERF_TEST, "Performance stress test",
-                                "Runs a 60 second benchmark across 3D waypoints, dungeon secrets, and an adaptive "
-                                        + "subwaypoint ramp. The settings overlay hides while it runs; press Esc to cancel. "
-                                        + "Your settings are restored when it finishes; "
-                                        + "Copy report puts the results on your clipboard.")
+                        Setting.action(ACTION_PERF_TEST, "Performance stress test", "")
                                 .aliases("benchmark", "profiler", "fps", "stress", "lag")),
                 // Legacy/codec-only fields: no row anywhere, but they stay in the
                 // import diff and the parity tests so the codec surface is covered.

--- a/src/main/java/com/babbur/waypointer/config/Storage.java
+++ b/src/main/java/com/babbur/waypointer/config/Storage.java
@@ -70,6 +70,29 @@ public final class Storage {
         return file;
     }
 
+    /** Read-only storage health used by the troubleshooting report. */
+    public DebugSnapshot debugSnapshot() {
+        boolean exists = Files.isRegularFile(file);
+        long size = -1L;
+        long modifiedAtMillis = -1L;
+        if (exists) {
+            try {
+                size = Files.size(file);
+                modifiedAtMillis = Files.getLastModifiedTime(file).toMillis();
+            } catch (IOException ignored) {
+                // The status flags remain useful even if metadata races a file replacement.
+            }
+        }
+        return new DebugSnapshot(file.getFileName().toString(), exists, size, modifiedAtMillis,
+                saver != null, writesBlocked, pendingSnapshotJson != null, snapshotCount, writeCount);
+    }
+
+    public record DebugSnapshot(String fileName, boolean exists, long sizeBytes,
+                                long modifiedAtMillis, boolean attached,
+                                boolean writesBlocked, boolean snapshotReady,
+                                int snapshotsCaptured, int writesCompleted) {
+    }
+
     public void load(ActiveGroupManager manager) {
         if (!Files.exists(file)) return;
 

--- a/src/main/java/com/babbur/waypointer/config/WaypointerConfig.java
+++ b/src/main/java/com/babbur/waypointer/config/WaypointerConfig.java
@@ -505,6 +505,7 @@ public final class WaypointerConfig {
 
     // --- getters/setters ---------------------------------------------------------------------
 
+    public int configSchemaVersion()               { return configSchemaVersion; }
     public double defaultReachRadius()        { return Waypoint.normalizeDefaultRadius(defaultReachRadius); }
     public boolean resetProgressOnWorldJoin() { return resetProgressOnWorldJoin; }
     public boolean restartRouteWhenComplete() { return restartRouteWhenComplete; }

--- a/src/main/java/com/babbur/waypointer/core/WaypointGroup.java
+++ b/src/main/java/com/babbur/waypointer/core/WaypointGroup.java
@@ -556,8 +556,9 @@ public final class WaypointGroup {
     }
 
         public void remove(int index) {
+        boolean removedSubwaypoint = isSubwaypoint(index);
         waypoints.remove(index);
-        promoteOrphanedSubwaypoints(index);
+        if (!removedSubwaypoint) promoteOrphanedSubwaypoints(index);
         if (currentIndex > index) currentIndex--;
         currentIndex = Math.min(currentIndex, waypoints.size());
         if (proximitySuppressedIndex == index) proximitySuppressedIndex = -1;

--- a/src/test/java/com/babbur/waypointer/core/WaypointGroupTest.java
+++ b/src/test/java/com/babbur/waypointer/core/WaypointGroupTest.java
@@ -51,6 +51,24 @@ class WaypointGroupTest {
     }
 
     @Test
+    void remove_middleSubwaypointKeepsRemainingSiblingsAttachedToTheirParent() {
+        WaypointGroup g = WaypointGroup.create("Subwaypoints", "dungeon_f7");
+        g.add(wp(0, 70, 0));
+        for (int i = 1; i <= 5; i++) {
+            g.add(wp(i, 70, 0));
+            assertTrue(g.toggleSubwaypoint(i));
+        }
+
+        g.remove(3);
+
+        assertEquals(List.of(0, 1, 2, 4, 5), g.waypoints().stream().map(Waypoint::x).toList());
+        for (int i = 1; i < g.size(); i++) {
+            assertTrue(g.isSubwaypoint(i), "remaining child " + i + " was promoted");
+            assertEquals(0, g.parentMainIndex(i));
+        }
+    }
+
+    @Test
     void move_currentIndexFollowsMovedWaypoint() {
         WaypointGroup g = route();
         g.advancePast(0);                 // currentIndex = 1 -> points at (10,70,0)

--- a/src/test/java/com/babbur/waypointer/debug/ConfigChangeHistoryTest.java
+++ b/src/test/java/com/babbur/waypointer/debug/ConfigChangeHistoryTest.java
@@ -1,0 +1,45 @@
+package com.babbur.waypointer.debug;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ConfigChangeHistoryTest {
+
+    @AfterEach
+    void clearHistory() {
+        ConfigChangeHistory.clear();
+    }
+
+    @Test
+    void keepsNewestChangesFirstAndSkipsNoOps() {
+        ConfigChangeHistory.recordSetting("showTracer", "On", "Off");
+        ConfigChangeHistory.recordSetting("labelScale", "1", "1");
+        ConfigChangeHistory.recordBulk("Applied Minimal preset");
+
+        List<ConfigChangeHistory.Entry> entries = ConfigChangeHistory.snapshot();
+
+        assertEquals(2, entries.size());
+        assertEquals("bulk", entries.get(0).kind());
+        assertEquals("showTracer", entries.get(1).subject());
+        assertEquals("On", entries.get(1).before());
+        assertEquals("Off", entries.get(1).after());
+    }
+
+    @Test
+    void ringBufferStaysBounded() {
+        for (int i = 0; i < 40; i++) {
+            ConfigChangeHistory.recordSetting("setting" + i, "old", "new");
+        }
+
+        List<ConfigChangeHistory.Entry> entries = ConfigChangeHistory.snapshot();
+
+        assertEquals(24, entries.size());
+        assertEquals("setting39", entries.get(0).subject());
+        assertTrue(entries.stream().noneMatch(entry -> entry.subject().equals("setting0")));
+    }
+}

--- a/src/test/java/com/babbur/waypointer/debug/DebugLogTailTest.java
+++ b/src/test/java/com/babbur/waypointer/debug/DebugLogTailTest.java
@@ -1,0 +1,57 @@
+package com.babbur.waypointer.debug;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DebugLogTailTest {
+
+    @Test
+    void returnsOnlyRecentRelevantLines(@TempDir Path directory) throws Exception {
+        Path log = directory.resolve("latest.log");
+        Files.writeString(log, String.join("\n",
+                "[INFO] ordinary minecraft line",
+                "[INFO] [Waypointer] loaded routes",
+                "[WARN] renderer warning",
+                "[INFO] another ordinary line",
+                "[ERROR] newest failure"));
+
+        List<String> lines = DebugLogTail.readRelevant(log, 2);
+
+        assertEquals(2, lines.size());
+        assertTrue(lines.get(0).contains("renderer warning"));
+        assertTrue(lines.get(1).contains("newest failure"));
+    }
+
+    @Test
+    void missingLogIsAnEmptyCapture(@TempDir Path directory) {
+        assertTrue(DebugLogTail.readRelevant(directory.resolve("missing.log"), 10).isEmpty());
+    }
+
+    @Test
+    void keepsBoundedStackTraceContextAfterAnError(@TempDir Path directory) throws Exception {
+        Path log = directory.resolve("latest.log");
+        Files.writeString(log, String.join("\n",
+                "[ERROR] Failed to render a Waypointer path",
+                "java.lang.IllegalStateException: broken renderer",
+                "\tat com.example.Renderer.draw(Renderer.java:42)",
+                "\tat com.example.Client.tick(Client.java:9)",
+                "Caused by: java.lang.IllegalArgumentException: bad target",
+                "\tat com.example.Path.find(Path.java:7)",
+                "[INFO] ordinary line after the stack trace"));
+
+        List<String> lines = DebugLogTail.readRelevant(log, 20);
+
+        assertEquals(6, lines.size());
+        assertTrue(lines.stream().anyMatch(line -> line.contains("IllegalStateException")));
+        assertTrue(lines.stream().anyMatch(line -> line.contains("Renderer.draw")));
+        assertTrue(lines.stream().anyMatch(line -> line.contains("Caused by")));
+        assertTrue(lines.stream().noneMatch(line -> line.contains("ordinary line")));
+    }
+}

--- a/src/test/java/com/babbur/waypointer/debug/DebugReportExportTest.java
+++ b/src/test/java/com/babbur/waypointer/debug/DebugReportExportTest.java
@@ -1,0 +1,115 @@
+package com.babbur.waypointer.debug;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DebugReportExportTest {
+
+    @Test
+    void allCategoriesAreIncludedByDefault() {
+        List<DebugReportExport.Section> sections = sampleSections();
+
+        String report = DebugReportExport.format(sections, DebugReportExport.Options.allEnabled());
+
+        assertTrue(report.contains("core-sentinel"));
+        assertTrue(report.contains("pc-secret"));
+        assertTrue(report.contains("mods-secret"));
+        assertFalse(report.contains(DebugReportExport.REDACTED));
+    }
+
+    @Test
+    void excludedCategoryIsReplacedWithoutLeakingItsBody() {
+        DebugReportExport.Options options = new DebugReportExport.Options(EnumSet.of(
+                DebugReportExport.Category.CORE,
+                DebugReportExport.Category.ACTIVE_MODS));
+
+        String report = DebugReportExport.format(sampleSections(), options);
+
+        assertTrue(report.contains("== PC Specs ==\n  [User redacted]\n"));
+        assertFalse(report.contains("pc-secret"));
+        assertTrue(report.contains("mods-secret"));
+        assertTrue(report.contains("core-sentinel"));
+    }
+
+    @Test
+    void everyUserControlledCategoryStartsEnabled() {
+        DebugReportExport.Options options = DebugReportExport.Options.allEnabled();
+
+        for (DebugReportExport.Category category : DebugReportExport.Category.userControlledValues()) {
+            assertTrue(options.includes(category), category.name());
+        }
+        assertEquals(6, DebugReportExport.Category.userControlledValues().size());
+    }
+
+    @Test
+    void eachDisclosureCategoryCanBeRedactedIndependently() {
+        List<DebugReportExport.Section> sections = new java.util.ArrayList<>();
+        sections.add(new DebugReportExport.Section("Core", DebugReportExport.Category.CORE,
+                List.of("  core-sentinel")));
+        for (DebugReportExport.Category category : DebugReportExport.Category.userControlledValues()) {
+            sections.add(new DebugReportExport.Section(category.label(), category,
+                    List.of("  secret-" + category.name())));
+        }
+
+        for (DebugReportExport.Category excluded : DebugReportExport.Category.userControlledValues()) {
+            EnumSet<DebugReportExport.Category> included = EnumSet.allOf(DebugReportExport.Category.class);
+            included.remove(excluded);
+
+            String report = DebugReportExport.format(sections, new DebugReportExport.Options(included));
+
+            assertFalse(report.contains("secret-" + excluded.name()), excluded.name());
+            assertTrue(report.contains("== " + excluded.label() + " ==\n  [User redacted]\n"),
+                    excluded.name());
+            assertTrue(report.contains("core-sentinel"));
+            for (DebugReportExport.Category other : DebugReportExport.Category.userControlledValues()) {
+                if (other != excluded) assertTrue(report.contains("secret-" + other.name()), other.name());
+            }
+        }
+    }
+
+    @Test
+    void disclosureLabelsAreReadableAndDescriptionsExplainTheData() {
+        List<String> labels = DebugReportExport.Category.userControlledValues().stream()
+                .map(DebugReportExport.Category::label)
+                .toList();
+
+        assertEquals(List.of(
+                "PC Specs",
+                "Active Mods and Versions",
+                "Server, Player, and Location",
+                "Routes, Waypoints, and Coordinates",
+                "Settings and Recent Changes",
+                "Recent Logs and Activity"), labels);
+        assertTrue(DebugReportExport.Category.userControlledValues().stream()
+                .allMatch(category -> !category.description().isBlank()));
+    }
+
+    @Test
+    void controlCharactersCannotInjectExtraReportLines() {
+        String report = DebugReportExport.format(List.of(
+                new DebugReportExport.Section("Core\n== Forged ==", DebugReportExport.Category.CORE,
+                        List.of("  Value: safe\n== Forged body =="))),
+                DebugReportExport.Options.allEnabled());
+
+        assertFalse(report.contains("\n== Forged =="));
+        assertFalse(report.contains("\n== Forged body =="));
+        assertTrue(report.contains("Core == Forged =="));
+        assertTrue(report.contains("Value: safe == Forged body =="));
+    }
+
+    private static List<DebugReportExport.Section> sampleSections() {
+        return List.of(
+                new DebugReportExport.Section("Core", DebugReportExport.Category.CORE,
+                        List.of("  core-sentinel")),
+                new DebugReportExport.Section("PC Specs", DebugReportExport.Category.PC_SPECS,
+                        List.of("  pc-secret")),
+                new DebugReportExport.Section("Mods", DebugReportExport.Category.ACTIVE_MODS,
+                        List.of("  mods-secret")));
+    }
+}

--- a/src/test/java/com/babbur/waypointer/render/GroundPathfinderTest.java
+++ b/src/test/java/com/babbur/waypointer/render/GroundPathfinderTest.java
@@ -65,6 +65,84 @@ class GroundPathfinderTest {
     }
 
     @Test
+    void diagnosesNoPassableStartAndPreservesRequestedEndpoints() {
+        BlockPos start = new BlockPos(0, 0, 0);
+        BlockPos goal = new BlockPos(2, 0, 0);
+        GroundPathfinder.GridPathResult result = GroundPathfinder.findPathResult(
+                (x, y, z) -> x == 2 && y == 0 && z == 0,
+                start,
+                goal,
+                16,
+                64,
+                12,
+                32);
+
+        assertTrue(result.cells().isEmpty());
+        assertEquals(GroundPathfinder.FailureReason.NO_PASSABLE_START,
+                result.diagnostics().reason());
+        assertEquals(start, result.diagnostics().rawStart());
+        assertEquals(goal, result.diagnostics().rawGoal());
+        assertEquals(start, result.diagnostics().resolvedStart());
+        assertEquals(goal, result.diagnostics().resolvedGoal());
+        assertEquals(0, result.diagnostics().expansions());
+        assertEquals(64, result.diagnostics().expansionLimit());
+        assertTrue(result.diagnostics().computeTimeNanos() >= 0L);
+    }
+
+    @Test
+    void diagnosesTargetsOutsideDistanceLimitWithoutExpanding() {
+        GroundPathfinder.GridPathResult result = GroundPathfinder.findPathResult(
+                (x, y, z) -> true,
+                new BlockPos(0, 0, 0),
+                new BlockPos(20, 0, 0),
+                4,
+                64,
+                12,
+                32);
+
+        assertTrue(result.cells().isEmpty());
+        assertEquals(GroundPathfinder.FailureReason.OUTSIDE_DISTANCE_LIMIT,
+                result.diagnostics().reason());
+        assertEquals(0, result.diagnostics().expansions());
+    }
+
+    @Test
+    void distinguishesExpansionLimitFromNoRouteWithinBounds() {
+        GroundPathfinder.Grid detourGrid = (x, y, z) ->
+                y == 0
+                        && x >= 0 && x <= 4
+                        && z >= 0 && z <= 1
+                        && !(x == 1 && z == 0);
+        GroundPathfinder.GridPathResult limited = GroundPathfinder.findPathResult(
+                detourGrid,
+                new BlockPos(0, 0, 0),
+                new BlockPos(4, 0, 0),
+                16,
+                1,
+                12,
+                32);
+
+        GroundPathfinder.Grid isolatedEndpoints = (x, y, z) ->
+                y == 0 && z == 0 && (x == 0 || x == 2);
+        GroundPathfinder.GridPathResult exhausted = GroundPathfinder.findPathResult(
+                isolatedEndpoints,
+                new BlockPos(0, 0, 0),
+                new BlockPos(2, 0, 0),
+                16,
+                64,
+                12,
+                32);
+
+        assertEquals(GroundPathfinder.FailureReason.EXPANSION_LIMIT_EXHAUSTED,
+                limited.diagnostics().reason());
+        assertEquals(1, limited.diagnostics().expansions());
+        assertEquals(1, limited.diagnostics().expansionLimit());
+        assertEquals(GroundPathfinder.FailureReason.NO_ROUTE_WITHIN_BOUNDS,
+                exhausted.diagnostics().reason());
+        assertTrue(exhausted.diagnostics().expansions() < exhausted.diagnostics().expansionLimit());
+    }
+
+    @Test
     void doesNotCutDiagonallyThroughBlockedCorners() {
         Set<BlockPos> walkable = Set.of(
                 new BlockPos(0, 0, 0),

--- a/src/test/java/com/babbur/waypointer/render/RenderDiagnosticsTest.java
+++ b/src/test/java/com/babbur/waypointer/render/RenderDiagnosticsTest.java
@@ -1,0 +1,99 @@
+package com.babbur.waypointer.render;
+
+import com.babbur.waypointer.config.WaypointerConfig;
+import com.babbur.waypointer.core.Waypoint;
+import com.babbur.waypointer.core.WaypointGroup;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.phys.Vec3;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RenderDiagnosticsTest {
+
+    @BeforeEach
+    void enableDetailedCapture() {
+        RenderDiagnostics.setDetailedCaptureEnabled(true);
+    }
+
+    @AfterEach
+    void disableDetailedCapture() {
+        RenderDiagnostics.setDetailedCaptureEnabled(false);
+    }
+
+    @Test
+    void dungeonPathRequiresTwoPointsBeforeItCanReplaceStraightTracer() {
+        assertFalse(WaypointRenderer.isDrawableDungeonEntryPath(List.of()));
+        assertFalse(WaypointRenderer.isDrawableDungeonEntryPath(List.of(new Vec3(0.0, 64.0, 0.0))));
+        assertTrue(WaypointRenderer.isDrawableDungeonEntryPath(List.of(
+                new Vec3(0.0, 64.0, 0.0),
+                new Vec3(5.0, 64.0, 5.0))));
+
+        assertFalse(RenderDiagnostics.shouldSuppressStraightTracer(false, false));
+        assertTrue(RenderDiagnostics.shouldSuppressStraightTracer(false, true));
+    }
+
+    @Test
+    void irisHudFallbackNeverSuppressesStraightTracerForWorldDungeonPath() {
+        assertFalse(RenderDiagnostics.shouldSuppressStraightTracer(true, true));
+        assertFalse(RenderDiagnostics.shouldSuppressStraightTracer(true, false));
+    }
+
+    @Test
+    void fallbackStateWorksWithDetailedCaptureDisabled() {
+        WaypointGroup group = WaypointGroup.create("Minimal", "altar");
+        RenderDiagnostics.setDetailedCaptureEnabled(false);
+        RenderDiagnostics.beginFrame(List.of(group), new WaypointerConfig(), false);
+
+        RenderDiagnostics.recordDungeonPathSubmission(group, true);
+
+        assertTrue(RenderDiagnostics.shouldSuppressStraightTracer(group));
+        assertTrue(RenderDiagnostics.snapshot().groups().isEmpty());
+        assertEquals(0L, RenderDiagnostics.snapshot().updatedAtEpochMillis());
+    }
+
+    @Test
+    void cachedEmptyPathFallsThroughToStraightTracerAndReportsFinalDecision() {
+        WaypointGroup group = WaypointGroup.create("Empty Path", "altar");
+        group.add(new Waypoint(5, 64, 5, "Target", Waypoint.DEFAULT_COLOR, 0, 0.0));
+        RenderDiagnostics.beginFrame(List.of(group), new WaypointerConfig(), false);
+
+        BlockPos start = new BlockPos(0, 64, 0);
+        BlockPos goal = new BlockPos(5, 64, 5);
+        GroundPathfinder.Diagnostics diagnostics = new GroundPathfinder.Diagnostics(
+                start,
+                goal,
+                start,
+                goal,
+                GroundPathfinder.FailureReason.NO_ROUTE_WITHIN_BOUNDS,
+                37,
+                8_000,
+                2_500_000L);
+        RenderDiagnostics.recordPathLookup(
+                group,
+                new GroundPathfinder.PathResult(List.of(), diagnostics),
+                true,
+                125_000_000L);
+        RenderDiagnostics.recordDungeonPathSubmission(group, false);
+
+        assertFalse(RenderDiagnostics.shouldSuppressStraightTracer(group));
+        RenderDiagnostics.recordStraightTracerSubmitted(group);
+
+        RenderDiagnostics.GroupSnapshot snapshot = RenderDiagnostics.snapshot().groups().getFirst();
+        assertEquals("hit", snapshot.path().cacheStatus());
+        assertEquals(125.0, snapshot.path().cacheAgeMillis());
+        assertEquals("empty", snapshot.path().result());
+        assertEquals("no route within search bounds", snapshot.path().reason());
+        assertEquals(37, snapshot.path().expansions());
+        assertFalse(snapshot.dungeonPathSubmitted());
+        assertFalse(snapshot.straightTracerSuppressed());
+        assertTrue(snapshot.straightTracerSubmitted());
+        assertEquals("straight tracer submitted", snapshot.finalOutcome());
+    }
+}

--- a/src/test/java/com/babbur/waypointer/screen/settings/SettingsCatalogTest.java
+++ b/src/test/java/com/babbur/waypointer/screen/settings/SettingsCatalogTest.java
@@ -241,6 +241,14 @@ class SettingsCatalogTest {
     }
 
     @Test
+    void dungeonEntryPathIsOffByDefaultInTheCatalog() {
+        Setting entryPath = SettingsCatalog.byId("showDungeonEntryPathToFirstWaypoint");
+
+        assertNotNull(entryPath);
+        assertEquals(false, entryPath.get(new WaypointerConfig(), new DungeonConfig()));
+    }
+
+    @Test
     void formatValueRendersEveryKindReadably() {
         assertEquals("On", Setting.formatValue(Setting.Kind.BOOL, Boolean.TRUE, List.of()));
         assertEquals("Off", Setting.formatValue(Setting.Kind.BOOL, Boolean.FALSE, List.of()));


### PR DESCRIPTION
Turns `/wp debug` into a consent-gated troubleshooting report covering system, mods, server, settings, routes, logs, storage, and renderer/path diagnostics, with straight-tracer fallback when dungeon entry pathfinding fails. Adds bounded tests, preserves SubWP siblings during deletion, leaves navigate-to-first disabled by default, and closes #64.