### PR TITLE
Consolidate waypoint placement keybind

### DIFF
--- a/src/client/java/com/babbur/waypointer/input/WaypointRepositionMode.java
+++ b/src/client/java/com/babbur/waypointer/input/WaypointRepositionMode.java
@@ -235,6 +235,28 @@ public final class WaypointRepositionMode {
         startAddSession(manager, config, Mode.ADD_WHERE_LOOKING, false);
     }
 
+    /** Capture the current crosshair target and open the naming screen immediately. */
+    public static void openAddWhereLooking(ActiveGroupManager manager, WaypointerConfig config) {
+        if (manager == null || config == null) return;
+
+        Minecraft mc = Minecraft.getInstance();
+        if (mc.player == null || mc.level == null) return;
+        if (addBlockedByInstalledSecrets(mc, manager)) return;
+
+        BlockPos pos = targetedBlock(mc);
+        PreciseTarget precise = targetedPrecise(mc);
+        if (pos == null || precise == null) {
+            showStatus(mc, HELP_EDIT_NO_BLOCK_TARGET);
+            return;
+        }
+
+        WaypointGroup group = manager.getOrCreateActiveGroup(config.skipAheadMechanicEnabled());
+        int flags = defaultDungeonEditFlags(group, mc.level, pos);
+        AddNamedWaypointScreen.openWhereLooking(null, manager, config, group,
+                pos.getX(), pos.getY(), pos.getZ(),
+                precise.preciseX(), precise.preciseY(), precise.preciseZ(), flags);
+    }
+
     private static void startAddSession(ActiveGroupManager manager, WaypointerConfig config,
                                         Mode mode, boolean preciseSmallPlacement) {
         if (manager == null || config == null) return;

--- a/src/client/java/com/babbur/waypointer/input/WaypointRepositionMode.java
+++ b/src/client/java/com/babbur/waypointer/input/WaypointRepositionMode.java
@@ -75,17 +75,8 @@ public final class WaypointRepositionMode {
     private static final Component HELP_MOVE_PRECISE = Component.literal(
             "Left click to place the small waypoint at the cursor, snapped to 1/16 blocks.")
             .withStyle(ChatFormatting.AQUA);
-    private static final Component HELP_ADD = Component.literal(
-            "Left click to place the waypoint.")
-            .withStyle(ChatFormatting.AQUA);
-    private static final Component HELP_ADD_NAMED = Component.literal(
-            "Left click to place the named waypoint.")
-            .withStyle(ChatFormatting.AQUA);
-    private static final Component HELP_ADD_SUBWAYPOINT = Component.literal(
-            "Left click to place the subwaypoint.")
-            .withStyle(ChatFormatting.AQUA);
-    private static final Component HELP_ADD_SMALL_SUBWAYPOINT = Component.literal(
-            "Left click to place the small subwaypoint at the cursor, snapped to 1/16 blocks.")
+    private static final Component HELP_ADD_WHERE_LOOKING = Component.literal(
+            "Left click to place and name the waypoint.")
             .withStyle(ChatFormatting.AQUA);
     private static final Component HELP_EDIT_ON = Component.literal(
             "Edit mode enabled. Left click a waypoint to move it. Right click adds a waypoint.")
@@ -240,17 +231,8 @@ public final class WaypointRepositionMode {
         showHelp(mc);
     }
 
-    public static void startAdd(ActiveGroupManager manager, WaypointerConfig config,
-                                boolean named) {
-        startAddSession(manager, config, named ? Mode.ADD_NAMED : Mode.ADD_UNNAMED,
-                false);
-    }
-
-    public static void startAddSubwaypoint(ActiveGroupManager manager, WaypointerConfig config,
-                                           boolean small) {
-        startAddSession(manager, config,
-                small ? Mode.ADD_SMALL_SUBWAYPOINT : Mode.ADD_SUBWAYPOINT,
-                small);
+    public static void startAddWhereLooking(ActiveGroupManager manager, WaypointerConfig config) {
+        startAddSession(manager, config, Mode.ADD_WHERE_LOOKING, false);
     }
 
     private static void startAddSession(ActiveGroupManager manager, WaypointerConfig config,
@@ -599,16 +581,6 @@ public final class WaypointRepositionMode {
             moveExistingPrecise(mc, session, target);
             return;
         }
-        if (session.mode == Mode.ADD_SMALL_SUBWAYPOINT) {
-            PreciseTarget target = targetedPrecise(mc);
-            if (target == null) {
-                showHelp(mc);
-                return;
-            }
-            addSmallSubwaypoint(mc, session, target);
-            return;
-        }
-
         BlockPos pos = targetedBlock(mc);
         if (pos == null) {
             showHelp(mc);
@@ -617,9 +589,8 @@ public final class WaypointRepositionMode {
 
         switch (session.mode) {
             case MOVE_EXISTING -> moveExisting(mc, session, pos);
-            case ADD_UNNAMED -> addUnnamed(mc, session, pos);
-            case ADD_NAMED -> openNamedPrompt(mc, session, pos);
-            case ADD_SUBWAYPOINT -> addSubwaypoint(mc, session, pos);
+            case ADD_WHERE_LOOKING -> openWhereLookingPrompt(mc, session, pos,
+                    targetedPrecise(mc));
         }
     }
 
@@ -694,24 +665,6 @@ public final class WaypointRepositionMode {
         showStatus(mc, HELP_EDIT_MOVED);
     }
 
-    private static void addUnnamed(Minecraft mc, Session session, BlockPos pos) {
-        ClientLevel level = mc == null ? null : mc.level;
-        int flags = defaultDungeonEditFlags(session.group, level, pos);
-        addStored(session.group, new Waypoint(pos.getX(), pos.getY(), pos.getZ(),
-                "", session.config.defaultWaypointColor(), flags, 0.0));
-        int index = session.group.size() - 1;
-        finishAddedWaypoint(mc, session, index);
-    }
-
-    private static void addSubwaypoint(Minecraft mc, Session session, BlockPos pos) {
-        ClientLevel level = mc == null ? null : mc.level;
-        int flags = subwaypointCreationFlags(session.group, level, pos, false);
-        addStored(session.group, new Waypoint(pos.getX(), pos.getY(), pos.getZ(),
-                "", session.config.defaultWaypointColor(), flags, 0.0));
-        int index = session.group.size() - 1;
-        finishAddedWaypoint(mc, session, index);
-    }
-
     /**
      * Append with room-local conversion: stored dungeon-room routes keep
      * room-local coordinates, so a waypoint picked in world space converts
@@ -735,47 +688,17 @@ public final class WaypointRepositionMode {
         return true;
     }
 
-    private static void addSmallSubwaypoint(Minecraft mc, Session session, PreciseTarget target) {
-        ClientLevel level = mc == null ? null : mc.level;
-        int blockX = Math.floorDiv(target.preciseX(), Waypoint.PRECISE_SCALE);
-        int blockY = Math.floorDiv(target.preciseY(), Waypoint.PRECISE_SCALE);
-        int blockZ = Math.floorDiv(target.preciseZ(), Waypoint.PRECISE_SCALE);
-        BlockPos pos = new BlockPos(blockX, blockY, blockZ);
-        int flags = subwaypointCreationFlags(session.group, level, pos, true);
-        addStored(session.group, new Waypoint(blockX, blockY, blockZ,
-                "", session.config.defaultWaypointColor(), flags, 0.0,
-                Waypoint.TEMP_NONE, 0L,
-                target.preciseX(), target.preciseY(), target.preciseZ()));
-        int index = session.group.size() - 1;
-        finishAddedWaypoint(mc, session, index);
-    }
-
-    private static int subwaypointCreationFlags(WaypointGroup group, ClientLevel level,
-                                                BlockPos pos, boolean small) {
-        int flags = defaultDungeonEditFlags(group, level, pos) | Waypoint.FLAG_SUBWAYPOINT;
-        if (small) {
-            flags |= Waypoint.FLAG_SMALL_SUBWAYPOINT;
-        }
-        return flags;
-    }
-
-    private static void finishAddedWaypoint(Minecraft mc, Session session, int index) {
-        new WaypointAddFlow().afterWaypointAdded(session.group, index,
-                session.config.showWaypointChatShareButtons());
-        session.manager.fireDataChanged();
-        playEditSound(mc, session.config);
-        active = null;
-        reopenEditor(mc, session.withWaypointIndex(index));
-    }
-
-    private static void openNamedPrompt(Minecraft mc, Session session, BlockPos pos) {
+    private static void openWhereLookingPrompt(Minecraft mc, Session session, BlockPos pos,
+                                               PreciseTarget preciseTarget) {
         ClientLevel level = mc == null ? null : mc.level;
         int flags = defaultDungeonEditFlags(session.group, level, pos);
         active = null;
-        if (mc == null) return;
+        if (mc == null || preciseTarget == null) return;
         mc.execute(
-                () -> AddNamedWaypointScreen.openAt(null, session.manager, session.config,
-                session.group, pos.getX(), pos.getY(), pos.getZ(), flags));
+                () -> AddNamedWaypointScreen.openWhereLooking(null, session.manager, session.config,
+                session.group, pos.getX(), pos.getY(), pos.getZ(),
+                preciseTarget.preciseX(), preciseTarget.preciseY(), preciseTarget.preciseZ(),
+                flags));
     }
 
     private static void cancel(Minecraft mc) {
@@ -880,10 +803,7 @@ public final class WaypointRepositionMode {
 
     private enum Mode {
         MOVE_EXISTING,
-        ADD_UNNAMED,
-        ADD_NAMED,
-        ADD_SUBWAYPOINT,
-        ADD_SMALL_SUBWAYPOINT
+        ADD_WHERE_LOOKING
     }
 
     private record SelectedWaypoint(WaypointGroup group, int waypointIndex) {}
@@ -905,18 +825,10 @@ public final class WaypointRepositionMode {
     private record Session(ActiveGroupManager manager, WaypointerConfig config,
                            WaypointGroup group, int waypointIndex, Mode mode,
                            boolean preciseSmallPlacement, boolean reopenEditorAfterCommit) {
-        Session withWaypointIndex(int index) {
-            return new Session(manager, config, group, index, mode, preciseSmallPlacement,
-                    reopenEditorAfterCommit);
-        }
-
         Component help() {
             return switch (mode) {
                 case MOVE_EXISTING -> preciseSmallPlacement ? HELP_MOVE_PRECISE : HELP_MOVE;
-                case ADD_UNNAMED -> HELP_ADD;
-                case ADD_NAMED -> HELP_ADD_NAMED;
-                case ADD_SUBWAYPOINT -> HELP_ADD_SUBWAYPOINT;
-                case ADD_SMALL_SUBWAYPOINT -> HELP_ADD_SMALL_SUBWAYPOINT;
+                case ADD_WHERE_LOOKING -> HELP_ADD_WHERE_LOOKING;
             };
         }
     }

--- a/src/client/java/com/babbur/waypointer/input/WaypointerKeybinds.java
+++ b/src/client/java/com/babbur/waypointer/input/WaypointerKeybinds.java
@@ -280,7 +280,7 @@ public final class WaypointerKeybinds {
             return;
         }
         while (addWaypointWhereLooking.consumeClick()) {
-            WaypointRepositionMode.startAddWhereLooking(manager, config);
+            WaypointRepositionMode.openAddWhereLooking(manager, config);
             drainWaypointKeybindClicks();
             return;
         }

--- a/src/client/java/com/babbur/waypointer/input/WaypointerKeybinds.java
+++ b/src/client/java/com/babbur/waypointer/input/WaypointerKeybinds.java
@@ -37,7 +37,7 @@ import java.util.List;
 /**
  * Registers and polls the mod's keybinds.
  *
- * Thirteen bindings today:
+ * Ten bindings today:
  *
  *   - Open Waypointer GUI -- the primary way into the GUI.
  *   - Add Waypoint -- drops a waypoint at the player's position into the
@@ -48,10 +48,8 @@ import java.util.List;
  *     waypoint at the player's current position with that name.
  *   - Add Temp Waypoint at Player -- drops a temporary waypoint using the
  *     user's default expiry mode and duration.
- *   - Add Subwaypoint Where Looking -- pick a block in-world, then add a
- *     subwaypoint there.
- *   - Add Small Subwaypoint Where Looking -- pick a precise in-world hit point,
- *     then add a tiny subwaypoint there.
+ *   - Add Waypoint Where Looking -- pick a block in-world, then name it and
+ *     optionally make it a SubWP or small SubWP.
  *   - Skip Waypoint -- advances the current active group(s) past their current
  *     waypoint. Useful for dungeon speedruns or when a waypoint is physically
  *     unreachable. Unbound by default; players who don't want it just don't
@@ -64,11 +62,6 @@ import java.util.List;
  *   - Exit Edit Mode -- explicitly disables persistent edit mode.
  *   - Toggle Edit Mode -- flips persistent edit mode for players who prefer one
  *     bind instead of separate enter/exit binds.
- *   - Edit Mode: Add Waypoint -- pick a block in-world, then add an unnamed
- *     waypoint there.
- *   - Edit Mode: Add Named Waypoint -- pick a block in-world, then name the
- *     waypoint before adding it.
- *
  * All bindings are registered under a single Waypointer category via the
  * identifier-based API so the vanilla controls screen groups them together.
  * None are bound by default (apart from Open Waypointer GUI): the mod treats every
@@ -81,18 +74,12 @@ public final class WaypointerKeybinds {
     static final String ADD_WAYPOINT_HERE_TRANSLATION_KEY = "key.waypointer.add_waypoint_here";
     static final String ADD_NAMED_WAYPOINT_HERE_TRANSLATION_KEY = "key.waypointer.add_named_waypoint_here";
     static final String ADD_TEMP_WAYPOINT_HERE_TRANSLATION_KEY = "key.waypointer.add_temp_waypoint_here";
-    static final String ADD_SUBWAYPOINT_WHERE_LOOKING_TRANSLATION_KEY =
-            "key.waypointer.add_subwaypoint_where_looking";
-    static final String ADD_SMALL_SUBWAYPOINT_WHERE_LOOKING_TRANSLATION_KEY =
-            "key.waypointer.add_small_subwaypoint_where_looking";
     static final String SKIP_WAYPOINT_TRANSLATION_KEY = "key.waypointer.skip_waypoint";
     static final String PREVIOUS_WAYPOINT_TRANSLATION_KEY = "key.waypointer.previous_waypoint";
     static final String ENTER_EDIT_MODE_TRANSLATION_KEY = "key.waypointer.enter_edit_mode";
     static final String EXIT_EDIT_MODE_TRANSLATION_KEY = "key.waypointer.exit_edit_mode";
     static final String TOGGLE_EDIT_MODE_TRANSLATION_KEY = "key.waypointer.toggle_edit_mode";
     static final String REPOSITION_ADD_WAYPOINT_TRANSLATION_KEY = "key.waypointer.reposition_add_waypoint";
-    static final String REPOSITION_ADD_NAMED_WAYPOINT_TRANSLATION_KEY =
-            "key.waypointer.reposition_add_named_waypoint";
     static final int OPEN_EDITOR_DEFAULT_KEY = GLFW.GLFW_KEY_U;
     static final int UNBOUND_DEFAULT_KEY = InputConstants.UNKNOWN.getValue();
     static final List<String> KEYBIND_TRANSLATION_KEYS = List.of(
@@ -100,20 +87,14 @@ public final class WaypointerKeybinds {
             ADD_WAYPOINT_HERE_TRANSLATION_KEY,
             ADD_NAMED_WAYPOINT_HERE_TRANSLATION_KEY,
             ADD_TEMP_WAYPOINT_HERE_TRANSLATION_KEY,
-            ADD_SUBWAYPOINT_WHERE_LOOKING_TRANSLATION_KEY,
-            ADD_SMALL_SUBWAYPOINT_WHERE_LOOKING_TRANSLATION_KEY,
             SKIP_WAYPOINT_TRANSLATION_KEY,
             PREVIOUS_WAYPOINT_TRANSLATION_KEY,
             ENTER_EDIT_MODE_TRANSLATION_KEY,
             EXIT_EDIT_MODE_TRANSLATION_KEY,
             TOGGLE_EDIT_MODE_TRANSLATION_KEY,
-            REPOSITION_ADD_WAYPOINT_TRANSLATION_KEY,
-            REPOSITION_ADD_NAMED_WAYPOINT_TRANSLATION_KEY);
+            REPOSITION_ADD_WAYPOINT_TRANSLATION_KEY);
     static final List<Integer> KEYBIND_DEFAULT_KEYS = List.of(
             OPEN_EDITOR_DEFAULT_KEY,
-            UNBOUND_DEFAULT_KEY,
-            UNBOUND_DEFAULT_KEY,
-            UNBOUND_DEFAULT_KEY,
             UNBOUND_DEFAULT_KEY,
             UNBOUND_DEFAULT_KEY,
             UNBOUND_DEFAULT_KEY,
@@ -137,15 +118,12 @@ public final class WaypointerKeybinds {
     private final KeyMapping addWaypointHere;
     private final KeyMapping addNamedWaypointHere;
     private final KeyMapping addTempWaypointHere;
-    private final KeyMapping addSubwaypointWhereLooking;
-    private final KeyMapping addSmallSubwaypointWhereLooking;
     private final KeyMapping skipWaypoint;
     private final KeyMapping previousWaypoint;
     private final KeyMapping enterEditMode;
     private final KeyMapping exitEditMode;
     private final KeyMapping toggleEditMode;
-    private final KeyMapping repositionAddWaypoint;
-    private final KeyMapping repositionAddNamedWaypoint;
+    private final KeyMapping addWaypointWhereLooking;
     private final Runnable openGui;
     private final ActiveGroupManager manager;
     private final WaypointerConfig config;
@@ -184,16 +162,6 @@ public final class WaypointerKeybinds {
                 InputConstants.Type.KEYSYM,
                 UNBOUND_DEFAULT_KEY,
                 CATEGORY));
-        this.addSubwaypointWhereLooking = KeyMappingHelper.registerKeyMapping(new KeyMapping(
-                ADD_SUBWAYPOINT_WHERE_LOOKING_TRANSLATION_KEY,
-                InputConstants.Type.KEYSYM,
-                UNBOUND_DEFAULT_KEY,
-                CATEGORY));
-        this.addSmallSubwaypointWhereLooking = KeyMappingHelper.registerKeyMapping(new KeyMapping(
-                ADD_SMALL_SUBWAYPOINT_WHERE_LOOKING_TRANSLATION_KEY,
-                InputConstants.Type.KEYSYM,
-                UNBOUND_DEFAULT_KEY,
-                CATEGORY));
         // Unbound by default: skip is a destructive-ish shortcut (it mutates route
         // progress) and players should opt in by choosing a key, not discover it by
         // accident on first launch.
@@ -223,13 +191,8 @@ public final class WaypointerKeybinds {
                 InputConstants.Type.KEYSYM,
                 UNBOUND_DEFAULT_KEY,
                 CATEGORY));
-        this.repositionAddWaypoint = KeyMappingHelper.registerKeyMapping(new KeyMapping(
+        this.addWaypointWhereLooking = KeyMappingHelper.registerKeyMapping(new KeyMapping(
                 REPOSITION_ADD_WAYPOINT_TRANSLATION_KEY,
-                InputConstants.Type.KEYSYM,
-                UNBOUND_DEFAULT_KEY,
-                CATEGORY));
-        this.repositionAddNamedWaypoint = KeyMappingHelper.registerKeyMapping(new KeyMapping(
-                REPOSITION_ADD_NAMED_WAYPOINT_TRANSLATION_KEY,
                 InputConstants.Type.KEYSYM,
                 UNBOUND_DEFAULT_KEY,
                 CATEGORY));
@@ -299,16 +262,6 @@ public final class WaypointerKeybinds {
             return;
         }
         while (addTempWaypointHere.consumeClick()) addTempWaypointAtPlayer(mc);
-        while (addSubwaypointWhereLooking.consumeClick()) {
-            WaypointRepositionMode.startAddSubwaypoint(manager, config, false);
-            drainWaypointKeybindClicks();
-            return;
-        }
-        while (addSmallSubwaypointWhereLooking.consumeClick()) {
-            WaypointRepositionMode.startAddSubwaypoint(manager, config, true);
-            drainWaypointKeybindClicks();
-            return;
-        }
         while (skipWaypoint.consumeClick()) skipCurrentWaypoint(mc);
         while (previousWaypoint.consumeClick()) goBackToPreviousWaypoint(mc);
         while (enterEditMode.consumeClick()) {
@@ -326,13 +279,8 @@ public final class WaypointerKeybinds {
             drainWaypointKeybindClicks();
             return;
         }
-        while (repositionAddWaypoint.consumeClick()) {
-            WaypointRepositionMode.startAdd(manager, config, false);
-            drainWaypointKeybindClicks();
-            return;
-        }
-        while (repositionAddNamedWaypoint.consumeClick()) {
-            WaypointRepositionMode.startAdd(manager, config, true);
+        while (addWaypointWhereLooking.consumeClick()) {
+            WaypointRepositionMode.startAddWhereLooking(manager, config);
             drainWaypointKeybindClicks();
             return;
         }
@@ -343,15 +291,12 @@ public final class WaypointerKeybinds {
         while (addWaypointHere.consumeClick()) {}
         while (addNamedWaypointHere.consumeClick()) {}
         while (addTempWaypointHere.consumeClick()) {}
-        while (addSubwaypointWhereLooking.consumeClick()) {}
-        while (addSmallSubwaypointWhereLooking.consumeClick()) {}
         while (skipWaypoint.consumeClick()) {}
         while (previousWaypoint.consumeClick()) {}
         while (enterEditMode.consumeClick()) {}
         while (exitEditMode.consumeClick()) {}
         while (toggleEditMode.consumeClick()) {}
-        while (repositionAddWaypoint.consumeClick()) {}
-        while (repositionAddNamedWaypoint.consumeClick()) {}
+        while (addWaypointWhereLooking.consumeClick()) {}
     }
 
     private void skipCurrentWaypoint(Minecraft mc) {

--- a/src/client/java/com/babbur/waypointer/progression/ProximityTracker.java
+++ b/src/client/java/com/babbur/waypointer/progression/ProximityTracker.java
@@ -487,7 +487,11 @@ public final class ProximityTracker {
                 group.remove(j);
             }
         }
-        group.restartIfRouteCompleted(restartWhenComplete && !isDungeonRoomRouteGroup(group));
+        boolean restart = restartWhenComplete && !isDungeonRoomRouteGroup(group);
+        group.restartIfRouteCompleted(restart);
+        if (restart && group.mainWaypointCount() == 1) {
+            group.suppressProximityUntilExit(group.currentIndex());
+        }
         return true;
     }
 

--- a/src/client/java/com/babbur/waypointer/screen/AddNamedWaypointScreen.java
+++ b/src/client/java/com/babbur/waypointer/screen/AddNamedWaypointScreen.java
@@ -30,6 +30,7 @@ public final class AddNamedWaypointScreen extends Screen {
 
     private static final int PANEL_W = 280;
     private static final int PANEL_H = 136;
+    private static final int OPTIONS_PANEL_H = 164;
     private static final int GLFW_KEY_ENTER = 257;
     private static final int GLFW_KEY_KP_ENTER = 335;
     private static final int MAX_NAME_LENGTH = 64;
@@ -44,11 +45,19 @@ public final class AddNamedWaypointScreen extends Screen {
     private final int fixedY;
     private final int fixedZ;
     private final int fixedFlags;
+    private final boolean showSubtypeOptions;
+    private final int fixedPreciseX;
+    private final int fixedPreciseY;
+    private final int fixedPreciseZ;
 
     private EditBox nameBox;
     private Button confirmButton;
+    private GuiTokens.StyledCheckbox subwaypointCheckbox;
+    private GuiTokens.StyledCheckbox smallCheckbox;
     private boolean nameErrorVisible;
     private String enteredName = "";
+    private boolean subwaypointSelected;
+    private boolean smallSelected;
 
     public AddNamedWaypointScreen(Screen parent, ActiveGroupManager manager,
                                   WaypointerConfig config, WaypointGroup targetGroup) {
@@ -59,7 +68,19 @@ public final class AddNamedWaypointScreen extends Screen {
                                    WaypointerConfig config, WaypointGroup targetGroup,
                                    boolean useFixedPosition, int fixedX, int fixedY, int fixedZ,
                                    int fixedFlags) {
-        super(Component.literal("Create Named Waypoint"));
+        this(parent, manager, config, targetGroup, useFixedPosition,
+                fixedX, fixedY, fixedZ, fixedFlags, false,
+                fixedX * Waypoint.PRECISE_SCALE,
+                fixedY * Waypoint.PRECISE_SCALE,
+                fixedZ * Waypoint.PRECISE_SCALE);
+    }
+
+    private AddNamedWaypointScreen(Screen parent, ActiveGroupManager manager,
+                                   WaypointerConfig config, WaypointGroup targetGroup,
+                                   boolean useFixedPosition, int fixedX, int fixedY, int fixedZ,
+                                   int fixedFlags, boolean showSubtypeOptions,
+                                   int fixedPreciseX, int fixedPreciseY, int fixedPreciseZ) {
+        super(Component.literal(showSubtypeOptions ? "Create Waypoint" : "Create Named Waypoint"));
         this.parent = parent;
         this.manager = manager;
         this.config = config;
@@ -69,6 +90,10 @@ public final class AddNamedWaypointScreen extends Screen {
         this.fixedY = fixedY;
         this.fixedZ = fixedZ;
         this.fixedFlags = fixedFlags;
+        this.showSubtypeOptions = showSubtypeOptions;
+        this.fixedPreciseX = fixedPreciseX;
+        this.fixedPreciseY = fixedPreciseY;
+        this.fixedPreciseZ = fixedPreciseZ;
     }
 
     public static void open(Screen parent, ActiveGroupManager manager,
@@ -90,10 +115,21 @@ public final class AddNamedWaypointScreen extends Screen {
                 new AddNamedWaypointScreen(parent, manager, config, targetGroup, true, x, y, z, flags));
     }
 
+    public static void openWhereLooking(Screen parent, ActiveGroupManager manager,
+                                        WaypointerConfig config, WaypointGroup targetGroup,
+                                        int x, int y, int z,
+                                        int preciseX, int preciseY, int preciseZ,
+                                        int flags) {
+        MinecraftCompat.setScreen(Minecraft.getInstance(),
+                new AddNamedWaypointScreen(parent, manager, config, targetGroup,
+                        true, x, y, z, flags, true, preciseX, preciseY, preciseZ));
+    }
+
     @Override
     protected void init() {
         int panelX = (width - PANEL_W) / 2;
-        int panelY = (height - PANEL_H) / 2;
+        int panelH = panelHeight();
+        int panelY = (height - panelH) / 2;
         int inner = panelX + PAD_OUTER;
         int fieldW = PANEL_W - PAD_OUTER * 2;
 
@@ -106,7 +142,24 @@ public final class AddNamedWaypointScreen extends Screen {
         setFocused(nameBox);
         nameBox.setFocused(true);
 
-        int footerY = panelY + PANEL_H - BTN_H - PAD_OUTER / 2;
+        if (showSubtypeOptions) {
+            int optionsY = panelY + 66;
+            int subwaypointBoxX = inner + font.width("Subwaypoint") + GAP_TIGHT;
+            subwaypointCheckbox = styledCheckbox(subwaypointBoxX, optionsY, BTN_H,
+                    Component.literal("Subwaypoint"), subwaypointSelected,
+                    this::onSubwaypointChanged, null);
+            addRenderableWidget(subwaypointCheckbox);
+
+            int smallLabelX = subwaypointBoxX + BTN_H + GAP_SECTION;
+            int smallBoxX = smallLabelX + font.width("Small") + GAP_TIGHT;
+            smallCheckbox = styledCheckbox(smallBoxX, optionsY, BTN_H,
+                    Component.literal("Small"), smallSelected,
+                    value -> smallSelected = value, null);
+            addRenderableWidget(smallCheckbox);
+            updateSubtypeControls();
+        }
+
+        int footerY = panelY + panelH - BTN_H - PAD_OUTER / 2;
         addRenderableWidget(Button.builder(Component.literal("Cancel"), this::onCancelButtonClicked)
                 .bounds(panelX + PANEL_W - PAD_OUTER - 140 - GAP, footerY, 70, BTN_H)
                 .build());
@@ -122,13 +175,26 @@ public final class AddNamedWaypointScreen extends Screen {
         g.fill(0, 0, width, height, 0x80000000);
 
         int panelX = (width - PANEL_W) / 2;
-        int panelY = (height - PANEL_H) / 2;
-        g.fill(panelX, panelY, panelX + PANEL_W, panelY + PANEL_H, SURFACE);
+        int panelH = panelHeight();
+        int panelY = (height - panelH) / 2;
+        g.fill(panelX, panelY, panelX + PANEL_W, panelY + panelH, SURFACE);
         g.text(font, getTitle(), panelX + PAD_OUTER, panelY + PAD_OUTER, TEXT, false);
+
+        if (showSubtypeOptions) {
+            int optionsY = panelY + 66;
+            int labelY = opticalTextY(optionsY, BTN_H);
+            int inner = panelX + PAD_OUTER;
+            int subwaypointBoxX = inner + font.width("Subwaypoint") + GAP_TIGHT;
+            int smallLabelX = subwaypointBoxX + BTN_H + GAP_SECTION;
+            g.text(font, "Subwaypoint", inner, labelY, TEXT, false);
+            g.text(font, "Small", smallLabelX, labelY,
+                    subwaypointSelected ? TEXT : TEXT_MUTED, false);
+        }
 
         super.extractRenderState(g, mouseX, mouseY, partial);
         if (nameErrorVisible) {
-            g.text(font, "Name required", panelX + PAD_OUTER, panelY + 60,
+            int errorY = showSubtypeOptions ? panelY + 92 : panelY + 60;
+            g.text(font, "Name required", panelX + PAD_OUTER, errorY,
                     0xFFFF8A8A, false);
         }
     }
@@ -164,11 +230,12 @@ public final class AddNamedWaypointScreen extends Screen {
         int y;
         int z;
         int flags = 0;
+        CreationOptions options = creationOptions(subwaypointSelected, smallSelected);
         if (useFixedPosition) {
             x = fixedX;
             y = fixedY;
             z = fixedZ;
-            flags = fixedFlags;
+            flags = creationFlags(fixedFlags, options);
         } else {
             LocalPlayer player = Minecraft.getInstance().player;
             if (player == null) {
@@ -186,8 +253,20 @@ public final class AddNamedWaypointScreen extends Screen {
                 : targetGroup;
 
         // Stored dungeon-room routes keep room-local coordinates.
-        target.add(DungeonRoomWaypointPlacement.toStoredWaypoint(target,
-                new Waypoint(x, y, z, name, config.defaultWaypointColor(), flags, 0.0)));
+        Waypoint waypoint;
+        if (useFixedPosition && options.small()) {
+            waypoint = new Waypoint(
+                    Math.floorDiv(fixedPreciseX, Waypoint.PRECISE_SCALE),
+                    Math.floorDiv(fixedPreciseY, Waypoint.PRECISE_SCALE),
+                    Math.floorDiv(fixedPreciseZ, Waypoint.PRECISE_SCALE),
+                    name, config.defaultWaypointColor(), flags, 0.0,
+                    Waypoint.TEMP_NONE, 0L,
+                    fixedPreciseX, fixedPreciseY, fixedPreciseZ);
+        } else {
+            waypoint = new Waypoint(x, y, z, name,
+                    config.defaultWaypointColor(), flags, 0.0);
+        }
+        target.add(DungeonRoomWaypointPlacement.toStoredWaypoint(target, waypoint));
         new WaypointAddFlow().afterWaypointAdded(target, target.size() - 1,
                 config.showWaypointChatShareButtons());
         manager.fireDataChanged();
@@ -198,6 +277,29 @@ public final class AddNamedWaypointScreen extends Screen {
     private void onNameEdited(String value) {
         enteredName = value == null ? "" : value;
         updateConfirmState();
+    }
+
+    private void onSubwaypointChanged(boolean selected) {
+        subwaypointSelected = selected;
+        updateSubtypeControls();
+    }
+
+    private void updateSubtypeControls() {
+        if (smallCheckbox != null) smallCheckbox.active = subwaypointSelected;
+    }
+
+    private int panelHeight() {
+        return showSubtypeOptions ? OPTIONS_PANEL_H : PANEL_H;
+    }
+
+    static CreationOptions creationOptions(boolean subwaypoint, boolean small) {
+        return new CreationOptions(subwaypoint, subwaypoint && small);
+    }
+
+    static int creationFlags(int baseFlags, CreationOptions options) {
+        if (options == null || !options.subwaypoint()) return baseFlags;
+        int flags = baseFlags | Waypoint.FLAG_SUBWAYPOINT;
+        return options.small() ? flags | Waypoint.FLAG_SMALL_SUBWAYPOINT : flags;
     }
 
     static String sanitizeWaypointName(String rawName) {
@@ -223,4 +325,6 @@ public final class AddNamedWaypointScreen extends Screen {
 
     @Override
     public boolean isPauseScreen() { return false; }
+
+    record CreationOptions(boolean subwaypoint, boolean small) {}
 }

--- a/src/client/java/com/babbur/waypointer/screen/AddNamedWaypointScreen.java
+++ b/src/client/java/com/babbur/waypointer/screen/AddNamedWaypointScreen.java
@@ -23,11 +23,11 @@ import java.util.List;
 import static com.babbur.waypointer.screen.GuiTokens.*;
 
 /**
- * One-field modal for creating a waypoint with a name.
+ * One-field modal for creating a waypoint with an optional name.
  *
  * <p>The normal create action stays instant and unnamed. This prompt is the
- * explicit "I want to name it now" path, so it does only that: focus a single
- * text box, commit on Enter, and close on Cancel or Confirm.
+ * explicit naming path: focus a single text box, commit on Enter, and close on
+ * Cancel or Confirm. Leaving the field blank creates an unnamed waypoint.
  */
 public final class AddNamedWaypointScreen extends Screen {
 
@@ -55,10 +55,8 @@ public final class AddNamedWaypointScreen extends Screen {
     private final boolean subwaypointAvailable;
 
     private EditBox nameBox;
-    private Button confirmButton;
     private GuiTokens.StyledCheckbox subwaypointCheckbox;
     private GuiTokens.StyledCheckbox smallCheckbox;
-    private boolean nameErrorVisible;
     private String enteredName = "";
     private boolean subwaypointSelected;
     private boolean smallSelected;
@@ -169,11 +167,10 @@ public final class AddNamedWaypointScreen extends Screen {
         addRenderableWidget(styledButton(
                 panelX + PANEL_W - PAD_OUTER - 140 - GAP, footerY, 70, BTN_H,
                 Component.literal("Cancel"), this::onCancelButtonClicked, null));
-        confirmButton = styledButton(
+        Button confirmButton = styledButton(
                 panelX + PANEL_W - PAD_OUTER - 70, footerY, 70, BTN_H,
                 Component.literal("Confirm"), this::onConfirmButtonClicked, null);
         addRenderableWidget(confirmButton);
-        updateConfirmState();
         updatePreview();
     }
 
@@ -200,11 +197,6 @@ public final class AddNamedWaypointScreen extends Screen {
         }
 
         super.extractRenderState(g, mouseX, mouseY, partial);
-        if (nameErrorVisible) {
-            int errorY = showSubtypeOptions ? panelY + 56 : panelY + 60;
-            g.text(font, "Name required", panelX + PAD_OUTER, errorY,
-                    0xFFFF8A8A, false);
-        }
     }
 
     @Override
@@ -228,11 +220,6 @@ public final class AddNamedWaypointScreen extends Screen {
     private void createAndClose() {
         String draft = nameBox == null ? enteredName : nameBox.getValue();
         String name = sanitizeWaypointName(draft);
-        if (name == null) {
-            nameErrorVisible = true;
-            updateConfirmState();
-            return;
-        }
 
         int x;
         int y;
@@ -285,7 +272,6 @@ public final class AddNamedWaypointScreen extends Screen {
 
     private void onNameEdited(String value) {
         enteredName = value == null ? "" : value;
-        updateConfirmState();
         updatePreview();
     }
 
@@ -329,19 +315,10 @@ public final class AddNamedWaypointScreen extends Screen {
     }
 
     static String sanitizeWaypointName(String rawName) {
-        if (rawName == null) return null;
-        String trimmed = rawName.trim();
-        if (trimmed.isEmpty()) return null;
+        String trimmed = rawName == null ? "" : rawName.trim();
         return trimmed.length() > MAX_NAME_LENGTH
                 ? trimmed.substring(0, MAX_NAME_LENGTH)
                 : trimmed;
-    }
-
-    private void updateConfirmState() {
-        String draft = nameBox == null ? enteredName : nameBox.getValue();
-        boolean hasName = sanitizeWaypointName(draft) != null;
-        if (hasName) nameErrorVisible = false;
-        if (confirmButton != null) confirmButton.active = hasName;
     }
 
     private void updatePreview() {

--- a/src/client/java/com/babbur/waypointer/screen/AddNamedWaypointScreen.java
+++ b/src/client/java/com/babbur/waypointer/screen/AddNamedWaypointScreen.java
@@ -17,6 +17,9 @@ import net.minecraft.client.input.KeyEvent;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.network.chat.Component;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static com.babbur.waypointer.screen.GuiTokens.*;
 
 /**
@@ -30,7 +33,7 @@ public final class AddNamedWaypointScreen extends Screen {
 
     private static final int PANEL_W = 280;
     private static final int PANEL_H = 136;
-    private static final int OPTIONS_PANEL_H = 164;
+    private static final int OPTIONS_PANEL_H = 126;
     private static final int GLFW_KEY_ENTER = 257;
     private static final int GLFW_KEY_KP_ENTER = 335;
     private static final int MAX_NAME_LENGTH = 64;
@@ -49,6 +52,7 @@ public final class AddNamedWaypointScreen extends Screen {
     private final int fixedPreciseX;
     private final int fixedPreciseY;
     private final int fixedPreciseZ;
+    private final boolean subwaypointAvailable;
 
     private EditBox nameBox;
     private Button confirmButton;
@@ -58,6 +62,7 @@ public final class AddNamedWaypointScreen extends Screen {
     private String enteredName = "";
     private boolean subwaypointSelected;
     private boolean smallSelected;
+    private WaypointGroup previewGroup;
 
     public AddNamedWaypointScreen(Screen parent, ActiveGroupManager manager,
                                   WaypointerConfig config, WaypointGroup targetGroup) {
@@ -94,6 +99,7 @@ public final class AddNamedWaypointScreen extends Screen {
         this.fixedPreciseX = fixedPreciseX;
         this.fixedPreciseY = fixedPreciseY;
         this.fixedPreciseZ = fixedPreciseZ;
+        this.subwaypointAvailable = canCreateSubwaypoint(targetGroup);
     }
 
     public static void open(Screen parent, ActiveGroupManager manager,
@@ -154,20 +160,21 @@ public final class AddNamedWaypointScreen extends Screen {
             int smallBoxX = smallLabelX + font.width("Small") + GAP_TIGHT;
             smallCheckbox = styledCheckbox(smallBoxX, optionsY, BTN_H,
                     Component.literal("Small"), smallSelected,
-                    value -> smallSelected = value, null);
+                    this::onSmallChanged, null);
             addRenderableWidget(smallCheckbox);
             updateSubtypeControls();
         }
 
         int footerY = panelY + panelH - BTN_H - PAD_OUTER / 2;
-        addRenderableWidget(Button.builder(Component.literal("Cancel"), this::onCancelButtonClicked)
-                .bounds(panelX + PANEL_W - PAD_OUTER - 140 - GAP, footerY, 70, BTN_H)
-                .build());
-        confirmButton = Button.builder(Component.literal("Confirm"), this::onConfirmButtonClicked)
-                .bounds(panelX + PANEL_W - PAD_OUTER - 70, footerY, 70, BTN_H)
-                .build();
+        addRenderableWidget(styledButton(
+                panelX + PANEL_W - PAD_OUTER - 140 - GAP, footerY, 70, BTN_H,
+                Component.literal("Cancel"), this::onCancelButtonClicked, null));
+        confirmButton = styledButton(
+                panelX + PANEL_W - PAD_OUTER - 70, footerY, 70, BTN_H,
+                Component.literal("Confirm"), this::onConfirmButtonClicked, null);
         addRenderableWidget(confirmButton);
         updateConfirmState();
+        updatePreview();
     }
 
     @Override
@@ -186,14 +193,15 @@ public final class AddNamedWaypointScreen extends Screen {
             int inner = panelX + PAD_OUTER;
             int subwaypointBoxX = inner + font.width("Subwaypoint") + GAP_TIGHT;
             int smallLabelX = subwaypointBoxX + BTN_H + GAP_SECTION;
-            g.text(font, "Subwaypoint", inner, labelY, TEXT, false);
+            g.text(font, "Subwaypoint", inner, labelY,
+                    subwaypointAvailable ? TEXT : TEXT_MUTED, false);
             g.text(font, "Small", smallLabelX, labelY,
                     subwaypointSelected ? TEXT : TEXT_MUTED, false);
         }
 
         super.extractRenderState(g, mouseX, mouseY, partial);
         if (nameErrorVisible) {
-            int errorY = showSubtypeOptions ? panelY + 92 : panelY + 60;
+            int errorY = showSubtypeOptions ? panelY + 56 : panelY + 60;
             g.text(font, "Name required", panelX + PAD_OUTER, errorY,
                     0xFFFF8A8A, false);
         }
@@ -230,7 +238,8 @@ public final class AddNamedWaypointScreen extends Screen {
         int y;
         int z;
         int flags = 0;
-        CreationOptions options = creationOptions(subwaypointSelected, smallSelected);
+        CreationOptions options = creationOptions(
+                subwaypointAvailable, subwaypointSelected, smallSelected);
         if (useFixedPosition) {
             x = fixedX;
             y = fixedY;
@@ -277,15 +286,23 @@ public final class AddNamedWaypointScreen extends Screen {
     private void onNameEdited(String value) {
         enteredName = value == null ? "" : value;
         updateConfirmState();
+        updatePreview();
     }
 
     private void onSubwaypointChanged(boolean selected) {
-        subwaypointSelected = selected;
+        subwaypointSelected = subwaypointAvailable && selected;
         updateSubtypeControls();
+        updatePreview();
+    }
+
+    private void onSmallChanged(boolean selected) {
+        smallSelected = subwaypointAvailable && subwaypointSelected && selected;
+        updatePreview();
     }
 
     private void updateSubtypeControls() {
-        if (smallCheckbox != null) smallCheckbox.active = subwaypointSelected;
+        if (subwaypointCheckbox != null) subwaypointCheckbox.active = subwaypointAvailable;
+        if (smallCheckbox != null) smallCheckbox.active = subwaypointAvailable && subwaypointSelected;
     }
 
     private int panelHeight() {
@@ -294,6 +311,15 @@ public final class AddNamedWaypointScreen extends Screen {
 
     static CreationOptions creationOptions(boolean subwaypoint, boolean small) {
         return new CreationOptions(subwaypoint, subwaypoint && small);
+    }
+
+    static CreationOptions creationOptions(boolean parentAvailable,
+                                           boolean subwaypoint, boolean small) {
+        return creationOptions(parentAvailable && subwaypoint, small);
+    }
+
+    static boolean canCreateSubwaypoint(WaypointGroup group) {
+        return group != null && group.mainWaypointCount() > 0;
     }
 
     static int creationFlags(int baseFlags, CreationOptions options) {
@@ -318,9 +344,60 @@ public final class AddNamedWaypointScreen extends Screen {
         if (confirmButton != null) confirmButton.active = hasName;
     }
 
+    private void updatePreview() {
+        if (!showSubtypeOptions || manager == null || targetGroup == null) return;
+
+        if (previewGroup == null) {
+            previewGroup = WaypointGroup.create("Waypoint preview", targetGroup.zoneId());
+            previewGroup.setTemp(true);
+            previewGroup.setRuntimeOnly(true);
+            previewGroup.setLoadMode(WaypointGroup.LoadMode.STATIC);
+            previewGroup.setGradientStartColor(targetGroup.gradientStartColor());
+            previewGroup.setGradientEndColor(targetGroup.gradientEndColor());
+            previewGroup.setStaticColor(targetGroup.staticColor());
+            previewGroup.setGradientMode(targetGroup.gradientMode());
+            previewGroup.setPaint(targetGroup.paint());
+            previewGroup.setPaintEnabled(targetGroup.paintEnabled());
+            manager.setWaypointPreview(previewGroup);
+        }
+
+        CreationOptions options = creationOptions(
+                subwaypointAvailable, subwaypointSelected, smallSelected);
+        int flags = creationFlags(fixedFlags, options);
+        String previewName = enteredName == null ? "" : enteredName.trim();
+        Waypoint preview = options.small()
+                ? new Waypoint(
+                        Math.floorDiv(fixedPreciseX, Waypoint.PRECISE_SCALE),
+                        Math.floorDiv(fixedPreciseY, Waypoint.PRECISE_SCALE),
+                        Math.floorDiv(fixedPreciseZ, Waypoint.PRECISE_SCALE),
+                        previewName, config.defaultWaypointColor(), flags, 0.0,
+                        Waypoint.TEMP_NONE, 0L,
+                        fixedPreciseX, fixedPreciseY, fixedPreciseZ)
+                : new Waypoint(fixedX, fixedY, fixedZ, previewName,
+                        config.defaultWaypointColor(), flags, 0.0);
+
+        List<Waypoint> previewWaypoints = new ArrayList<>(targetGroup.waypoints());
+        previewWaypoints.add(preview);
+        previewGroup.replaceWaypoints(previewWaypoints);
+        previewGroup.focusOnlyVisibleIndex(previewWaypoints.size() - 1);
+    }
+
+    private void clearPreview() {
+        if (previewGroup == null || manager == null) return;
+        manager.clearWaypointPreview(previewGroup);
+        previewGroup = null;
+    }
+
     @Override
     public void onClose() {
+        clearPreview();
         MinecraftCompat.setScreen(minecraft, parent);
+    }
+
+    @Override
+    public void removed() {
+        clearPreview();
+        super.removed();
     }
 
     @Override

--- a/src/main/java/com/babbur/waypointer/core/ActiveGroupManager.java
+++ b/src/main/java/com/babbur/waypointer/core/ActiveGroupManager.java
@@ -42,6 +42,7 @@ public final class ActiveGroupManager {
     private final List<Consumer<Zone>> zoneListeners = new ArrayList<>();
     private String focusedTempGroupId;
     private String focusedAuthoringGroupId;
+    private WaypointGroup waypointPreview;
 
     private final List<Runnable> dataListeners = new ArrayList<>();
     private final List<Runnable> persistentDataListeners = new ArrayList<>();
@@ -83,15 +84,17 @@ public final class ActiveGroupManager {
 
         if (currentZone == null) {
             WaypointGroup focused = focusedAuthoringGroup();
-            cachedActive = focused != null && focused.enabled() && shouldSurfaceActiveGroup(focused)
+            List<WaypointGroup> active = focused != null
+                    && focused.enabled() && shouldSurfaceActiveGroup(focused)
                     ? List.of(focused)
                     : Collections.emptyList();
+            cachedActive = withWaypointPreview(active);
             return cachedActive;
         }
         String zoneId = currentZone.id();
         WaypointGroup focused = focusedTempGroupForZone(zoneId);
         if (focused != null) {
-            cachedActive = List.of(focused);
+            cachedActive = withWaypointPreview(List.of(focused));
             return cachedActive;
         }
 
@@ -101,8 +104,28 @@ public final class ActiveGroupManager {
                 active.add(g);
             }
         }
-        cachedActive = List.copyOf(active);
+        cachedActive = withWaypointPreview(active);
         return cachedActive;
+    }
+
+    private List<WaypointGroup> withWaypointPreview(List<WaypointGroup> active) {
+        if (waypointPreview == null) return List.copyOf(active);
+        List<WaypointGroup> combined = new ArrayList<>(active.size() + 1);
+        combined.addAll(active);
+        combined.add(waypointPreview);
+        return List.copyOf(combined);
+    }
+
+    /** Surface one session-only group through the normal renderer without persisting it. */
+    public void setWaypointPreview(WaypointGroup preview) {
+        waypointPreview = preview;
+        cachedActive = null;
+    }
+
+    public void clearWaypointPreview(WaypointGroup preview) {
+        if (waypointPreview != preview) return;
+        waypointPreview = null;
+        cachedActive = null;
     }
 
     private static boolean shouldSurfaceActiveGroup(WaypointGroup group) {

--- a/src/main/java/com/babbur/waypointer/core/WaypointGroup.java
+++ b/src/main/java/com/babbur/waypointer/core/WaypointGroup.java
@@ -825,6 +825,11 @@ public final class WaypointGroup {
         return index == proximitySuppressedIndex;
     }
 
+    /** Keep a just-wrapped waypoint inert until the player leaves its reach radius. */
+    public void suppressProximityUntilExit(int index) {
+        proximitySuppressedIndex = index >= 0 && index < waypoints.size() ? index : -1;
+    }
+
     public void clearProximitySuppression() {
         proximitySuppressedIndex = -1;
     }

--- a/src/main/java/com/babbur/waypointer/core/WaypointGroup.java
+++ b/src/main/java/com/babbur/waypointer/core/WaypointGroup.java
@@ -651,6 +651,15 @@ public final class WaypointGroup {
             advancePast(reachedIndex);
             return;
         }
+        // A single destination has no meaningful start-to-finish interval. Keep
+        // its normal progression/loop behavior, but never manufacture a 0 ms
+        // record or completion message from entering the same point.
+        if (mainWaypointCount() == 1) {
+            resetRouteTiming();
+            pendingRouteCompletion = null;
+            advancePast(reachedIndex);
+            return;
+        }
 
         int from = currentIndex;
         boolean timing = routeStartedAtMillis >= 0L;

--- a/src/main/resources/assets/waypointer/lang/en_us.json
+++ b/src/main/resources/assets/waypointer/lang/en_us.json
@@ -3,14 +3,11 @@
   "key.waypointer.add_waypoint_here": "Add Waypoint",
   "key.waypointer.add_named_waypoint_here": "Add Named Waypoint",
   "key.waypointer.add_temp_waypoint_here": "Add Temp Waypoint at Player",
-  "key.waypointer.add_subwaypoint_where_looking": "Add Subwaypoint Where Looking",
-  "key.waypointer.add_small_subwaypoint_where_looking": "Add Small Subwaypoint Where Looking",
   "key.waypointer.skip_waypoint": "Skip Waypoint",
   "key.waypointer.previous_waypoint": "Go Back Waypoint",
   "key.waypointer.enter_edit_mode": "Enter Edit Mode",
   "key.waypointer.exit_edit_mode": "Exit Edit Mode",
   "key.waypointer.toggle_edit_mode": "Toggle Edit Mode",
-  "key.waypointer.reposition_add_waypoint": "Edit Mode: Add Waypoint",
-  "key.waypointer.reposition_add_named_waypoint": "Edit Mode: Add Named Waypoint",
+  "key.waypointer.reposition_add_waypoint": "Add Waypoint Where Looking",
   "key.category.waypointer.main": "Waypointer"
 }

--- a/src/test/java/com/babbur/waypointer/core/ActiveGroupManagerTest.java
+++ b/src/test/java/com/babbur/waypointer/core/ActiveGroupManagerTest.java
@@ -145,6 +145,24 @@ class ActiveGroupManagerTest {
     }
 
     @Test
+    void waypointPreviewRendersWithoutJoiningPersistedGroups() {
+        ActiveGroupManager manager = new ActiveGroupManager();
+        WaypointGroup preview = WaypointGroup.create("Preview", "unknown");
+        preview.setRuntimeOnly(true);
+        preview.setTemp(true);
+        preview.add(Waypoint.at(1, 2, 3));
+
+        manager.setWaypointPreview(preview);
+
+        assertEquals(List.of(preview), manager.activeGroups());
+        assertFalse(manager.allGroups().contains(preview));
+
+        manager.clearWaypointPreview(preview);
+
+        assertTrue(manager.activeGroups().isEmpty());
+    }
+
+    @Test
     void completedDungeonRoomRouteIsHiddenFromActiveGroups() {
         assertNotNull(DungeonRoomData.definition("spider"));
         ActiveGroupManager manager = new ActiveGroupManager();

--- a/src/test/java/com/babbur/waypointer/input/WaypointerKeybindsTest.java
+++ b/src/test/java/com/babbur/waypointer/input/WaypointerKeybindsTest.java
@@ -49,20 +49,19 @@ class WaypointerKeybindsTest {
                 WaypointerKeybinds.ADD_WAYPOINT_HERE_TRANSLATION_KEY,
                 WaypointerKeybinds.ADD_NAMED_WAYPOINT_HERE_TRANSLATION_KEY,
                 WaypointerKeybinds.ADD_TEMP_WAYPOINT_HERE_TRANSLATION_KEY,
-                WaypointerKeybinds.ADD_SUBWAYPOINT_WHERE_LOOKING_TRANSLATION_KEY,
-                WaypointerKeybinds.ADD_SMALL_SUBWAYPOINT_WHERE_LOOKING_TRANSLATION_KEY,
                 WaypointerKeybinds.SKIP_WAYPOINT_TRANSLATION_KEY,
                 WaypointerKeybinds.PREVIOUS_WAYPOINT_TRANSLATION_KEY,
                 WaypointerKeybinds.ENTER_EDIT_MODE_TRANSLATION_KEY,
                 WaypointerKeybinds.EXIT_EDIT_MODE_TRANSLATION_KEY,
                 WaypointerKeybinds.TOGGLE_EDIT_MODE_TRANSLATION_KEY,
-                WaypointerKeybinds.REPOSITION_ADD_WAYPOINT_TRANSLATION_KEY,
-                WaypointerKeybinds.REPOSITION_ADD_NAMED_WAYPOINT_TRANSLATION_KEY),
+                WaypointerKeybinds.REPOSITION_ADD_WAYPOINT_TRANSLATION_KEY),
                 WaypointerKeybinds.KEYBIND_TRANSLATION_KEYS);
-        assertEquals(13, WaypointerKeybinds.KEYBIND_TRANSLATION_KEYS.size());
+        assertEquals(10, WaypointerKeybinds.KEYBIND_TRANSLATION_KEYS.size());
         for (String translationKey : WaypointerKeybinds.KEYBIND_TRANSLATION_KEYS) {
             assertLanguageEntry(english, translationKey);
         }
+        assertEquals("Add Waypoint Where Looking",
+                english.get(WaypointerKeybinds.REPOSITION_ADD_WAYPOINT_TRANSLATION_KEY).getAsString());
     }
 
     @Test

--- a/src/test/java/com/babbur/waypointer/progression/ProximityAdvanceTest.java
+++ b/src/test/java/com/babbur/waypointer/progression/ProximityAdvanceTest.java
@@ -255,6 +255,44 @@ class ProximityAdvanceTest {
     }
 
     @Test
+    void oneMainWaypointWithSubwaypointsNeverCreatesRouteTimingRecords() {
+        WaypointGroup group = WaypointGroup.create("single", "test_zone");
+        group.setDefaultRadius(2.0);
+        group.add(Waypoint.at(0, 0, 0));
+        group.add(Waypoint.at(1, 0, 0));
+        group.toggleSubwaypoint(1);
+
+        assertEquals(1, group.mainWaypointCount());
+        assertTrue(ProximityTracker.advanceIfReached(group, 0.5, 0.5, 0.5,
+                true, true, false, 1_000L, true));
+        assertEquals(0, group.currentIndex(), "looping progress should still restart");
+        assertNull(group.consumeRouteCompletion());
+        assertEquals(-1L, group.bestTimeMillis());
+
+        assertFalse(ProximityTracker.advanceIfReached(group, 5.0, 0.5, 0.5,
+                true, true, false, 1_500L, true));
+        assertTrue(ProximityTracker.advanceIfReached(group, 0.5, 0.5, 0.5,
+                true, true, false, 2_000L, true));
+        assertNull(group.consumeRouteCompletion());
+        assertEquals(-1L, group.bestTimeMillis());
+    }
+
+    @Test
+    void multipleMainWaypointsStillCreateRouteTimingRecords() {
+        WaypointGroup group = line();
+
+        assertTrue(ProximityTracker.advanceIfReached(group, 0.5, 0.5, 0.5,
+                false, false, false, 1_000L, true));
+        assertTrue(ProximityTracker.advanceIfReached(group, 30.5, 0.5, 0.5,
+                false, true, false, 2_000L, true));
+
+        WaypointGroup.RouteCompletion completion = group.consumeRouteCompletion();
+        assertNotNull(completion);
+        assertEquals(1_000L, completion.elapsedMillis());
+        assertEquals(1_000L, group.bestTimeMillis());
+    }
+
+    @Test
     void dungeonRoomRouteDoesNotLoopWhenRestartEnabled() {
         WaypointGroup group = dungeonTriggerGroup();
         group.add(Waypoint.at(0, 0, 0));

--- a/src/test/java/com/babbur/waypointer/progression/ProximityAdvanceTest.java
+++ b/src/test/java/com/babbur/waypointer/progression/ProximityAdvanceTest.java
@@ -240,6 +240,21 @@ class ProximityAdvanceTest {
     }
 
     @Test
+    void oneWaypointLoopRearmsOnlyAfterLeavingItsReachRadius() {
+        WaypointGroup group = WaypointGroup.create("single", "test_zone");
+        group.setDefaultRadius(2.0);
+        group.add(Waypoint.at(0, 0, 0));
+
+        assertTrue(ProximityTracker.advanceIfReached(group, 0.5, 0.5, 0.5, true));
+        assertEquals(0, group.currentIndex());
+        assertTrue(group.isProximitySuppressed(0));
+
+        assertFalse(ProximityTracker.advanceIfReached(group, 0.5, 0.5, 0.5, true));
+        assertFalse(ProximityTracker.advanceIfReached(group, 5.0, 0.5, 0.5, true));
+        assertTrue(ProximityTracker.advanceIfReached(group, 0.5, 0.5, 0.5, true));
+    }
+
+    @Test
     void dungeonRoomRouteDoesNotLoopWhenRestartEnabled() {
         WaypointGroup group = dungeonTriggerGroup();
         group.add(Waypoint.at(0, 0, 0));

--- a/src/test/java/com/babbur/waypointer/screen/AddNamedWaypointScreenTest.java
+++ b/src/test/java/com/babbur/waypointer/screen/AddNamedWaypointScreenTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AddNamedWaypointScreenTest {
@@ -17,10 +16,10 @@ class AddNamedWaypointScreenTest {
     }
 
     @Test
-    void sanitizeWaypointNameRejectsBlankNames() {
-        assertNull(AddNamedWaypointScreen.sanitizeWaypointName(null));
-        assertNull(AddNamedWaypointScreen.sanitizeWaypointName(""));
-        assertNull(AddNamedWaypointScreen.sanitizeWaypointName("   "));
+    void sanitizeWaypointNameKeepsBlankNamesAsUnnamedWaypoints() {
+        assertEquals("", AddNamedWaypointScreen.sanitizeWaypointName(null));
+        assertEquals("", AddNamedWaypointScreen.sanitizeWaypointName(""));
+        assertEquals("", AddNamedWaypointScreen.sanitizeWaypointName("   "));
     }
 
     @Test

--- a/src/test/java/com/babbur/waypointer/screen/AddNamedWaypointScreenTest.java
+++ b/src/test/java/com/babbur/waypointer/screen/AddNamedWaypointScreenTest.java
@@ -1,6 +1,7 @@
 package com.babbur.waypointer.screen;
 
 import com.babbur.waypointer.core.Waypoint;
+import com.babbur.waypointer.core.WaypointGroup;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -41,6 +42,19 @@ class AddNamedWaypointScreenTest {
         assertFalse(regular.small());
         assertTrue(smallSubwaypoint.subwaypoint());
         assertTrue(smallSubwaypoint.small());
+    }
+
+    @Test
+    void subwaypointOptionRequiresAnExistingParentWaypoint() {
+        WaypointGroup empty = WaypointGroup.create("route", "hub");
+
+        assertFalse(AddNamedWaypointScreen.canCreateSubwaypoint(empty));
+        assertFalse(AddNamedWaypointScreen.creationOptions(false, true, true).subwaypoint());
+
+        empty.add(Waypoint.at(0, 0, 0));
+
+        assertTrue(AddNamedWaypointScreen.canCreateSubwaypoint(empty));
+        assertTrue(AddNamedWaypointScreen.creationOptions(true, true, true).small());
     }
 
     @Test

--- a/src/test/java/com/babbur/waypointer/screen/AddNamedWaypointScreenTest.java
+++ b/src/test/java/com/babbur/waypointer/screen/AddNamedWaypointScreenTest.java
@@ -1,9 +1,12 @@
 package com.babbur.waypointer.screen;
 
+import com.babbur.waypointer.core.Waypoint;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AddNamedWaypointScreenTest {
 
@@ -25,5 +28,32 @@ class AddNamedWaypointScreenTest {
 
         assertEquals(64, capped.length());
         assertEquals("A".repeat(64), capped);
+    }
+
+    @Test
+    void smallOptionRequiresSubwaypoint() {
+        AddNamedWaypointScreen.CreationOptions regular =
+                AddNamedWaypointScreen.creationOptions(false, true);
+        AddNamedWaypointScreen.CreationOptions smallSubwaypoint =
+                AddNamedWaypointScreen.creationOptions(true, true);
+
+        assertFalse(regular.subwaypoint());
+        assertFalse(regular.small());
+        assertTrue(smallSubwaypoint.subwaypoint());
+        assertTrue(smallSubwaypoint.small());
+    }
+
+    @Test
+    void creationFlagsPreserveBaseFlagsAndAddOnlyValidSubwaypointFlags() {
+        int baseFlags = Waypoint.FLAG_SKIP_ON_STAND;
+
+        assertEquals(baseFlags, AddNamedWaypointScreen.creationFlags(baseFlags,
+                AddNamedWaypointScreen.creationOptions(false, true)));
+        assertEquals(baseFlags | Waypoint.FLAG_SUBWAYPOINT,
+                AddNamedWaypointScreen.creationFlags(baseFlags,
+                        AddNamedWaypointScreen.creationOptions(true, false)));
+        assertEquals(baseFlags | Waypoint.FLAG_SUBWAYPOINT | Waypoint.FLAG_SMALL_SUBWAYPOINT,
+                AddNamedWaypointScreen.creationFlags(baseFlags,
+                        AddNamedWaypointScreen.creationOptions(true, true)));
     }
 }


### PR DESCRIPTION
Consolidates where-looking placement into one immediate keybind with a compact custom-button modal, live preview, parent-aware SubWP/Small options, and optional names. It also prevents one-main-waypoint routes from repeatedly completing or producing route timers while the player remains in reach, closing #66.