### PR TITLE
Maybe fix the crash on 1.21.11

### DIFF
--- a/src/main/java/com/babbur/waypointer/core/WaypointGroup.java
+++ b/src/main/java/com/babbur/waypointer/core/WaypointGroup.java
@@ -104,7 +104,7 @@ public final class WaypointGroup {
      * also reaches routes created later; choosing Color, Gradient, or One turns
      * it off for that route without deleting its artwork.
      */
-    private boolean paintEnabled = true;
+    private boolean paintEnabled = false;
     /**
      * Session-only reach state for static-route cycling. Unlike currentIndex,
      * this is unordered: a static map overlay lets the player visit points in


### PR DESCRIPTION
When you import/create new group of wp you crash instant and when the mod try to load the route it recrashes.
To fix it I went to the waypoint.json in the config and changed paint enable to false. I think the commit should do the trick as I think the mod put paint enable to true by default atm (changin it to false would make you not instantly crash).