### PR TITLE
Skip mined dungeon waypoints

### DIFF
--- a/API.md
+++ b/API.md
@@ -314,6 +314,7 @@ WaypointSpec secret = WaypointSpec.at(12, 70, -8)
 | `DEPTH_CHECKED` | Render only through the normal depth buffer |
 | `SKIP_ON_STAND` | Advance when standing on the point's block |
 | `SKIP_ON_INTERACT` | Advance when interacting with the point's block |
+| `SKIP_ON_MINE` | Advance after the point's block is observed and then mined |
 
 Subwaypoint style flags only have meaning when `SUBWAYPOINT` is also set.
 `WaypointFlags.contains(flags, required)` checks a bit set.

--- a/src/client/java/com/babbur/waypointer/dungeon/DungeonRoomRouteSync.java
+++ b/src/client/java/com/babbur/waypointer/dungeon/DungeonRoomRouteSync.java
@@ -136,6 +136,7 @@ public final class DungeonRoomRouteSync {
             removeGeneratedGroup(generatedId);
             return;
         }
+        group.setEnabled(config == null || config.roomRouteEnabled(roomId));
         replaceGeneratedGroup(generatedId, group);
     }
 
@@ -289,6 +290,40 @@ public final class DungeonRoomRouteSync {
 
         WaypointGroup mirror = manager.get(generatedGroupId(source.zoneId()));
         if (mirror != null && mirror != visibleGroup) mutation.accept(mirror);
+    }
+
+    /** Persist a route-list visibility change at the owner of a dungeon mirror. */
+    public static void setRouteEnabled(ActiveGroupManager manager,
+                                       DungeonConfig config,
+                                       WaypointGroup visibleGroup,
+                                       boolean enabled) {
+        if (visibleGroup == null) return;
+        WaypointGroup stored = storedSourceForMirror(manager, visibleGroup);
+        if (stored != null) {
+            stored.setEnabled(enabled);
+        } else if (isGeneratedGroup(visibleGroup) && config != null) {
+            config.setRoomRouteEnabled(visibleGroup.zoneId(), enabled);
+        }
+        visibleGroup.setEnabled(enabled);
+
+        WaypointGroup source = stored == null && !isGeneratedGroup(visibleGroup)
+                ? visibleGroup
+                : stored;
+        if (manager != null && source != null) {
+            WaypointGroup mirror = manager.get(generatedGroupId(source.zoneId()));
+            if (mirror != null) mirror.setEnabled(enabled);
+        }
+    }
+
+    public static void setDefinitionRouteEnabled(ActiveGroupManager manager,
+                                                 DungeonConfig config,
+                                                 String roomZoneId,
+                                                 boolean enabled) {
+        if (config == null || roomZoneId == null || roomZoneId.isBlank()) return;
+        config.setRoomRouteEnabled(roomZoneId, enabled);
+        if (manager == null) return;
+        WaypointGroup mirror = manager.get(generatedGroupId(roomZoneId));
+        if (mirror != null) mirror.setEnabled(enabled);
     }
 
     /**

--- a/src/client/java/com/babbur/waypointer/dungeon/DungeonRoomRouteSync.java
+++ b/src/client/java/com/babbur/waypointer/dungeon/DungeonRoomRouteSync.java
@@ -257,6 +257,41 @@ public final class DungeonRoomRouteSync {
     }
 
     /**
+     * Apply an explicit editor progress change to both halves of a projected
+     * dungeon route. The stored group owns the UI state, while its runtime
+     * mirror owns rendering; mutating only one lets the next mirror rebuild
+     * restore stale progress from the other.
+     */
+    public static void setManualCurrentIndex(ActiveGroupManager manager,
+                                             WaypointGroup visibleGroup,
+                                             int index) {
+        applyManualProgress(manager, visibleGroup, group -> group.setCurrentIndex(index));
+    }
+
+    public static void resetManualProgress(ActiveGroupManager manager,
+                                           WaypointGroup visibleGroup) {
+        applyManualProgress(manager, visibleGroup, WaypointGroup::resetProgress);
+    }
+
+    private static void applyManualProgress(ActiveGroupManager manager,
+                                            WaypointGroup visibleGroup,
+                                            Consumer<WaypointGroup> mutation) {
+        if (visibleGroup == null || mutation == null) return;
+        mutation.accept(visibleGroup);
+        if (manager == null) return;
+
+        WaypointGroup stored = storedSourceForMirror(manager, visibleGroup);
+        if (stored != null) mutation.accept(stored);
+        WaypointGroup source = stored == null && !isGeneratedGroup(visibleGroup)
+                ? visibleGroup
+                : stored;
+        if (source == null) return;
+
+        WaypointGroup mirror = manager.get(generatedGroupId(source.zoneId()));
+        if (mirror != null && mirror != visibleGroup) mutation.accept(mirror);
+    }
+
+    /**
      * True when in-world edits in this room should be refused because the room
      * shows downloaded secrets that the user has not converted into their own
      * route yet — editing the throwaway mirror would silently discard changes.

--- a/src/client/java/com/babbur/waypointer/progression/ProximityTracker.java
+++ b/src/client/java/com/babbur/waypointer/progression/ProximityTracker.java
@@ -30,6 +30,8 @@ import net.minecraft.world.phys.BlockHitResult;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Watches the local player each client tick and advances any active group whose
@@ -48,10 +50,14 @@ public final class ProximityTracker {
 
     private static final double STAND_SKIP_SCAN_RADIUS = 1.75D;
     static final long STAND_SKIP_HOLD_MS = 500L;
+    static final int MINE_BLOCK_UNKNOWN = 0;
+    static final int MINE_BLOCK_PRESENT = 1;
+    static final int MINE_BLOCK_AIR = 2;
 
     private final ActiveGroupManager manager;
     private final WaypointerConfig config;
     private final DungeonChestInteractionGuard chestInteractionGuard;
+    private final Set<MineTarget> observedMineTargets = new HashSet<>();
 
     public ProximityTracker(ActiveGroupManager manager, WaypointerConfig config) {
         this(manager, config, null);
@@ -113,7 +119,11 @@ public final class ProximityTracker {
 
     private void onTick(Minecraft mc) {
         LocalPlayer p = mc.player;
-        if (p == null) return;
+        ClientLevel level = mc.level;
+        if (p == null || level == null) {
+            observedMineTargets.clear();
+            return;
+        }
 
         double px = p.getX();
         double py = p.getY();
@@ -127,14 +137,24 @@ public final class ProximityTracker {
         boolean skipOnlyVisible = config.skipAheadOnlyVisibleWaypoints();
         boolean hideReachedStatic = config.hideReachedStaticWaypointsUntilCycleComplete();
         boolean trackRouteTimes = config.routeTimesEnabled();
+        long nowMillis = System.currentTimeMillis();
+        Set<MineTarget> liveMineTargets = new HashSet<>();
         for (WaypointGroup group : manager.activeGroups()) {
+            boolean skippingEnabled = globalSkipAhead && group.skipAheadEnabled();
+            boolean mined = updateMinedWaypointProgress(group, (x, y, z) -> {
+                BlockPos pos = new BlockPos(x, y, z);
+                if (!level.hasChunkAt(pos)) return MINE_BLOCK_UNKNOWN;
+                return level.getBlockState(pos).isAir() ? MINE_BLOCK_AIR : MINE_BLOCK_PRESENT;
+            }, observedMineTargets, liveMineTargets, loop, skippingEnabled, nowMillis,
+                    trackRouteTimes);
             boolean changed = updateGroupProgress(group, px, py, pz, loop, globalSkipAhead,
                     skipOnlyVisible, hideReachedStatic, trackRouteTimes);
-            if (changed) reportRouteCompletion(manager, group, trackRouteTimes);
-            if (changed && shouldHideCompletedDungeonRoomRoute(group)) {
+            if (mined || changed) reportRouteCompletion(manager, group, trackRouteTimes);
+            if ((mined || changed) && shouldHideCompletedDungeonRoomRoute(group)) {
                 manager.fireTransientDataChanged();
             }
         }
+        observedMineTargets.retainAll(liveMineTargets);
     }
 
     public static boolean updateGroupProgress(WaypointGroup group,
@@ -314,6 +334,52 @@ public final class ProximityTracker {
 
         return advancePastReachedIndex(group, from, reachedIndex, restartWhenComplete,
                 allowSkipAhead, nowMillis, trackRouteTimes);
+    }
+
+    static boolean updateMinedWaypointProgress(WaypointGroup group,
+                                               MineBlockLookup blocks,
+                                               Set<MineTarget> observed,
+                                               Set<MineTarget> live,
+                                               boolean restartWhenComplete,
+                                               boolean skippingEnabled,
+                                               long nowMillis,
+                                               boolean trackRouteTimes) {
+        if (!isEligibleDungeonTriggerGroup(group) || blocks == null
+                || observed == null || live == null) {
+            return false;
+        }
+
+        int from = group.currentIndex();
+        int to = group.loadMode() == WaypointGroup.LoadMode.STATIC || skippingEnabled
+                ? group.size() - 1
+                : from;
+        int highestMined = -1;
+        boolean staticChanged = false;
+        for (int i = Math.max(0, from); i <= to; i++) {
+            if (group.isSubwaypoint(i)) continue;
+            Waypoint waypoint = group.get(i);
+            if (!waypoint.hasFlag(Waypoint.FLAG_SKIP_ON_MINE)) continue;
+
+            MineTarget target = new MineTarget(
+                    group.id(), i, waypoint.x(), waypoint.y(), waypoint.z());
+            live.add(target);
+            int state = blocks.stateAt(waypoint.x(), waypoint.y(), waypoint.z());
+            if (state == MINE_BLOCK_PRESENT) {
+                observed.add(target);
+            } else if (state == MINE_BLOCK_AIR && observed.remove(target)) {
+                if (group.loadMode() == WaypointGroup.LoadMode.STATIC) {
+                    staticChanged |= group.markStaticWaypointReached(i);
+                } else {
+                    highestMined = i;
+                }
+            }
+        }
+
+        if (group.loadMode() == WaypointGroup.LoadMode.STATIC) return staticChanged;
+        return highestMined >= 0 && advancePastReachedIndex(
+                group, from, highestMined,
+                restartWhenComplete && !isDungeonRoomRouteGroup(group),
+                skippingEnabled, nowMillis, trackRouteTimes);
     }
 
     public static boolean advanceIfInteractedWithBlock(WaypointGroup group,
@@ -514,7 +580,8 @@ public final class ProximityTracker {
         if (group.isSubwaypoint(index)) return false;
         Waypoint waypoint = group.get(index);
         return !waypoint.hasFlag(Waypoint.FLAG_SKIP_ON_STAND)
-                && !waypoint.hasFlag(Waypoint.FLAG_SKIP_ON_INTERACT);
+                && !waypoint.hasFlag(Waypoint.FLAG_SKIP_ON_INTERACT)
+                && !waypoint.hasFlag(Waypoint.FLAG_SKIP_ON_MINE);
     }
 
     private static boolean[] visibleIndexMask(WaypointGroup group) {
@@ -546,7 +613,9 @@ public final class ProximityTracker {
         if (isDungeonStandSkipWaypoint(group, w)) {
             return isStandSkipReached(group, index, w, px, py, pz, nowMillis);
         }
-        if (isDungeonInteractSkipWaypoint(group, w)) return false;
+        if (isDungeonInteractSkipWaypoint(group, w) || isDungeonMineSkipWaypoint(group, w)) {
+            return false;
+        }
         return isWithinReach(group, w, px, py, pz);
     }
 
@@ -560,6 +629,12 @@ public final class ProximityTracker {
         return isEligibleDungeonTriggerGroup(group)
                 && w != null
                 && w.hasFlag(Waypoint.FLAG_SKIP_ON_INTERACT);
+    }
+
+    private static boolean isDungeonMineSkipWaypoint(WaypointGroup group, Waypoint w) {
+        return isEligibleDungeonTriggerGroup(group)
+                && w != null
+                && w.hasFlag(Waypoint.FLAG_SKIP_ON_MINE);
     }
 
     private static boolean isStandSkipReached(WaypointGroup group, int index, Waypoint w,
@@ -646,5 +721,13 @@ public final class ProximityTracker {
         double dy = w.centerY() - py;
         double dz = w.centerZ() - pz;
         return dx * dx + dy * dy + dz * dz <= r * r;
+    }
+
+    @FunctionalInterface
+    interface MineBlockLookup {
+        int stateAt(int x, int y, int z);
+    }
+
+    record MineTarget(String groupId, int index, int x, int y, int z) {
     }
 }

--- a/src/client/java/com/babbur/waypointer/render/WaypointRenderer.java
+++ b/src/client/java/com/babbur/waypointer/render/WaypointRenderer.java
@@ -790,7 +790,8 @@ public final class WaypointRenderer implements HudElement {
     static boolean usesBlockShapeBounds(Waypoint waypoint) {
         if (waypoint == null) return false;
         if (isSmallSubwaypoint(waypoint)) return false;
-        if (waypoint.hasFlag(Waypoint.FLAG_SKIP_ON_INTERACT)) return true;
+        if (waypoint.hasFlag(Waypoint.FLAG_SKIP_ON_INTERACT)
+                || waypoint.hasFlag(Waypoint.FLAG_SKIP_ON_MINE)) return true;
         return waypoint.isSubwaypoint();
     }
 

--- a/src/client/java/com/babbur/waypointer/screen/GroupEditScreen.java
+++ b/src/client/java/com/babbur/waypointer/screen/GroupEditScreen.java
@@ -274,7 +274,7 @@ public final class GroupEditScreen extends Screen {
                 : naturalResetY;
         addSidebarWidget(styledButton(sidebarInner, resetY, fieldW, BTN_H,
                 Component.literal("Reset Progress"), b -> {
-            group.resetProgress();
+            DungeonRoomRouteSync.resetManualProgress(manager, group);
             manager.fireDataChanged();
         }, Tooltip.create(Component.literal("Set current waypoint to #1."))));
         sidebarScrollOffset = Math.max(0, Math.min(maxSidebarScroll, sidebarScrollOffset));
@@ -1536,7 +1536,7 @@ public final class GroupEditScreen extends Screen {
                     }
                     action = "toggle-subwaypoint";
                 } else {
-                    group.setCurrentIndex(idx);
+                    DungeonRoomRouteSync.setManualCurrentIndex(manager, group, idx);
                     manager.fireDataChanged();
                     action = "goto";
                 }

--- a/src/client/java/com/babbur/waypointer/screen/GroupEditScreen.java
+++ b/src/client/java/com/babbur/waypointer/screen/GroupEditScreen.java
@@ -109,7 +109,8 @@ public final class GroupEditScreen extends Screen {
     static final int WAYPOINT_CONTROL_ACTION_NONE = 0;
     static final int WAYPOINT_CONTROL_ACTION_STAND_SKIP = 1;
     static final int WAYPOINT_CONTROL_ACTION_INTERACT_SKIP = 2;
-    static final int WAYPOINT_CONTROL_ACTION_DEPTH_CHECK = 3;
+    static final int WAYPOINT_CONTROL_ACTION_MINE_SKIP = 3;
+    static final int WAYPOINT_CONTROL_ACTION_DEPTH_CHECK = 4;
     private static final int SUBWAY_STYLE_BUTTON_W = 26;
     private static final int SUBWAY_STYLE_BUTTON_H = 18;
     private static final int SUBWAY_STYLE_BUTTON_TOP_PAD = 2;
@@ -1315,6 +1316,13 @@ public final class GroupEditScreen extends Screen {
                     isInside(mouseX, mouseY, interactX, y,
                             SUBWAY_STYLE_BUTTON_W, SUBWAY_STYLE_BUTTON_H),
                     WAYPOINT_CONTROL_ACTION_INTERACT_SKIP);
+
+            int mineX = mineSkipButtonX(rowRight);
+            renderWaypointControlButton(g, mineX, y,
+                    waypoint.hasFlag(Waypoint.FLAG_SKIP_ON_MINE),
+                    isInside(mouseX, mouseY, mineX, y,
+                            SUBWAY_STYLE_BUTTON_W, SUBWAY_STYLE_BUTTON_H),
+                    WAYPOINT_CONTROL_ACTION_MINE_SKIP);
         }
         renderDepthCheckButton(g, waypoint, rowRight, rowY, mouseX, mouseY);
     }
@@ -1337,6 +1345,13 @@ public final class GroupEditScreen extends Screen {
             g.fill(cx - 4, cy + 2, cx, cy + 5, secondary);
             g.fill(cx + 2, cy - 3, cx + 6, cy + 3, primary);
             g.fill(cx, cy + 4, cx + 4, cy + 7, secondary);
+            return;
+        }
+
+        if (action == WAYPOINT_CONTROL_ACTION_MINE_SKIP) {
+            g.fill(cx - 6, cy - 5, cx + 2, cy - 3, primary);
+            g.fill(cx, cy - 3, cx + 3, cy, primary);
+            g.fill(cx - 1, cy - 1, cx + 1, cy + 6, secondary);
             return;
         }
 
@@ -1446,10 +1461,14 @@ public final class GroupEditScreen extends Screen {
     }
 
     private static int standSkipButtonX(int rowRight) {
-        return depthCheckButtonX(rowRight) - (SUBWAY_STYLE_BUTTON_W + GAP_TIGHT) * 2;
+        return depthCheckButtonX(rowRight) - (SUBWAY_STYLE_BUTTON_W + GAP_TIGHT) * 3;
     }
 
     private static int interactSkipButtonX(int rowRight) {
+        return mineSkipButtonX(rowRight) - SUBWAY_STYLE_BUTTON_W - GAP_TIGHT;
+    }
+
+    private static int mineSkipButtonX(int rowRight) {
         return depthCheckButtonX(rowRight) - SUBWAY_STYLE_BUTTON_W - GAP_TIGHT;
     }
 
@@ -1680,6 +1699,10 @@ public final class GroupEditScreen extends Screen {
             if (isInside(mx, my, interactX, y, SUBWAY_STYLE_BUTTON_W, SUBWAY_STYLE_BUTTON_H)) {
                 return WAYPOINT_CONTROL_ACTION_INTERACT_SKIP;
             }
+            int mineX = mineSkipButtonX(rowRight);
+            if (isInside(mx, my, mineX, y, SUBWAY_STYLE_BUTTON_W, SUBWAY_STYLE_BUTTON_H)) {
+                return WAYPOINT_CONTROL_ACTION_MINE_SKIP;
+            }
         }
 
         int depthX = depthCheckButtonX(rowRight);
@@ -1724,6 +1747,9 @@ public final class GroupEditScreen extends Screen {
         if (action == WAYPOINT_CONTROL_ACTION_INTERACT_SKIP) {
             return dungeonInteractSkipTooltipText();
         }
+        if (action == WAYPOINT_CONTROL_ACTION_MINE_SKIP) {
+            return dungeonMineSkipTooltipText();
+        }
         if (action == WAYPOINT_CONTROL_ACTION_DEPTH_CHECK) {
             return "Render in LOS only";
         }
@@ -1756,6 +1782,10 @@ public final class GroupEditScreen extends Screen {
         return "Dungeons: Interact to skip";
     }
 
+    static String dungeonMineSkipTooltipText() {
+        return "Dungeons: Mine to skip";
+    }
+
     private String subwaypointStyleTooltipAt(double mouseX, double mouseY) {
         int action = subwaypointStyleActionAt(mouseX, mouseY);
         if (action == SUBWAY_STYLE_ACTION_SMALL) {
@@ -1785,6 +1815,9 @@ public final class GroupEditScreen extends Screen {
         }
         if (action == WAYPOINT_CONTROL_ACTION_INTERACT_SKIP && dungeonRoomGroup) {
             return Waypoint.FLAG_SKIP_ON_INTERACT;
+        }
+        if (action == WAYPOINT_CONTROL_ACTION_MINE_SKIP && dungeonRoomGroup) {
+            return Waypoint.FLAG_SKIP_ON_MINE;
         }
         if (action == WAYPOINT_CONTROL_ACTION_DEPTH_CHECK) {
             return Waypoint.FLAG_DEPTH_CHECKED;

--- a/src/client/java/com/babbur/waypointer/screen/WaypointerScreen.java
+++ b/src/client/java/com/babbur/waypointer/screen/WaypointerScreen.java
@@ -80,6 +80,9 @@ public final class WaypointerScreen extends Screen {
     private static final String DUNGEON_ROOMS_LABEL = "Dungeon Rooms";
     private static final String DUNGEON_ROOM_LABEL_PREFIX = "Dungeons: ";
     private static final int DUNGEON_ROOM_ACCENT = 0xFFFF8A8A;
+    static final int CURRENT_DUNGEON_ROOM_ACCENT = 0xFF58C878;
+    private static final int CURRENT_DUNGEON_ROOM_BG = 0x332A7040;
+    private static final int CURRENT_DUNGEON_ROOM_SELECTED_BG = 0x553A8A50;
     private static final int ROUTE_ROW_PITCH = ROW_H + 4;
     private static final int ROUTE_TOGGLE_CHIP_W = 54;
     private static final int ROUTE_TOGGLE_CHIP_H = 14;
@@ -109,6 +112,7 @@ public final class WaypointerScreen extends Screen {
      * a specific route.
      */
     private String pendingFocusRoomZoneId;
+    private String lastObservedCurrentRoomZoneId;
 
     // Delete uses a two-click confirm: first click arms, second within CONFIRM_WINDOW_MS
     // commits. A full modal would be more intrusive than this class of action warrants;
@@ -211,6 +215,7 @@ public final class WaypointerScreen extends Screen {
         this.manager = manager;
         this.config = config;
         this.selectedZoneId = initialSelectedZoneId(manager);
+        this.lastObservedCurrentRoomZoneId = currentDungeonRoomZoneId(manager);
     }
 
     public static void open(ActiveGroupManager manager, WaypointerConfig config) {
@@ -243,6 +248,7 @@ public final class WaypointerScreen extends Screen {
     private void focusCurrentDungeonRoomOnOpen() {
         String roomZoneId = currentDungeonRoomZoneId(manager);
         if (roomZoneId == null) return;
+        lastObservedCurrentRoomZoneId = roomZoneId;
         selectedZoneId = DUNGEON_ROOMS_ZONE_ID;
         selectedDungeonRoomZoneId = roomZoneId;
         expandedDungeonRoomZoneIds.add(roomZoneId);
@@ -411,14 +417,22 @@ public final class WaypointerScreen extends Screen {
         Layout layout = layout();
         int rowsTop = mainRowsTop(layout.top());
         int listHeight = Math.max(0, layout.bottom() - rowsTop);
+        scrollOffset = scrollOffsetToRevealRow(
+                scrollOffset, rowIndex, rows.size(), listHeight);
+    }
+
+    static int scrollOffsetToRevealRow(int currentOffset, int rowIndex,
+                                       int rowCount, int listHeight) {
+        if (rowIndex < 0 || rowIndex >= rowCount) return currentOffset;
         int rowTop = rowIndex * ROUTE_ROW_PITCH;
         int rowBottom = rowTop + ROW_H + 2;
-        if (rowTop < scrollOffset) {
-            scrollOffset = rowTop;
-        } else if (rowBottom > scrollOffset + listHeight) {
-            scrollOffset = rowBottom - listHeight + GAP;
+        int next = currentOffset;
+        if (rowTop < next) {
+            next = rowTop;
+        } else if (rowBottom > next + listHeight) {
+            next = rowBottom - listHeight + GAP;
         }
-        scrollOffset = MathUtil.clamp(scrollOffset, 0, maxMainScroll(rows.size(), listHeight));
+        return MathUtil.clamp(next, 0, maxMainScroll(rowCount, listHeight));
     }
 
     private static int maxMainScroll(int rowCount, int listHeight) {
@@ -732,17 +746,26 @@ public final class WaypointerScreen extends Screen {
         for (String roomId : roomIds) {
             if (dungeonRoomHasRoutes(roomId)) populated.add(roomId);
         }
-        return orderedDungeonRoomIds(roomIds, populated);
+        return orderedDungeonRoomIds(roomIds, populated, currentRoomZoneId);
     }
 
     static List<String> orderedDungeonRoomIds(Collection<String> roomIds,
                                                Set<String> populatedRoomIds) {
+        return orderedDungeonRoomIds(roomIds, populatedRoomIds, null);
+    }
+
+    static List<String> orderedDungeonRoomIds(Collection<String> roomIds,
+                                               Set<String> populatedRoomIds,
+                                               String currentRoomZoneId) {
         List<String> ordered = new ArrayList<>(new LinkedHashSet<>(roomIds));
         Set<String> populated = populatedRoomIds == null ? Set.of() : populatedRoomIds;
         ordered.sort(Comparator
                 .comparing((String id) -> !populated.contains(id))
                 .thenComparing(id -> displayZoneLabel(id).toLowerCase(Locale.ROOT))
                 .thenComparing(id -> id));
+        if (currentRoomZoneId != null && ordered.remove(currentRoomZoneId)) {
+            ordered.add(0, currentRoomZoneId);
+        }
         return ordered;
     }
 
@@ -880,6 +903,7 @@ public final class WaypointerScreen extends Screen {
 
     @Override
     public void extractRenderState(GuiGraphicsExtractor g, int mouseX, int mouseY, float partial) {
+        focusCurrentDungeonRoomIfChanged();
         super.extractRenderState(g, mouseX, mouseY, partial);
 
         // Reset the Delete button label once the confirm/flash window elapses.
@@ -948,6 +972,19 @@ public final class WaypointerScreen extends Screen {
         if (infoHovered) {
             renderRouteListInfoTooltip(g, mouseX, mouseY);
         }
+    }
+
+    private void focusCurrentDungeonRoomIfChanged() {
+        String currentRoomZoneId = currentDungeonRoomZoneId(manager);
+        if (currentRoomZoneId == null
+                ? lastObservedCurrentRoomZoneId == null
+                : currentRoomZoneId.equals(lastObservedCurrentRoomZoneId)) {
+            return;
+        }
+        lastObservedCurrentRoomZoneId = currentRoomZoneId;
+        if (currentRoomZoneId == null) return;
+        focusRoomByZoneId(currentRoomZoneId);
+        refreshActionButtons();
     }
 
     private Component islandSelectorLabel() {
@@ -1520,13 +1557,14 @@ public final class WaypointerScreen extends Screen {
         boolean selected = !hasSelectedGroupInRoom(row.roomZoneId)
                 && (row.roomZoneId.equals(selectedDungeonRoomZoneId)
                 || selectedDungeonRoomZoneId == null && row.currentRoom);
-        int bg = selected ? SELECTED : hovered ? HOVER : 0;
+        int accent = roomHeaderAccent(row.currentRoom);
+        int bg = roomHeaderBackground(selected, hovered, row.currentRoom);
         if (bg != 0) g.fill(x1, y1, x2, rowBot, bg);
-        if (selected) g.fill(x1, y1, x1 + 2, rowBot, DUNGEON_ROOM_ACCENT);
+        if (selected || row.currentRoom) g.fill(x1, y1, x1 + 2, rowBot, accent);
 
         int labelX = x1 + GAP + 2;
         boolean hasRoutes = row.roomRouteCount > 0 || row.roomSecretCount > 0;
-        int textColor = hasRoutes || row.currentRoom ? DUNGEON_ROOM_ACCENT : TEXT_DIM;
+        int textColor = row.currentRoom ? accent : hasRoutes ? DUNGEON_ROOM_ACCENT : TEXT_DIM;
         int labelMaxW = Math.max(24, x2 - GAP - labelX);
         String label = font.plainSubstrByWidth(displayZoneLabel(row.roomZoneId), labelMaxW);
         g.text(font, label, labelX, y1 + 4, textColor, false);
@@ -1535,6 +1573,17 @@ public final class WaypointerScreen extends Screen {
                 row.currentRoom, row.searchReveal && !row.expanded);
         String clippedSubtitle = font.plainSubstrByWidth(subtitle, labelMaxW);
         g.text(font, clippedSubtitle, labelX, y1 + 14, TEXT_MUTED, false);
+    }
+
+    static int roomHeaderAccent(boolean currentRoom) {
+        return currentRoom ? CURRENT_DUNGEON_ROOM_ACCENT : DUNGEON_ROOM_ACCENT;
+    }
+
+    static int roomHeaderBackground(boolean selected, boolean hovered, boolean currentRoom) {
+        if (currentRoom) {
+            return selected ? CURRENT_DUNGEON_ROOM_SELECTED_BG : CURRENT_DUNGEON_ROOM_BG;
+        }
+        return selected ? SELECTED : hovered ? HOVER : 0;
     }
 
     /**

--- a/src/client/java/com/babbur/waypointer/screen/WaypointerScreen.java
+++ b/src/client/java/com/babbur/waypointer/screen/WaypointerScreen.java
@@ -14,6 +14,7 @@ import com.babbur.waypointer.core.Zone;
 import com.babbur.waypointer.debug.DebugEventLog;
 import com.babbur.waypointer.dungeon.DungeonRoomRouteSync;
 import com.babbur.waypointer.dungeon.DungeonRouteDownloader;
+import com.babbur.waypointer.dungeon.config.DungeonConfig;
 import com.babbur.waypointer.dungeon.data.DungeonRoomData;
 import com.babbur.waypointer.dungeon.data.DungeonRoomDefinition;
 import com.babbur.waypointer.dungeon.data.DungeonRoomShareCodec;
@@ -1574,7 +1575,8 @@ public final class WaypointerScreen extends Screen {
 
         int labelX = x1 + GAP + 8;
         String pts = row.roomSecretCount + " pt" + (row.roomSecretCount == 1 ? "" : "s");
-        int ptsX = x2 - GAP - font.width(pts);
+        int chipX = routeToggleChipX(x2);
+        int ptsX = chipX - GAP - font.width(pts);
         g.text(font, pts, ptsX, y1 + 4, TEXT_MUTED, false);
 
         int labelMaxW = Math.max(24, ptsX - GAP_TIGHT - labelX);
@@ -1582,6 +1584,7 @@ public final class WaypointerScreen extends Screen {
                 labelX, y1 + 4, TEXT_DIM, false);
         g.text(font, font.plainSubstrByWidth(secretRouteSubtitle(row.secretSuppressed), labelMaxW),
                 labelX, y1 + 14, TEXT_MUTED, false);
+        renderRouteToggleChip(g, definitionRouteEnabled(row.roomZoneId), x2, y1);
     }
 
     static String secretRouteSubtitle(boolean suppressedByUserRoute) {
@@ -1661,19 +1664,7 @@ public final class WaypointerScreen extends Screen {
         // Right-aligned toggle pill -- kept as the one exception to "no button chrome",
         // because it's genuinely a tap target with two states and the pill shape
         // communicates that more clearly than a checkbox in a dense row.
-        String toggle = routeToggleLabel(group.enabled());
-        int chipY = y1 + 5;
-        int chipRight = chipX + ROUTE_TOGGLE_CHIP_W;
-        int chipBottom = chipY + ROUTE_TOGGLE_CHIP_H;
-        g.fill(chipX, chipY, chipRight, chipBottom,
-                group.enabled() ? ACCENT : BORDER);
-        g.fill(chipX + 1, chipY + 1, chipRight - 1, chipBottom - 1, 0xE0181D22);
-        if (group.enabled()) {
-            g.fill(chipX + 1, chipBottom - 2, chipRight - 1, chipBottom - 1, ACCENT);
-        }
-        int tw = font.width(toggle);
-        g.text(font, toggle, chipX + (ROUTE_TOGGLE_CHIP_W - tw) / 2,
-                chipY + 3, group.enabled() ? TEXT : TEXT_DIM, false);
+        renderRouteToggleChip(g, group.enabled(), x2, y1);
 
         // Cross-zone hint (rare, but possible if a group's zone id drifts)
         String zid = group.zoneId();
@@ -1699,6 +1690,31 @@ public final class WaypointerScreen extends Screen {
 
     static String routeToggleLabel(boolean enabled) {
         return enabled ? "Shown" : "Hidden";
+    }
+
+    private void renderRouteToggleChip(GuiGraphicsExtractor g, boolean enabled,
+                                       int rowRight, int rowY) {
+        int chipX = routeToggleChipX(rowRight);
+        int chipY = rowY + 5;
+        int chipRight = chipX + ROUTE_TOGGLE_CHIP_W;
+        int chipBottom = chipY + ROUTE_TOGGLE_CHIP_H;
+        g.fill(chipX, chipY, chipRight, chipBottom, enabled ? ACCENT : BORDER);
+        g.fill(chipX + 1, chipY + 1, chipRight - 1, chipBottom - 1, 0xE0181D22);
+        if (enabled) {
+            g.fill(chipX + 1, chipBottom - 2, chipRight - 1, chipBottom - 1, ACCENT);
+        }
+        String toggle = routeToggleLabel(enabled);
+        int tw = font.width(toggle);
+        g.text(font, toggle, chipX + (ROUTE_TOGGLE_CHIP_W - tw) / 2,
+                chipY + 3, enabled ? TEXT : TEXT_DIM, false);
+    }
+
+    private static boolean definitionRouteEnabled(String roomZoneId) {
+        return definitionRouteEnabled(WaypointerClient.dungeonConfig(), roomZoneId);
+    }
+
+    static boolean definitionRouteEnabled(DungeonConfig config, String roomZoneId) {
+        return config == null || config.roomRouteEnabled(roomZoneId);
     }
 
     /**
@@ -1757,8 +1773,19 @@ public final class WaypointerScreen extends Screen {
         if (my > rowBottom) return false;
 
         RouteListRow row = rows.get(idx);
+        int rowRight = mainContentRight(layout.mainLeft(), layout.mainRight()) - 2;
         if (row.secretRoute) {
             selectedDungeonRoomZoneId = row.roomZoneId;
+            if (mx >= routeToggleHitLeft(rowRight) && mx <= rowRight) {
+                boolean enabled = !definitionRouteEnabled(row.roomZoneId);
+                DungeonRoomRouteSync.setDefinitionRouteEnabled(
+                        manager, WaypointerClient.dungeonConfig(), row.roomZoneId, enabled);
+                manager.fireDataChanged();
+                DebugEventLog.record("WaypointerScreen", "secret-route", row.roomZoneId, idx,
+                        "(none)", "(none)", doubleClick, false, false,
+                        "toggle-chip", enabled ? "show-route" : "hide-route");
+                return true;
+            }
             if (doubleClick && !row.secretSuppressed) {
                 convertSecretRouteToEditable(row.roomZoneId);
                 return true;
@@ -1798,9 +1825,9 @@ public final class WaypointerScreen extends Screen {
         String selectedAfter = selectedGroupId == null ? "(none)" : selectedGroupId;
 
         // Toggle-chip hit test -- rightmost region of the row.
-        int rowRight = mainContentRight(layout.mainLeft(), layout.mainRight()) - 2;
         if (mx >= routeToggleHitLeft(rowRight) && mx <= rowRight) {
-            group.setEnabled(!group.enabled());
+            DungeonRoomRouteSync.setRouteEnabled(
+                    manager, WaypointerClient.dungeonConfig(), group, !group.enabled());
             manager.fireDataChanged();
             DebugEventLog.record("WaypointerScreen", "route", group.id(), idx,
                     selectedBefore, selectedAfter, doubleClick, shiftDown, controlDown,
@@ -2130,7 +2157,17 @@ public final class WaypointerScreen extends Screen {
     }
 
     private void hideShownRoutes(List<WaypointGroup> shownRoutes) {
-        int hidden = hideRoutes(shownRoutes);
+        int hidden = 0;
+        if (isDungeonRoomsZone(selectedZoneId)) {
+            for (WaypointGroup group : shownRoutes) {
+                if (group == null || !group.enabled()) continue;
+                DungeonRoomRouteSync.setRouteEnabled(
+                        manager, WaypointerClient.dungeonConfig(), group, false);
+                hidden++;
+            }
+        } else {
+            hidden = hideRoutes(shownRoutes);
+        }
         if (hidden == 0) {
             clearHideAllConfirmation();
             refreshActionButtons();

--- a/src/main/java/com/babbur/waypointer/api/WaypointFlags.java
+++ b/src/main/java/com/babbur/waypointer/api/WaypointFlags.java
@@ -14,6 +14,7 @@ public final class WaypointFlags {
     public static final int DEPTH_CHECKED = 1 << 8;
     public static final int SKIP_ON_STAND = 1 << 9;
     public static final int SKIP_ON_INTERACT = 1 << 10;
+    public static final int SKIP_ON_MINE = 1 << 11;
 
     public static final int SUBWAYPOINT_STYLE = SMALL_SUBWAYPOINT
             | FILLED_SUBWAYPOINT

--- a/src/main/java/com/babbur/waypointer/core/Waypoint.java
+++ b/src/main/java/com/babbur/waypointer/core/Waypoint.java
@@ -53,6 +53,8 @@ public record Waypoint(
     public static final int FLAG_SKIP_ON_STAND = 1 << 9;
     /** Dungeon-room behavior flag: interacting with this waypoint's block explicitly advances/skips it. */
     public static final int FLAG_SKIP_ON_INTERACT = 1 << 10;
+    /** Dungeon-room behavior flag: mining this waypoint's block explicitly advances/skips it. */
+    public static final int FLAG_SKIP_ON_MINE = 1 << 11;
     /** Visual flags that only make sense while {@link #FLAG_SUBWAYPOINT} is present. */
     public static final int SUBWAYPOINT_STYLE_FLAGS = FLAG_SMALL_SUBWAYPOINT
             | FLAG_FILLED_SUBWAYPOINT

--- a/src/main/java/com/babbur/waypointer/core/WaypointGroup.java
+++ b/src/main/java/com/babbur/waypointer/core/WaypointGroup.java
@@ -383,6 +383,17 @@ public final class WaypointGroup {
         if (cur < 0) return;
 
         int activeParent = activeSubwaypointParentIndex();
+        if (isDungeonRoomRoute()) {
+            if (activeParent >= 0) {
+                action.accept(activeParent);
+                for (int child = activeParent + 1; child < n && isSubwaypoint(child); child++) {
+                    action.accept(child);
+                }
+            }
+            for (int i = cur; i < n; i++) action.accept(i);
+            return;
+        }
+
         int prev = previousMainIndexBefore(cur);
         if (activeParent >= 0) {
             action.accept(activeParent);
@@ -422,6 +433,10 @@ public final class WaypointGroup {
         return zoneId.equals("dungeon")
                 || zoneId.startsWith("dungeon_")
                 || DungeonRoomData.definition(zoneId) != null;
+    }
+
+    private boolean isDungeonRoomRoute() {
+        return DungeonRoomData.definition(zoneId) != null;
     }
 
     public Waypoint get(int index) {

--- a/src/main/java/com/babbur/waypointer/dungeon/config/DungeonConfig.java
+++ b/src/main/java/com/babbur/waypointer/dungeon/config/DungeonConfig.java
@@ -78,6 +78,9 @@ public final class DungeonConfig {
      */
     private boolean routesPromptDismissed = false;
 
+    /** Definition-backed room routes explicitly hidden from the route list pill. */
+    private List<String> hiddenRouteRoomIds = new ArrayList<>();
+
     private transient Path file;
     private transient AsyncSaver saver;
     private transient final List<Runnable> enabledListeners = new ArrayList<>();
@@ -136,6 +139,11 @@ public final class DungeonConfig {
     public boolean autoCompleteRoomsOnGreenCheckmark() { return autoCompleteRoomsOnGreenCheckmark; }
     public boolean routesPromptDismissed()  { return routesPromptDismissed; }
 
+    public boolean roomRouteEnabled(String roomId) {
+        if (roomId == null || roomId.isBlank()) return true;
+        return hiddenRouteRoomIds == null || !hiddenRouteRoomIds.contains(roomId);
+    }
+
     public void setEnabled(boolean v) {
         if (enabled == v) return;
         enabled = v;
@@ -164,6 +172,7 @@ public final class DungeonConfig {
         hideCompletedRooms = defaults.hideCompletedRooms;
         autoCompleteRoomsOnGreenCheckmark = defaults.autoCompleteRoomsOnGreenCheckmark;
         routesPromptDismissed = defaults.routesPromptDismissed;
+        hiddenRouteRoomIds = new ArrayList<>();
         save();
         if (notifyEnabledListeners) {
             for (Runnable listener : List.copyOf(enabledListeners)) listener.run();
@@ -177,6 +186,14 @@ public final class DungeonConfig {
         save();
     }
     public void setRoutesPromptDismissed(boolean v) { this.routesPromptDismissed = v; save(); }
+    public void setRoomRouteEnabled(String roomId, boolean enabled) {
+        if (roomId == null || roomId.isBlank()) return;
+        if (hiddenRouteRoomIds == null) hiddenRouteRoomIds = new ArrayList<>();
+        boolean changed = enabled
+                ? hiddenRouteRoomIds.remove(roomId)
+                : !hiddenRouteRoomIds.contains(roomId) && hiddenRouteRoomIds.add(roomId);
+        if (changed) save();
+    }
     public void setDefaultDirection(String v) {
         if (v == null) return;
         String upper = v.trim().toUpperCase(java.util.Locale.ROOT);

--- a/src/test/java/com/babbur/waypointer/core/WaypointGroupTest.java
+++ b/src/test/java/com/babbur/waypointer/core/WaypointGroupTest.java
@@ -438,6 +438,22 @@ class WaypointGroupTest {
     }
 
     @Test
+    void forEachVisibleIndex_dungeonRoomSequence_showsAllRemainingWaypoints() {
+        WaypointGroup group = WaypointGroup.create("Dungeon Room", "altar");
+        group.setLoadMode(WaypointGroup.LoadMode.SEQUENCE);
+        group.add(Waypoint.at(0, 70, 0));
+        group.add(Waypoint.at(1, 70, 0));
+        group.add(Waypoint.at(2, 70, 0));
+        group.add(Waypoint.at(3, 70, 0));
+
+        assertArrayEquals(new int[] { 0, 1, 2, 3 }, visibleIndices(group));
+
+        group.setCurrentIndex(2);
+        assertArrayEquals(new int[] { 2, 3 }, visibleIndices(group),
+                "completed room waypoints stay hidden while every remaining one is surfaced");
+    }
+
+    @Test
     void forEachVisibleIndex_sequenceMode_atEnd_showsPrevAndCurrent() {
         WaypointGroup g = route();
         g.setLoadMode(WaypointGroup.LoadMode.SEQUENCE);

--- a/src/test/java/com/babbur/waypointer/dungeon/DungeonRoomRouteSyncTest.java
+++ b/src/test/java/com/babbur/waypointer/dungeon/DungeonRoomRouteSyncTest.java
@@ -538,6 +538,69 @@ class DungeonRoomRouteSyncTest {
     }
 
     @Test
+    void definitionRouteVisibilitySurvivesRuntimeMirrorRebuilds() {
+        ActiveGroupManager manager = new ActiveGroupManager();
+        DungeonConfig config = new DungeonConfig();
+        DungeonStateTracker tracker = new DungeonStateTracker(manager, config);
+        sync = new DungeonRoomRouteSync(manager, tracker, new DungeonRouteSession(), config);
+        sync.install();
+        DungeonRoom room = room("toggle-definition-room", "Toggle Definition Room");
+        DungeonRoomDefinition definition = DungeonRoomData.defineRoom(
+                "toggle-definition-room", "Toggle Definition Room", room);
+        DungeonRoomData.addWaypoint(definition.id(),
+                DungeonWaypoint.plain("secret", DungeonSecretCategory.CHEST, 1, 70, 1, ""));
+        tracker.setCurrentRoom(room);
+
+        String mirrorId = DungeonRoomRouteSync.generatedGroupId(definition.id());
+        WaypointGroup mirror = manager.get(mirrorId);
+        assertTrue(mirror.enabled());
+
+        DungeonRoomRouteSync.setRouteEnabled(manager, config, mirror, false);
+        manager.fireDataChanged();
+
+        assertFalse(config.roomRouteEnabled(definition.id()));
+        assertNotNull(manager.get(mirrorId));
+        assertFalse(manager.get(mirrorId).enabled(),
+                "a hidden definition mirror must not resurrect enabled during sync");
+
+        DungeonRoomRouteSync.setRouteEnabled(manager, config, manager.get(mirrorId), true);
+        manager.fireDataChanged();
+
+        assertTrue(config.roomRouteEnabled(definition.id()));
+        assertTrue(manager.get(mirrorId).enabled());
+    }
+
+    @Test
+    void storedRouteVisibilityControlsItsRuntimeMirror() {
+        ActiveGroupManager manager = new ActiveGroupManager();
+        DungeonConfig config = new DungeonConfig();
+        DungeonStateTracker tracker = new DungeonStateTracker(manager, config);
+        sync = new DungeonRoomRouteSync(manager, tracker, new DungeonRouteSession(), config);
+        sync.install();
+        DungeonRoom room = room("toggle-stored-room", "Toggle Stored Room");
+        DungeonRoomData.defineRoom("toggle-stored-room", "Toggle Stored Room", room);
+        WaypointGroup stored = WaypointGroup.create("User Route", "toggle-stored-room");
+        stored.add(Waypoint.at(1, 70, 1));
+        manager.add(stored);
+        tracker.setCurrentRoom(room);
+
+        String mirrorId = DungeonRoomRouteSync.generatedGroupId("toggle-stored-room");
+        assertNotNull(manager.get(mirrorId));
+
+        DungeonRoomRouteSync.setRouteEnabled(manager, config, stored, false);
+        manager.fireDataChanged();
+
+        assertFalse(stored.enabled());
+        assertNull(manager.get(mirrorId), "a hidden stored route removes its runtime projection");
+
+        DungeonRoomRouteSync.setRouteEnabled(manager, config, stored, true);
+        manager.fireDataChanged();
+
+        assertTrue(stored.enabled());
+        assertTrue(manager.get(mirrorId).enabled());
+    }
+
+    @Test
     void editableRouteFromDefinitionKeepsRoomLocalCoordinatesAndUniformColors() {
         DungeonRoom room = room("convert-room", "Convert Room");
         DungeonRoomDefinition definition =

--- a/src/test/java/com/babbur/waypointer/dungeon/DungeonRoomRouteSyncTest.java
+++ b/src/test/java/com/babbur/waypointer/dungeon/DungeonRoomRouteSyncTest.java
@@ -501,6 +501,43 @@ class DungeonRoomRouteSyncTest {
     }
 
     @Test
+    void manualStoredProgressChangesUpdateTheRenderedMirrorAcrossRebuilds() {
+        ActiveGroupManager manager = new ActiveGroupManager();
+        DungeonStateTracker tracker = new DungeonStateTracker(manager, new DungeonConfig());
+        sync = new DungeonRoomRouteSync(manager, tracker);
+        sync.install();
+        DungeonRoom room = room("manual-progress-room", "Manual Progress Room");
+        DungeonRoomData.defineRoom("manual-progress-room", "Manual Progress Room", room);
+
+        WaypointGroup stored = WaypointGroup.create("User Route", "manual-progress-room");
+        stored.add(Waypoint.at(1, 70, 1));
+        stored.add(Waypoint.at(2, 70, 2));
+        stored.add(Waypoint.at(3, 70, 3));
+        manager.add(stored);
+        tracker.setCurrentRoom(room);
+
+        String mirrorId = DungeonRoomRouteSync.generatedGroupId("manual-progress-room");
+        WaypointGroup mirror = manager.get(mirrorId);
+        mirror.setCurrentIndex(1);
+
+        DungeonRoomRouteSync.setManualCurrentIndex(manager, stored, 2);
+        manager.fireDataChanged();
+
+        assertEquals(2, stored.currentIndex());
+        assertEquals(2, manager.get(mirrorId).currentIndex(),
+                "a manual selection must replace stale runtime progress");
+        assertArrayEquals(new int[] { 2 }, visibleIndices(manager.get(mirrorId)));
+
+        DungeonRoomRouteSync.resetManualProgress(manager, stored);
+        manager.fireDataChanged();
+
+        assertEquals(0, stored.currentIndex());
+        assertEquals(0, manager.get(mirrorId).currentIndex(),
+                "reset must restore the rendered route to its first waypoint");
+        assertArrayEquals(new int[] { 0, 1, 2 }, visibleIndices(manager.get(mirrorId)));
+    }
+
+    @Test
     void editableRouteFromDefinitionKeepsRoomLocalCoordinatesAndUniformColors() {
         DungeonRoom room = room("convert-room", "Convert Room");
         DungeonRoomDefinition definition =

--- a/src/test/java/com/babbur/waypointer/dungeon/config/DungeonConfigTest.java
+++ b/src/test/java/com/babbur/waypointer/dungeon/config/DungeonConfigTest.java
@@ -100,4 +100,19 @@ class DungeonConfigTest {
         assertEquals("SE", config.defaultDirection());
     }
 
+    @Test
+    void definitionRouteVisibilityDefaultsShownAndPersistsPerRoom() {
+        DungeonConfig config = new DungeonConfig();
+
+        assertTrue(config.roomRouteEnabled("room-a"));
+        assertTrue(config.roomRouteEnabled("room-b"));
+
+        config.setRoomRouteEnabled("room-a", false);
+        assertFalse(config.roomRouteEnabled("room-a"));
+        assertTrue(config.roomRouteEnabled("room-b"));
+
+        config.setRoomRouteEnabled("room-a", true);
+        assertTrue(config.roomRouteEnabled("room-a"));
+    }
+
 }

--- a/src/test/java/com/babbur/waypointer/progression/ProximityAdvanceTest.java
+++ b/src/test/java/com/babbur/waypointer/progression/ProximityAdvanceTest.java
@@ -17,7 +17,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -159,6 +161,28 @@ class ProximityAdvanceTest {
         assertFalse(ProximityTracker.advanceIfInteractedWithBlock(group, 5, 2, 6, false));
 
         assertEquals(0, group.currentIndex());
+    }
+
+    @Test
+    void mineSkipAdvancesOnlyAfterObservedDungeonBlockBecomesAir() {
+        WaypointGroup group = dungeonTriggerGroup();
+        group.setDefaultRadius(10.0);
+        group.add(Waypoint.at(4, 2, 6).withFlags(Waypoint.FLAG_SKIP_ON_MINE));
+        Set<ProximityTracker.MineTarget> observed = new HashSet<>();
+
+        assertFalse(ProximityTracker.updateMinedWaypointProgress(
+                group, (x, y, z) -> ProximityTracker.MINE_BLOCK_AIR,
+                observed, new HashSet<>(), false, false, 1_000L, false));
+        assertFalse(ProximityTracker.advanceIfReached(group, 4.5, 2.5, 6.5,
+                false, true, false, 1_000L));
+        assertFalse(ProximityTracker.updateMinedWaypointProgress(
+                group, (x, y, z) -> ProximityTracker.MINE_BLOCK_PRESENT,
+                observed, new HashSet<>(), false, false, 1_100L, false));
+        assertTrue(ProximityTracker.updateMinedWaypointProgress(
+                group, (x, y, z) -> ProximityTracker.MINE_BLOCK_AIR,
+                observed, new HashSet<>(), false, false, 1_200L, false));
+
+        assertTrue(group.isComplete());
     }
 
     @Test

--- a/src/test/java/com/babbur/waypointer/render/WaypointRendererTest.java
+++ b/src/test/java/com/babbur/waypointer/render/WaypointRendererTest.java
@@ -152,13 +152,18 @@ class WaypointRendererTest {
     }
 
     @Test
-    void blockShapeWaypointBoundsAcceptsInteractWaypointShapes() {
+    void blockShapeWaypointBoundsAcceptsBlockTriggerWaypointShapes() {
         Waypoint interactWaypoint = waypointAt(10, 64, -5, Waypoint.FLAG_SKIP_ON_INTERACT);
+        Waypoint mineWaypoint = waypointAt(10, 64, -5, Waypoint.FLAG_SKIP_ON_MINE);
+        AABB localBounds = new AABB(0.375, 0.125, 0.25, 0.625, 0.875, 0.75);
 
-        AABB actual = WaypointRenderer.blockShapeWaypointBounds(interactWaypoint,
-                new AABB(0.375, 0.125, 0.25, 0.625, 0.875, 0.75));
+        AABB interactBounds = WaypointRenderer.blockShapeWaypointBounds(
+                interactWaypoint, localBounds);
+        AABB mineBounds = WaypointRenderer.blockShapeWaypointBounds(mineWaypoint, localBounds);
 
-        assertAabbEquals(new AABB(10.375, 64.125, -4.75, 10.625, 64.875, -4.25), actual);
+        AABB expected = new AABB(10.375, 64.125, -4.75, 10.625, 64.875, -4.25);
+        assertAabbEquals(expected, interactBounds);
+        assertAabbEquals(expected, mineBounds);
     }
 
     @Test

--- a/src/test/java/com/babbur/waypointer/screen/GroupEditScreenTest.java
+++ b/src/test/java/com/babbur/waypointer/screen/GroupEditScreenTest.java
@@ -163,6 +163,8 @@ class GroupEditScreenTest {
                 GroupEditScreen.dungeonStandSkipTooltipText());
         assertEquals("Dungeons: Interact to skip",
                 GroupEditScreen.dungeonInteractSkipTooltipText());
+        assertEquals("Dungeons: Mine to skip",
+                GroupEditScreen.dungeonMineSkipTooltipText());
     }
 
     @Test
@@ -173,12 +175,18 @@ class GroupEditScreenTest {
         assertEquals(Waypoint.FLAG_SKIP_ON_INTERACT,
                 GroupEditScreen.waypointControlFlagForAction(
                         GroupEditScreen.WAYPOINT_CONTROL_ACTION_INTERACT_SKIP, true));
+        assertEquals(Waypoint.FLAG_SKIP_ON_MINE,
+                GroupEditScreen.waypointControlFlagForAction(
+                        GroupEditScreen.WAYPOINT_CONTROL_ACTION_MINE_SKIP, true));
         assertEquals(0,
                 GroupEditScreen.waypointControlFlagForAction(
                         GroupEditScreen.WAYPOINT_CONTROL_ACTION_STAND_SKIP, false));
         assertEquals(0,
                 GroupEditScreen.waypointControlFlagForAction(
                         GroupEditScreen.WAYPOINT_CONTROL_ACTION_INTERACT_SKIP, false));
+        assertEquals(0,
+                GroupEditScreen.waypointControlFlagForAction(
+                        GroupEditScreen.WAYPOINT_CONTROL_ACTION_MINE_SKIP, false));
         assertEquals(Waypoint.FLAG_DEPTH_CHECKED,
                 GroupEditScreen.waypointControlFlagForAction(
                         GroupEditScreen.WAYPOINT_CONTROL_ACTION_DEPTH_CHECK, false));

--- a/src/test/java/com/babbur/waypointer/screen/WaypointerScreenTest.java
+++ b/src/test/java/com/babbur/waypointer/screen/WaypointerScreenTest.java
@@ -118,6 +118,16 @@ class WaypointerScreenTest {
     }
 
     @Test
+    void definitionRoutePillReflectsPersistedDungeonVisibility() {
+        com.babbur.waypointer.dungeon.config.DungeonConfig config =
+                new com.babbur.waypointer.dungeon.config.DungeonConfig();
+
+        assertTrue(WaypointerScreen.definitionRouteEnabled(config, "room-a"));
+        config.setRoomRouteEnabled("room-a", false);
+        assertFalse(WaypointerScreen.definitionRouteEnabled(config, "room-a"));
+    }
+
+    @Test
     void hideAllConfirmationRequiresSameShownRoutesInsideWindow() {
         WaypointGroup first = WaypointGroup.create("First", "hub");
         WaypointGroup second = WaypointGroup.create("Second", "hub");

--- a/src/test/java/com/babbur/waypointer/screen/WaypointerScreenTest.java
+++ b/src/test/java/com/babbur/waypointer/screen/WaypointerScreenTest.java
@@ -296,6 +296,55 @@ class WaypointerScreenTest {
     }
 
     @Test
+    void currentDungeonRoomSortsFirstEvenWhenItHasNoSavedRoute() {
+        DungeonRoomData.clearAllCustom();
+        try {
+            defineRoom("zed-populated", "Zed Populated");
+            defineRoom("alpha-current", "Alpha Current");
+            defineRoom("beta-populated", "Beta Populated");
+
+            assertEquals(List.of("alpha-current", "beta-populated", "zed-populated"),
+                    WaypointerScreen.orderedDungeonRoomIds(
+                            List.of("zed-populated", "alpha-current", "beta-populated"),
+                            Set.of("zed-populated", "beta-populated"),
+                            "alpha-current"));
+        } finally {
+            DungeonRoomData.clearAllCustom();
+        }
+    }
+
+    @Test
+    void roomFocusScrollOnlyMovesWhenTheTargetIsOutsideTheViewport() {
+        int pitch = GuiTokens.ROW_H + 4;
+        int viewport = pitch * 3;
+
+        assertEquals(pitch * 2, WaypointerScreen.scrollOffsetToRevealRow(
+                pitch * 2, 3, 10, viewport),
+                "an already-visible target preserves user scroll");
+
+        int revealed = WaypointerScreen.scrollOffsetToRevealRow(0, 7, 10, viewport);
+        int rowTop = 7 * pitch;
+        int rowBottom = rowTop + GuiTokens.ROW_H + 2;
+        assertTrue(rowTop >= revealed);
+        assertTrue(rowBottom <= revealed + viewport);
+
+        assertEquals(0, WaypointerScreen.scrollOffsetToRevealRow(
+                revealed, 0, 10, viewport),
+                "a newly-current first room scrolls back to the top");
+    }
+
+    @Test
+    void currentDungeonRoomHeaderUsesPersistentGreenHighlight() {
+        assertEquals(WaypointerScreen.CURRENT_DUNGEON_ROOM_ACCENT,
+                WaypointerScreen.roomHeaderAccent(true));
+        assertTrue(WaypointerScreen.roomHeaderAccent(true)
+                != WaypointerScreen.roomHeaderAccent(false));
+        assertTrue(WaypointerScreen.roomHeaderBackground(false, false, true) != 0,
+                "current room stays highlighted when a child route owns selection");
+        assertEquals(0, WaypointerScreen.roomHeaderBackground(false, false, false));
+    }
+
+    @Test
     void compactFooterFitsOnOneLineAtFiveHundredTwelvePixels() {
         assertTrue(WaypointerScreen.footerRequiredWidth() <= 512);
     }

--- a/src/test/java/com/babbur/waypointer/screen/settings/SettingsCatalogTest.java
+++ b/src/test/java/com/babbur/waypointer/screen/settings/SettingsCatalogTest.java
@@ -41,7 +41,7 @@ class SettingsCatalogTest {
 
     /** DungeonConfig fields deliberately kept out of the GUI (debug/UX-state). */
     private static final Set<String> DUNGEON_EXEMPT = Set.of(
-            "debugLogRoomChanges", "routesPromptDismissed",
+            "debugLogRoomChanges", "routesPromptDismissed", "hiddenRouteRoomIds",
             // Assumed room rotation is applied automatically / via /wpd; deliberately not surfaced in the GUI.
             "defaultDirection");
 


### PR DESCRIPTION
Adds optional mine-to-skip dungeon waypoints and keeps manual dungeon progress/reset synchronized with the rendered route. Dungeon rooms now show remaining waypoints, persist route visibility, and automatically surface and highlight the current room in green.